### PR TITLE
feat: complete authentication UI screens

### DIFF
--- a/src/screens/AuthNavigator.tsx
+++ b/src/screens/AuthNavigator.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+
+import EmailVerificationScreen from './EmailVerificationScreen';
+import ForgotPasswordScreen from './ForgotPasswordScreen';
+import LoginScreen from './LoginScreen';
+import RegisterScreen from './RegisterScreen';
+import type { AuthSession } from '../services/authService';
+
+type Screen = 'login' | 'register' | 'forgot' | 'verify';
+
+interface Props {
+  /** Called when the user is fully authenticated (and verified). */
+  onAuthenticated: (session: AuthSession) => void;
+}
+
+/**
+ * Lightweight auth flow navigator using callback-prop pattern.
+ * No external navigation library required.
+ */
+const AuthNavigator: React.FC<Props> = ({ onAuthenticated }) => {
+  const [screen, setScreen] = useState<Screen>('login');
+  const [pendingSession, setPendingSession] = useState<AuthSession | null>(null);
+
+  const handleAuthSuccess = (session: AuthSession) => {
+    setPendingSession(session);
+    setScreen('verify');
+  };
+
+  const handleVerified = () => {
+    if (pendingSession) onAuthenticated(pendingSession);
+  };
+
+  const handleSkipVerify = () => {
+    if (pendingSession) onAuthenticated(pendingSession);
+  };
+
+  switch (screen) {
+    case 'login':
+      return (
+        <LoginScreen
+          onSuccess={handleAuthSuccess}
+          onRegister={() => setScreen('register')}
+          onForgotPassword={() => setScreen('forgot')}
+        />
+      );
+    case 'register':
+      return <RegisterScreen onSuccess={handleAuthSuccess} onLogin={() => setScreen('login')} />;
+    case 'forgot':
+      return <ForgotPasswordScreen onBack={() => setScreen('login')} />;
+    case 'verify':
+      return <EmailVerificationScreen onVerified={handleVerified} onSkip={handleSkipVerify} />;
+  }
+};
+
+export default AuthNavigator;

--- a/src/screens/EmailVerificationScreen.tsx
+++ b/src/screens/EmailVerificationScreen.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { verifyEmail } from '../services/authService';
+
+interface Props {
+  onVerified: () => void;
+  onSkip?: () => void;
+}
+
+const EmailVerificationScreen: React.FC<Props> = ({ onVerified, onSkip }) => {
+  const [token, setToken] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const handleVerify = async () => {
+    if (!token.trim()) {
+      Alert.alert('Validation', 'Please enter the verification code.');
+      return;
+    }
+    setLoading(true);
+    try {
+      await verifyEmail(token.trim());
+      setDone(true);
+    } catch (err: unknown) {
+      Alert.alert('Verification Failed', err instanceof Error ? err.message : 'Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <View style={styles.inner}>
+        {done ? (
+          <>
+            <Text style={styles.icon}>✅</Text>
+            <Text style={styles.title}>Email Verified!</Text>
+            <Text style={styles.subtitle}>Your account is now fully activated.</Text>
+            <TouchableOpacity style={styles.btn} onPress={onVerified}>
+              <Text style={styles.btnText}>Continue</Text>
+            </TouchableOpacity>
+          </>
+        ) : (
+          <>
+            <Text style={styles.icon}>📧</Text>
+            <Text style={styles.title}>Verify Your Email</Text>
+            <Text style={styles.subtitle}>
+              Enter the verification code sent to your email address.
+            </Text>
+
+            <TextInput
+              style={styles.input}
+              placeholder="Verification Code"
+              placeholderTextColor="#aaa"
+              autoCapitalize="none"
+              value={token}
+              onChangeText={setToken}
+            />
+
+            <TouchableOpacity
+              style={[styles.btn, loading && styles.btnDisabled]}
+              onPress={() => void handleVerify()}
+              disabled={loading}
+            >
+              {loading ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <Text style={styles.btnText}>Verify Email</Text>
+              )}
+            </TouchableOpacity>
+
+            {onSkip && (
+              <TouchableOpacity style={styles.skipBtn} onPress={onSkip}>
+                <Text style={styles.skipText}>Skip for now</Text>
+              </TouchableOpacity>
+            )}
+          </>
+        )}
+      </View>
+    </KeyboardAvoidingView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  inner: { flex: 1, justifyContent: 'center', padding: 24 },
+  icon: { fontSize: 56, textAlign: 'center', marginBottom: 12 },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    textAlign: 'center',
+    color: '#1a1a1a',
+    marginBottom: 8,
+  },
+  subtitle: { fontSize: 14, color: '#666', textAlign: 'center', marginBottom: 28, lineHeight: 20 },
+  input: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    marginBottom: 12,
+    color: '#1a1a1a',
+  },
+  btn: {
+    backgroundColor: '#4CAF50',
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  btnDisabled: { opacity: 0.6 },
+  btnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
+  skipBtn: { alignItems: 'center', paddingVertical: 10 },
+  skipText: { color: '#999', fontSize: 14 },
+});
+
+export default EmailVerificationScreen;

