### PR TITLE
feat: add-interceptors

### DIFF
--- a/src/middleware/apiInterceptors.ts
+++ b/src/middleware/apiInterceptors.ts
@@ -1,0 +1,77 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { type AxiosInstance, type AxiosError, type InternalAxiosRequestConfig } from 'axios';
+
+const ACCESS_TOKEN_KEY = '@access_token';
+const REFRESH_TOKEN_KEY = '@refresh_token';
+
+interface TokenResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export const setupInterceptors = (apiClient: AxiosInstance): void => {
+  // Request: auth token injection
+  apiClient.interceptors.request.use(
+    async (config: InternalAxiosRequestConfig) => {
+      const token = await AsyncStorage.getItem(ACCESS_TOKEN_KEY);
+      if (token) config.headers.Authorization = `Bearer ${token}`;
+      return config;
+    },
+    (error: AxiosError) => Promise.reject(error),
+  );
+
+  // Request: logging
+  apiClient.interceptors.request.use(
+    (config: InternalAxiosRequestConfig) => {
+      console.log(`[API] ${config.method?.toUpperCase()} ${config.url}`);
+      return config;
+    },
+    (error: AxiosError) => {
+      console.error('[API] Request error:', error.message);
+      return Promise.reject(error);
+    },
+  );
+
+  // Response: logging + error handling + token refresh
+  apiClient.interceptors.response.use(
+    (response) => {
+      console.log(`[API] ${response.status} ${response.config.url}`);
+      return response;
+    },
+    async (error: AxiosError) => {
+      const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+
+      console.error(`[API] Error ${error.response?.status ?? 'network'}: ${originalRequest?.url}`);
+
+      // Token refresh on 401
+      if (error.response?.status === 401 && !originalRequest._retry) {
+        originalRequest._retry = true;
+        try {
+          const refreshToken = await AsyncStorage.getItem(REFRESH_TOKEN_KEY);
+          if (!refreshToken) return Promise.reject(error);
+
+          const { data } = await apiClient.post<TokenResponse>('/auth/refresh', { refreshToken });
+
+          await Promise.all([
+            AsyncStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken),
+            AsyncStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken),
+          ]);
+
+          originalRequest.headers.Authorization = `Bearer ${data.accessToken}`;
+          return apiClient(originalRequest);
+        } catch {
+          await Promise.all([
+            AsyncStorage.removeItem(ACCESS_TOKEN_KEY),
+            AsyncStorage.removeItem(REFRESH_TOKEN_KEY),
+          ]);
+        }
+      }
+
+      // Consistent error message
+      const message = error.response
+        ? `Request failed with status ${error.response.status}`
+        : error.message ?? 'Network error';
+      return Promise.reject(new Error(message));
+    },
+  );
+};

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,7 +1,7 @@
 import axios, { type AxiosInstance, type AxiosRequestConfig, type AxiosResponse } from 'axios';
 
 import config from '../config';
-import { getToken } from './authService';
+import { setupInterceptors } from '../middleware/apiInterceptors';
 
 // --- Circuit Breaker ---
 type CircuitState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
@@ -54,14 +54,7 @@ const apiClient: AxiosInstance = axios.create({
   },
 });
 
-apiClient.interceptors.request.use(async (requestConfig) => {
-  const token = await getToken();
-  if (token) {
-    requestConfig.headers = requestConfig.headers ?? {};
-    requestConfig.headers.Authorization = `Bearer ${token}`;
-  }
-  return requestConfig;
-});
+setupInterceptors(apiClient);
 
 // --- Resilient request wrapper ---
 export async function resilientRequest<T>(


### PR DESCRIPTION
## Here's what was done:                                                                                                                
                                                                                                                                                                
  - src/middleware/apiInterceptors.ts was created with all 5 interceptors (auth injection, request logging, response logging, error handling, token refresh)    
  - src/services/apiClient.ts was updated to use setupInterceptors(apiClient) instead of the incomplete inline interceptor                                      
                                                                                                                                                                
  All acceptance criteria are met:                                                                                                                              
                                                                                                                                                                
  - every request gets the auth token ✓                                                                                                                         
  - errors are normalized to a consistent format ✓                                                                                                              
  - request/response logging is enabled ✓                                                                                                                       
  - token refresh with automatic retry on 401 ✓       
closes #83 