### PR TITLE
feat(models): add Medication data model for issue #14

### DIFF
--- a/backend/models/Medication.ts
+++ b/backend/models/Medication.ts
@@ -1,0 +1,68 @@
+/**
+ * Supported medication frequency values used by the backend API.
+ */
+export enum MedicationFrequency {
+  ONCE_DAILY = "once_daily",
+  TWICE_DAILY = "twice_daily",
+  THREE_TIMES_DAILY = "three_times_daily",
+  EVERY_OTHER_DAY = "every_other_day",
+  WEEKLY = "weekly",
+  AS_NEEDED = "as_needed",
+}
+
+/**
+ * Medication lifecycle states used for tracking active and historical plans.
+ */
+export enum MedicationStatus {
+  ACTIVE = "active",
+  PAUSED = "paused",
+  COMPLETED = "completed",
+  DISCONTINUED = "discontinued",
+}
+
+/**
+ * Core medication model returned by backend APIs.
+ */
+export interface Medication {
+  id: string;
+  petId: string;
+  name: string;
+  dosage: string;
+  frequency: MedicationFrequency;
+  durationDays: number;
+  startDate: string;
+  endDate?: string;
+  status: MedicationStatus;
+  instructions?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Payload used to create a new medication schedule.
+ */
+export interface CreateMedicationInput {
+  petId: string;
+  name: string;
+  dosage: string;
+  frequency: MedicationFrequency;
+  durationDays: number;
+  startDate: string;
+  endDate?: string;
+  status?: MedicationStatus;
+  instructions?: string;
+}
+
+/**
+ * Payload used to update editable medication fields.
+ */
+export interface UpdateMedicationInput {
+  name?: string;
+  dosage?: string;
+  frequency?: MedicationFrequency;
+  durationDays?: number;
+  startDate?: string;
+  endDate?: string;
+  status?: MedicationStatus;
+  instructions?: string;
+}


### PR DESCRIPTION
## Summary
- add `backend/models/Medication.ts` with a documented `Medication` interface
- define `MedicationFrequency` and `MedicationStatus` enums
- export `CreateMedicationInput` and `UpdateMedicationInput` for app-wide API usage

## Notes
- includes required fields: `dosage`, `frequency`, and `durationDays`
- includes requested schema fields: `id`, `petId`, `name`, `dosage`, `frequency`, `startDate`, `endDate`, `status`, `instructions`

Closes #14