--- a/src/screens/ForgotPasswordScreen.tsx
+++ b/src/screens/ForgotPasswordScreen.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { requestPasswordReset, resetPassword } from '../services/authService';
+
+interface Props {
+  onBack: () => void;
+}
+
+type Step = 'request' | 'reset' | 'done';
+
+const ForgotPasswordScreen: React.FC<Props> = ({ onBack }) => {
+  const [step, setStep] = useState<Step>('request');
+  const [email, setEmail] = useState('');
+  const [token, setToken] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleRequest = async () => {
+    if (!email.trim()) {
+      Alert.alert('Validation', 'Please enter your email.');
+      return;
+    }
+    setLoading(true);
+    try {
+      await requestPasswordReset(email.trim());
+      setStep('reset');
+    } catch (err: unknown) {
+      Alert.alert('Error', err instanceof Error ? err.message : 'Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleReset = async () => {
+    if (!token.trim() || !newPassword) {
+      Alert.alert('Validation', 'Token and new password are required.');
+      return;
+    }
+    if (newPassword !== confirm) {
+      Alert.alert('Validation', 'Passwords do not match.');
+      return;
+    }
+    if (newPassword.length < 8) {
+      Alert.alert('Validation', 'Password must be at least 8 characters.');
+      return;
+    }
+    setLoading(true);
+    try {
+      await resetPassword(token.trim(), newPassword);
+      setStep('done');
+    } catch (err: unknown) {
+      Alert.alert('Error', err instanceof Error ? err.message : 'Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <View style={styles.inner}>
+        {/* Back */}
+        <TouchableOpacity onPress={onBack} style={styles.backBtn}>
+          <Text style={styles.backText}>‹ Back</Text>
+        </TouchableOpacity>
+
+        <Text style={styles.logo}>🔑</Text>
+
+        {step === 'request' && (
+          <>
+            <Text style={styles.title}>Forgot Password</Text>
+            <Text style={styles.subtitle}>Enter your email and we'll send a reset link.</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="Email"
+              placeholderTextColor="#aaa"
+              autoCapitalize="none"
+              keyboardType="email-address"
+              value={email}
+              onChangeText={setEmail}
+            />
+            <TouchableOpacity
+              style={[styles.btn, loading && styles.btnDisabled]}
+              onPress={() => void handleRequest()}
+              disabled={loading}
+            >
+              {loading ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <Text style={styles.btnText}>Send Reset Link</Text>
+              )}
+            </TouchableOpacity>
+          </>
+        )}
+
+        {step === 'reset' && (
+          <>
+            <Text style={styles.title}>Reset Password</Text>
+            <Text style={styles.subtitle}>Check your email for the reset token.</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="Reset Token"
+              placeholderTextColor="#aaa"
+              autoCapitalize="none"
+              value={token}
+              onChangeText={setToken}
+            />
+            <TextInput
+              style={styles.input}
+              placeholder="New Password"
+              placeholderTextColor="#aaa"
+              secureTextEntry
+              value={newPassword}
+              onChangeText={setNewPassword}
+            />
+            <TextInput
+              style={styles.input}
+              placeholder="Confirm New Password"
+              placeholderTextColor="#aaa"
+              secureTextEntry
+              value={confirm}
+              onChangeText={setConfirm}
+            />
+            <TouchableOpacity
+              style={[styles.btn, loading && styles.btnDisabled]}
+              onPress={() => void handleReset()}
+              disabled={loading}
+            >
+              {loading ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <Text style={styles.btnText}>Reset Password</Text>
+              )}
+            </TouchableOpacity>
+          </>
+        )}
+
+        {step === 'done' && (
+          <>
+            <Text style={styles.successIcon}>✅</Text>
+            <Text style={styles.title}>Password Reset!</Text>
+            <Text style={styles.subtitle}>You can now sign in with your new password.</Text>
+            <TouchableOpacity style={styles.btn} onPress={onBack}>
+              <Text style={styles.btnText}>Back to Sign In</Text>
+            </TouchableOpacity>
+          </>
+        )}
+      </View>
+    </KeyboardAvoidingView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  inner: { flex: 1, justifyContent: 'center', padding: 24 },
+  backBtn: { position: 'absolute', top: 48, left: 24 },
+  backText: { fontSize: 17, color: '#4CAF50' },
+  logo: { fontSize: 48, textAlign: 'center', marginBottom: 12 },
+  successIcon: { fontSize: 56, textAlign: 'center', marginBottom: 12 },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    textAlign: 'center',
+    color: '#1a1a1a',
+    marginBottom: 8,
+  },
+  subtitle: { fontSize: 14, color: '#666', textAlign: 'center', marginBottom: 28, lineHeight: 20 },
+  input: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    marginBottom: 12,
+    color: '#1a1a1a',
+  },
+  btn: {
+    backgroundColor: '#4CAF50',
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  btnDisabled: { opacity: 0.6 },
+  btnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
+});
+
+export default ForgotPasswordScreen;

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { login } from '../services/authService';
+import type { AuthSession } from '../services/authService';
+
+interface Props {
+  onSuccess: (session: AuthSession) => void;
+  onRegister: () => void;
+  onForgotPassword: () => void;
+}
+
+const LoginScreen: React.FC<Props> = ({ onSuccess, onRegister, onForgotPassword }) => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleLogin = async () => {
+    if (!email.trim() || !password) {
+      Alert.alert('Validation', 'Email and password are required.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const session = await login(email.trim(), password);
+      onSuccess(session);
+    } catch (err: unknown) {
+      Alert.alert('Login Failed', err instanceof Error ? err.message : 'Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <View style={styles.inner}>
+        <Text style={styles.logo}>🐾</Text>
+        <Text style={styles.title}>Welcome Back</Text>
+        <Text style={styles.subtitle}>Sign in to PetMedTracka</Text>
+
+        <TextInput
+          style={styles.input}
+          placeholder="Email"
+          placeholderTextColor="#aaa"
+          autoCapitalize="none"
+          keyboardType="email-address"
+          value={email}
+          onChangeText={setEmail}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Password"
+          placeholderTextColor="#aaa"
+          secureTextEntry
+          value={password}
+          onChangeText={setPassword}
+        />
+
+        <TouchableOpacity onPress={onForgotPassword} style={styles.forgotLink}>
+          <Text style={styles.link}>Forgot password?</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.btn, loading && styles.btnDisabled]}
+          onPress={() => void handleLogin()}
+          disabled={loading}
+        >
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.btnText}>Sign In</Text>
+          )}
+        </TouchableOpacity>
+
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>Don't have an account? </Text>
+          <TouchableOpacity onPress={onRegister}>
+            <Text style={styles.link}>Register</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </KeyboardAvoidingView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  inner: { flex: 1, justifyContent: 'center', padding: 24 },
+  logo: { fontSize: 56, textAlign: 'center', marginBottom: 12 },
+  title: { fontSize: 26, fontWeight: '700', textAlign: 'center', color: '#1a1a1a' },
+  subtitle: { fontSize: 15, color: '#666', textAlign: 'center', marginBottom: 32 },
+  input: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    marginBottom: 12,
+    color: '#1a1a1a',
+  },
+  forgotLink: { alignSelf: 'flex-end', marginBottom: 20 },
+  btn: {
+    backgroundColor: '#4CAF50',
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  btnDisabled: { opacity: 0.6 },
+  btnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
+  footer: { flexDirection: 'row', justifyContent: 'center' },
+  footerText: { color: '#666', fontSize: 14 },
+  link: { color: '#4CAF50', fontWeight: '600', fontSize: 14 },
+});
+
+export default LoginScreen;

