### PR TITLE
feat: pet profile screens (list, detail, add/edit, photo management)

### DIFF
--- a/src/screens/PetDetailScreen.tsx
+++ b/src/screens/PetDetailScreen.tsx
@@ -1,0 +1,170 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Alert, Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import petService, { type Pet } from '../services/petService';
+import { getPhoto } from '../utils/petPhotoStore';
+
+interface Props {
+  petId: string;
+  onBack: () => void;
+  onEdit: (pet: Pet) => void;
+}
+
+const PetDetailScreen: React.FC<Props> = ({ petId, onBack, onEdit }) => {
+  const [pet, setPet] = useState<Pet | null>(null);
+  const [photo, setPhoto] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const [data, uri] = await Promise.all([petService.getPetById(petId), getPhoto(petId)]);
+      setPet(data);
+      setPhoto(uri);
+    } catch {
+      Alert.alert('Error', 'Failed to load pet details.');
+      onBack();
+    }
+  }, [petId, onBack]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleDelete = () => {
+    Alert.alert('Delete Pet', `Remove ${pet?.name}?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await petService.deletePet(petId);
+            onBack();
+          } catch {
+            Alert.alert('Error', 'Failed to delete pet.');
+          }
+        },
+      },
+    ]);
+  };
+
+  if (!pet) return null;
+
+  const fields: { label: string; value: string | undefined }[] = [
+    { label: 'Species', value: pet.species },
+    { label: 'Breed', value: pet.breed },
+    {
+      label: 'Date of Birth',
+      value: pet.dateOfBirth ? new Date(pet.dateOfBirth).toLocaleDateString() : undefined,
+    },
+    { label: 'Microchip ID', value: pet.microchipId },
+    { label: 'Added', value: new Date(pet.createdAt).toLocaleDateString() },
+  ];
+
+  return (
+    <View style={styles.container}>
+      {/* Header */}
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onBack} style={styles.backBtn}>
+          <Text style={styles.backText}>‹ Back</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>{pet.name}</Text>
+        <TouchableOpacity onPress={() => onEdit(pet)} style={styles.editBtn}>
+          <Text style={styles.editBtnText}>Edit</Text>
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        {/* Photo */}
+        <View style={styles.photoSection}>
+          {photo ? (
+            <Image source={{ uri: photo }} style={styles.photo} />
+          ) : (
+            <View style={[styles.photo, styles.photoPlaceholder]}>
+              <Text style={styles.photoEmoji}>🐾</Text>
+            </View>
+          )}
+          <Text style={styles.petName}>{pet.name}</Text>
+        </View>
+
+        {/* Details */}
+        <View style={styles.detailsCard}>
+          {fields
+            .filter((f) => f.value)
+            .map((f) => (
+              <View key={f.label} style={styles.row}>
+                <Text style={styles.rowLabel}>{f.label}</Text>
+                <Text style={styles.rowValue}>{f.value}</Text>
+              </View>
+            ))}
+        </View>
+
+        <TouchableOpacity style={styles.deleteBtn} onPress={handleDelete}>
+          <Text style={styles.deleteBtnText}>Delete Pet</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 16,
+    backgroundColor: '#fff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#e0e0e0',
+  },
+  backBtn: { padding: 4 },
+  backText: { fontSize: 17, color: '#4CAF50' },
+  headerTitle: { fontSize: 17, fontWeight: '700', color: '#1a1a1a' },
+  editBtn: {
+    backgroundColor: '#e8f5e9',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  editBtnText: { color: '#4CAF50', fontWeight: '600' },
+  content: { padding: 16 },
+  photoSection: { alignItems: 'center', marginBottom: 20 },
+  photo: { width: 120, height: 120, borderRadius: 60, marginBottom: 10 },
+  photoPlaceholder: { backgroundColor: '#e8f5e9', justifyContent: 'center', alignItems: 'center' },
+  photoEmoji: { fontSize: 48 },
+  petName: { fontSize: 22, fontWeight: '700', color: '#1a1a1a' },
+  detailsCard: {
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    elevation: 2,
+    marginBottom: 20,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f0f0f0',
+  },
+  rowLabel: { fontSize: 14, color: '#666' },
+  rowValue: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1a1a1a',
+    maxWidth: '60%',
+    textAlign: 'right',
+  },
+  deleteBtn: {
+    backgroundColor: '#fdecea',
+    borderRadius: 10,
+    padding: 14,
+    alignItems: 'center',
+  },
+  deleteBtnText: { color: '#e53935', fontWeight: '700', fontSize: 15 },
+});
+
+export default PetDetailScreen;

--- a/src/screens/PetFormScreen.tsx
+++ b/src/screens/PetFormScreen.tsx
@@ -1,0 +1,239 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import petService, { type Pet } from '../services/petService';
+import { getPhoto, removePhoto, savePhoto } from '../utils/petPhotoStore';
+
+interface Props {
+  /** Pass a pet to edit; omit for add mode. */
+  pet?: Pet;
+  /** ownerId required when creating a new pet. */
+  ownerId?: string;
+  onBack: () => void;
+  onSaved: (pet: Pet) => void;
+}
+
+interface FormState {
+  name: string;
+  species: string;
+  breed: string;
+  dateOfBirth: string;
+  microchipId: string;
+}
+
+const EMPTY: FormState = { name: '', species: '', breed: '', dateOfBirth: '', microchipId: '' };
+
+const PetFormScreen: React.FC<Props> = ({ pet, ownerId = '', onBack, onSaved }) => {
+  const isEdit = !!pet;
+  const [form, setForm] = useState<FormState>(
+    pet
+      ? {
+          name: pet.name,
+          species: pet.species,
+          breed: pet.breed ?? '',
+          dateOfBirth: pet.dateOfBirth?.slice(0, 10) ?? '',
+          microchipId: pet.microchipId ?? '',
+        }
+      : EMPTY,
+  );
+  const [photoUri, setPhotoUri] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const loadPhoto = useCallback(async () => {
+    if (pet) setPhotoUri(await getPhoto(pet.id));
+  }, [pet]);
+
+  useEffect(() => {
+    void loadPhoto();
+  }, [loadPhoto]);
+
+  const set = (key: keyof FormState) => (val: string) => setForm((f) => ({ ...f, [key]: val }));
+
+  // ── Photo management ───────────────────────────────────────────────────────
+  // Without expo-image-picker installed we prompt for a URI directly.
+  // In a real build, replace this with ImagePicker.launchImageLibraryAsync().
+
+  const handlePhotoAction = () => {
+    Alert.alert('Pet Photo', 'Enter a photo URL or file URI', [
+      {
+        text: 'Enter URL',
+        onPress: () => {
+          Alert.prompt(
+            'Photo URL',
+            'Paste an image URL:',
+            (url) => {
+              if (url?.trim()) setPhotoUri(url.trim());
+            },
+            'plain-text',
+          );
+        },
+      },
+      photoUri
+        ? {
+            text: 'Remove Photo',
+            style: 'destructive',
+            onPress: () => setPhotoUri(null),
+          }
+        : { text: 'Cancel', style: 'cancel' },
+      ...(!photoUri ? [{ text: 'Cancel', style: 'cancel' as const }] : []),
+    ]);
+  };
+
+  // ── Save ───────────────────────────────────────────────────────────────────
+
+  const handleSave = async () => {
+    if (!form.name.trim() || !form.species.trim()) {
+      Alert.alert('Validation', 'Name and species are required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        name: form.name.trim(),
+        species: form.species.trim(),
+        breed: form.breed.trim() || undefined,
+        dateOfBirth: form.dateOfBirth.trim() || undefined,
+        microchipId: form.microchipId.trim() || undefined,
+      };
+
+      let saved: Pet;
+      if (isEdit && pet) {
+        saved = await petService.updatePet(pet.id, payload);
+      } else {
+        saved = await petService.createPet({ ...payload, ownerId });
+      }
+
+      // Persist photo locally
+      if (photoUri) {
+        await savePhoto(saved.id, photoUri);
+      } else if (isEdit && pet) {
+        await removePhoto(pet.id);
+      }
+
+      onSaved(saved);
+    } catch {
+      Alert.alert('Error', 'Failed to save pet. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      {/* Header */}
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onBack} style={styles.backBtn}>
+          <Text style={styles.backText}>‹ Back</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>{isEdit ? 'Edit Pet' : 'Add Pet'}</Text>
+        <TouchableOpacity
+          onPress={() => void handleSave()}
+          style={[styles.saveBtn, saving && styles.saveBtnDisabled]}
+          disabled={saving}
+        >
+          <Text style={styles.saveBtnText}>{saving ? 'Saving…' : 'Save'}</Text>
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        {/* Photo */}
+        <TouchableOpacity style={styles.photoSection} onPress={handlePhotoAction}>
+          {photoUri ? (
+            <Image source={{ uri: photoUri }} style={styles.photo} />
+          ) : (
+            <View style={[styles.photo, styles.photoPlaceholder]}>
+              <Text style={styles.photoEmoji}>🐾</Text>
+            </View>
+          )}
+          <Text style={styles.photoHint}>{photoUri ? 'Change photo' : 'Add photo'}</Text>
+        </TouchableOpacity>
+
+        {/* Fields */}
+        <View style={styles.formCard}>
+          {(
+            [
+              { key: 'name', label: 'Name *', placeholder: 'e.g. Buddy' },
+              { key: 'species', label: 'Species *', placeholder: 'e.g. Dog, Cat' },
+              { key: 'breed', label: 'Breed', placeholder: 'e.g. Labrador' },
+              { key: 'dateOfBirth', label: 'Date of Birth', placeholder: 'YYYY-MM-DD' },
+              { key: 'microchipId', label: 'Microchip ID', placeholder: 'Optional' },
+            ] as { key: keyof FormState; label: string; placeholder: string }[]
+          ).map(({ key, label, placeholder }) => (
+            <View key={key} style={styles.fieldRow}>
+              <Text style={styles.fieldLabel}>{label}</Text>
+              <TextInput
+                style={styles.input}
+                placeholder={placeholder}
+                value={form[key]}
+                onChangeText={set(key)}
+                placeholderTextColor="#bbb"
+              />
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 16,
+    backgroundColor: '#fff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#e0e0e0',
+  },
+  backBtn: { padding: 4 },
+  backText: { fontSize: 17, color: '#4CAF50' },
+  headerTitle: { fontSize: 17, fontWeight: '700', color: '#1a1a1a' },
+  saveBtn: {
+    backgroundColor: '#4CAF50',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  saveBtnDisabled: { opacity: 0.5 },
+  saveBtnText: { color: '#fff', fontWeight: '600' },
+  content: { padding: 16 },
+  photoSection: { alignItems: 'center', marginBottom: 20 },
+  photo: { width: 100, height: 100, borderRadius: 50, marginBottom: 8 },
+  photoPlaceholder: { backgroundColor: '#e8f5e9', justifyContent: 'center', alignItems: 'center' },
+  photoEmoji: { fontSize: 40 },
+  photoHint: { fontSize: 13, color: '#4CAF50', fontWeight: '600' },
+  formCard: {
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  fieldRow: { marginBottom: 14 },
+  fieldLabel: { fontSize: 13, color: '#666', marginBottom: 4, fontWeight: '600' },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+    backgroundColor: '#fafafa',
+    color: '#1a1a1a',
+  },
+});
+
+export default PetFormScreen;

--- a/src/screens/PetListScreen.tsx
+++ b/src/screens/PetListScreen.tsx
@@ -1,0 +1,144 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import petService, { type Pet } from '../services/petService';
+import { getPhoto } from '../utils/petPhotoStore';
+
+interface Props {
+  onSelectPet: (pet: Pet) => void;
+  onAddPet: () => void;
+}
+
+const PetListScreen: React.FC<Props> = ({ onSelectPet, onAddPet }) => {
+  const [pets, setPets] = useState<Pet[]>([]);
+  const [photos, setPhotos] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await petService.getAllPets();
+      setPets(data);
+      const photoMap: Record<string, string> = {};
+      await Promise.all(
+        data.map(async (p) => {
+          const uri = await getPhoto(p.id);
+          if (uri) photoMap[p.id] = uri;
+        }),
+      );
+      setPhotos(photoMap);
+    } catch {
+      Alert.alert('Error', 'Failed to load pets.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const renderItem = ({ item }: { item: Pet }) => (
+    <TouchableOpacity style={styles.card} onPress={() => onSelectPet(item)}>
+      {photos[item.id] ? (
+        <Image source={{ uri: photos[item.id] }} style={styles.avatar} />
+      ) : (
+        <View style={[styles.avatar, styles.avatarPlaceholder]}>
+          <Text style={styles.avatarEmoji}>🐾</Text>
+        </View>
+      )}
+      <View style={styles.cardInfo}>
+        <Text style={styles.petName}>{item.name}</Text>
+        <Text style={styles.petMeta}>
+          {item.species}
+          {item.breed ? ` · ${item.breed}` : ''}
+        </Text>
+        {item.dateOfBirth && (
+          <Text style={styles.petMeta}>
+            Born: {new Date(item.dateOfBirth).toLocaleDateString()}
+          </Text>
+        )}
+      </View>
+      <Text style={styles.chevron}>›</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>My Pets</Text>
+        <TouchableOpacity style={styles.addBtn} onPress={onAddPet}>
+          <Text style={styles.addBtnText}>+ Add</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading ? (
+        <ActivityIndicator style={styles.loader} size="large" color="#4CAF50" />
+      ) : (
+        <FlatList
+          data={pets}
+          keyExtractor={(p) => p.id}
+          renderItem={renderItem}
+          contentContainerStyle={styles.list}
+          ListEmptyComponent={<Text style={styles.empty}>No pets yet. Add one!</Text>}
+          onRefresh={load}
+          refreshing={loading}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 16,
+    backgroundColor: '#fff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#e0e0e0',
+  },
+  title: { fontSize: 20, fontWeight: '700', color: '#1a1a1a' },
+  addBtn: {
+    backgroundColor: '#4CAF50',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  addBtnText: { color: '#fff', fontWeight: '600' },
+  loader: { marginTop: 40 },
+  list: { padding: 12 },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 10,
+    shadowColor: '#000',
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  avatar: { width: 56, height: 56, borderRadius: 28, marginRight: 12 },
+  avatarPlaceholder: { backgroundColor: '#e8f5e9', justifyContent: 'center', alignItems: 'center' },
+  avatarEmoji: { fontSize: 24 },
+  cardInfo: { flex: 1 },
+  petName: { fontSize: 16, fontWeight: '700', color: '#1a1a1a' },
+  petMeta: { fontSize: 13, color: '#666', marginTop: 2 },
+  chevron: { fontSize: 22, color: '#bbb' },
+  empty: { textAlign: 'center', color: '#999', marginTop: 40, fontSize: 15 },
+});
+
+export default PetListScreen;

--- a/src/utils/petPhotoStore.ts
+++ b/src/utils/petPhotoStore.ts
@@ -1,0 +1,25 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY = '@pet_photos';
+
+async function getAll(): Promise<Record<string, string>> {
+  const raw = await AsyncStorage.getItem(KEY);
+  return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+}
+
+export async function getPhoto(petId: string): Promise<string | null> {
+  const map = await getAll();
+  return map[petId] ?? null;
+}
+
+export async function savePhoto(petId: string, uri: string): Promise<void> {
+  const map = await getAll();
+  map[petId] = uri;
+  await AsyncStorage.setItem(KEY, JSON.stringify(map));
+}
+
+export async function removePhoto(petId: string): Promise<void> {
+  const map = await getAll();
+  delete map[petId];
+  await AsyncStorage.setItem(KEY, JSON.stringify(map));
+}


### PR DESCRIPTION
Closes #99

---

## Summary
Implements all required pet profile screens.

## New Files
| File | Purpose |
|------|---------|
| `src/screens/PetListScreen.tsx` | FlatList of all pets with avatar, species/breed, pull-to-refresh |
| `src/screens/PetDetailScreen.tsx` | Full pet info card with edit & delete |
| `src/screens/PetFormScreen.tsx` | Add / edit form with photo management |
| `src/utils/petPhotoStore.ts` | AsyncStorage helper for local photo URI persistence |

## Features
- **Pet list** — avatar (photo or 🐾 placeholder), name, species, breed, DOB; pull-to-refresh
- **Pet detail** — all fields displayed in a card; edit and delete actions
- **Add/edit form** — name, species, breed, DOB, microchip ID; validation on required fields
- **Photo management** — attach/change/remove a photo URI per pet, persisted locally via AsyncStorage
- Screens are standalone components wired via callback props (`onSelectPet`, `onBack`, `onEdit`, `onSaved`) — no navigation library required

## Acceptance Criteria
- [x] Pet list displays
- [x] Pet details show correctly
- [x] Add/edit works