### PR TITLE
feat: create appointment service

### DIFF
--- a/backend/models/Appointment.ts
+++ b/backend/models/Appointment.ts
@@ -1,0 +1,60 @@
+/**
+ * Appointment status values.
+ */
+export type AppointmentStatus = "scheduled" | "completed" | "cancelled" | "no_show";
+
+/**
+ * Core appointment model returned by backend APIs.
+ */
+export interface Appointment {
+  id: string;
+  petId: string;
+  petName?: string;
+  vetId?: string;
+  vetName?: string;
+  clinicName?: string;
+  dateTime: string;
+  type?: string;
+  status: AppointmentStatus;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Payload for creating a new appointment.
+ */
+export interface CreateAppointmentInput {
+  petId: string;
+  vetId?: string;
+  dateTime: string;
+  type?: string;
+  notes?: string;
+}
+
+/**
+ * Payload for updating an existing appointment.
+ */
+export interface UpdateAppointmentInput {
+  dateTime?: string;
+  type?: string;
+  status?: AppointmentStatus;
+  notes?: string;
+}
+
+/**
+ * API response wrapper for single appointment.
+ */
+export interface AppointmentResponse {
+  data: Appointment;
+  message?: string;
+}
+
+/**
+ * API response wrapper for list of appointments.
+ */
+export interface AppointmentsListResponse {
+  data: Appointment[];
+  total?: number;
+  message?: string;
+}

--- a/backend/services/appointmentService.ts
+++ b/backend/services/appointmentService.ts
@@ -1,0 +1,116 @@
+import apiClient from "./apiClient";
+import { errorHandler } from "../middleware/errorHandler";
+import type {
+  Appointment,
+  CreateAppointmentInput,
+  UpdateAppointmentInput,
+  AppointmentResponse,
+  AppointmentsListResponse,
+} from "../models/Appointment";
+
+const APPOINTMENTS_ENDPOINT = "/appointments";
+
+/**
+ * Fetch all appointments, optionally filtered by petId.
+ */
+export async function getAppointments(petId?: string): Promise<AppointmentsListResponse> {
+  try {
+    const params = petId ? { petId } : {};
+    const response = await apiClient.get<AppointmentsListResponse>(APPOINTMENTS_ENDPOINT, {
+      params,
+    });
+    return response.data;
+  } catch (error) {
+    const handled = errorHandler(error);
+    throw new Error(handled.message);
+  }
+}
+
+/**
+ * Fetch a single appointment by ID.
+ */
+export async function getAppointment(id: string): Promise<AppointmentResponse> {
+  try {
+    const response = await apiClient.get<AppointmentResponse>(
+      `${APPOINTMENTS_ENDPOINT}/${id}`
+    );
+    return response.data;
+  } catch (error) {
+    const handled = errorHandler(error);
+    throw new Error(handled.message);
+  }
+}
+
+/**
+ * Create a new appointment.
+ */
+export async function createAppointment(
+  input: CreateAppointmentInput
+): Promise<AppointmentResponse> {
+  try {
+    const response = await apiClient.post<AppointmentResponse>(
+      APPOINTMENTS_ENDPOINT,
+      input
+    );
+    return response.data;
+  } catch (error) {
+    const handled = errorHandler(error);
+    throw new Error(handled.message);
+  }
+}
+
+/**
+ * Update an existing appointment.
+ */
+export async function updateAppointment(
+  id: string,
+  input: UpdateAppointmentInput
+): Promise<AppointmentResponse> {
+  try {
+    const response = await apiClient.put<AppointmentResponse>(
+      `${APPOINTMENTS_ENDPOINT}/${id}`,
+      input
+    );
+    return response.data;
+  } catch (error) {
+    const handled = errorHandler(error);
+    throw new Error(handled.message);
+  }
+}
+
+/**
+ * Cancel an appointment (sets status to "cancelled").
+ */
+export async function cancelAppointment(id: string): Promise<AppointmentResponse> {
+  return updateAppointment(id, { status: "cancelled" });
+}
+
+/**
+ * Fetch upcoming appointments (scheduled, not cancelled, dateTime >= now).
+ * Optionally filter by petId.
+ */
+export async function getUpcomingAppointments(
+  petId?: string
+): Promise<AppointmentsListResponse> {
+  try {
+    const { data: appointments } = await getAppointments(petId);
+    const list = Array.isArray(appointments) ? appointments : [];
+
+    const now = new Date();
+    const upcoming = list.filter((apt: Appointment) => {
+      if (apt.status === "cancelled" || apt.status === "completed") return false;
+      return new Date(apt.dateTime) >= now;
+    });
+
+    return {
+      data: upcoming.sort(
+        (a, b) =>
+          new Date(a.dateTime).getTime() - new Date(b.dateTime).getTime()
+      ),
+      total: upcoming.length,
+    };
+  } catch (error) {
+    const handled = errorHandler(error);
+    throw new Error(handled.message);
+  }
+}


### PR DESCRIPTION
This PR closes #16 
Created Files
1. backend/models/Appointment.ts
TypeScript types for appointments:
Appointment – full appointment model
CreateAppointmentInput – create payload
UpdateAppointmentInput – update payload
AppointmentResponse / AppointmentsListResponse – API response wrappers
AppointmentStatus – "scheduled" | "completed" | "cancelled" | "no_show"
2. backend/services/appointmentService.ts
Service functions using apiClient and errorHandler:
Function	Description
getAppointments(petId?)	Fetch appointments, optionally by pet
getAppointment(id)	Fetch one appointment by ID
createAppointment(input)	Create an appointment
updateAppointment(id, input)	Update an appointment
cancelAppointment(id)	Cancel via status "cancelled"
getUpcomingAppointments(petId?)	Get future, non-cancelled appointments
Acceptance criteria
CRUD: getAppointments, createAppointment, updateAppointment, cancelAppointment implemented
Upcoming filter: getUpcomingAppointments filters by dateTime >= now and status not cancelled / completed
Error handling: errorHandler used in all API calls
Typed responses: all functions return typed responses (AppointmentResponse / AppointmentsListResponse)
API expectations
Base: GET/POST /appointments, GET/PUT /appointments/:id
cancelAppointment uses updateAppointment with { status: "cancelled" }