--- a/src/screens/RegisterScreen.tsx
+++ b/src/screens/RegisterScreen.tsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { register } from '../services/authService';
+import type { AuthSession } from '../services/authService';
+
+interface Props {
+  onSuccess: (session: AuthSession) => void;
+  onLogin: () => void;
+}
+
+const RegisterScreen: React.FC<Props> = ({ onSuccess, onLogin }) => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleRegister = async () => {
+    if (!name.trim() || !email.trim() || !password) {
+      Alert.alert('Validation', 'All fields are required.');
+      return;
+    }
+    if (password !== confirm) {
+      Alert.alert('Validation', 'Passwords do not match.');
+      return;
+    }
+    if (password.length < 8) {
+      Alert.alert('Validation', 'Password must be at least 8 characters.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const session = await register({ name: name.trim(), email: email.trim(), password });
+      onSuccess(session);
+    } catch (err: unknown) {
+      Alert.alert('Registration Failed', err instanceof Error ? err.message : 'Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView contentContainerStyle={styles.inner} keyboardShouldPersistTaps="handled">
+        <Text style={styles.logo}>🐾</Text>
+        <Text style={styles.title}>Create Account</Text>
+        <Text style={styles.subtitle}>Join PetMedTracka</Text>
+
+        <TextInput
+          style={styles.input}
+          placeholder="Full Name"
+          placeholderTextColor="#aaa"
+          value={name}
+          onChangeText={setName}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Email"
+          placeholderTextColor="#aaa"
+          autoCapitalize="none"
+          keyboardType="email-address"
+          value={email}
+          onChangeText={setEmail}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Password (min 8 characters)"
+          placeholderTextColor="#aaa"
+          secureTextEntry
+          value={password}
+          onChangeText={setPassword}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Confirm Password"
+          placeholderTextColor="#aaa"
+          secureTextEntry
+          value={confirm}
+          onChangeText={setConfirm}
+        />
+
+        <TouchableOpacity
+          style={[styles.btn, loading && styles.btnDisabled]}
+          onPress={() => void handleRegister()}
+          disabled={loading}
+        >
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.btnText}>Create Account</Text>
+          )}
+        </TouchableOpacity>
+
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>Already have an account? </Text>
+          <TouchableOpacity onPress={onLogin}>
+            <Text style={styles.link}>Sign In</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  inner: { flexGrow: 1, justifyContent: 'center', padding: 24 },
+  logo: { fontSize: 56, textAlign: 'center', marginBottom: 12 },
+  title: { fontSize: 26, fontWeight: '700', textAlign: 'center', color: '#1a1a1a' },
+  subtitle: { fontSize: 15, color: '#666', textAlign: 'center', marginBottom: 32 },
+  input: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    marginBottom: 12,
+    color: '#1a1a1a',
+  },
+  btn: {
+    backgroundColor: '#4CAF50',
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 8,
+    marginBottom: 20,
+  },
+  btnDisabled: { opacity: 0.6 },
+  btnText: { color: '#fff', fontSize: 16, fontWeight: '700' },
+  footer: { flexDirection: 'row', justifyContent: 'center' },
+  footerText: { color: '#666', fontSize: 14 },
+  link: { color: '#4CAF50', fontWeight: '600', fontSize: 14 },
+});
+
+export default RegisterScreen;


### PR DESCRIPTION
Closes #98

---

## Summary
Implements all required authentication screens with responsive design and complete navigation flow.

## New Screens
| Screen | Features |
|--------|----------|
| **LoginScreen** | Email/password input, forgot password link, register link |
| **RegisterScreen** | Name/email/password/confirm, validation (min 8 chars, match check) |
| **ForgotPasswordScreen** | Two-step flow: request token → reset password with new password |
| **EmailVerificationScreen** | Token input with optional skip, success state |
| **AuthNavigator** | Wires all screens via callback props (no nav library) |

## Features
- **Responsive design** — KeyboardAvoidingView for iOS, ScrollView where needed
- **Complete navigation** — callback-prop pattern: `onSuccess`, `onBack`, `onRegister`, `onLogin`, `onForgotPassword`, `onVerified`, `onSkip`
- **Validation** — email/password required, password min 8 chars, confirm match
- **Loading states** — ActivityIndicator during async calls
- **Error handling** — Alert dialogs for all failures
- **Multi-step flows** — ForgotPassword (request → reset → done), EmailVerification (input → verified)

## Acceptance Criteria
- [x] All auth screens work
- [x] Navigation complete
- [x] Responsive design