### PR TITLE
feat: iimplement graphql client

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     ]
   },
   "dependencies": {
+    "@urql/core": "^5.0.0",
+    "graphql": "^16.0.0",
     "@react-native-async-storage/async-storage": "^2.1.2",
     "@react-native-community/geolocation": "^3.4.0",
     "@react-native-community/netinfo": "^11.4.1",

--- a/src/services/graphqlClient.ts
+++ b/src/services/graphqlClient.ts
@@ -1,0 +1,52 @@
+import { createClient, fetchExchange, type Client, type Operation } from '@urql/core';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { makeOperation } from '@urql/core';
+
+import config from '../config';
+
+const ACCESS_TOKEN_KEY = '@access_token';
+
+const authExchange = () => ({
+  name: 'authExchange',
+  async applyAuth(operation: Operation): Promise<Operation> {
+    const token = await AsyncStorage.getItem(ACCESS_TOKEN_KEY);
+    if (!token) return operation;
+    return makeOperation(operation.kind, operation, {
+      ...operation.context,
+      fetchOptions: {
+        ...(typeof operation.context.fetchOptions === 'object'
+          ? operation.context.fetchOptions
+          : {}),
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    });
+  },
+});
+
+const client: Client = createClient({
+  url: `${config.api.baseUrl}/graphql`,
+  exchanges: [fetchExchange],
+  fetchOptions: () => ({ headers: { 'Content-Type': 'application/json' } }),
+});
+
+export async function gqlRequest<T>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const token = await AsyncStorage.getItem(ACCESS_TOKEN_KEY);
+  const result = await client.query<T>(query, variables ?? {}, {
+    fetchOptions: {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    },
+  }).toPromise();
+
+  if (result.error) throw new Error(result.error.message);
+  return result.data as T;
+}
+
+export default client;

--- a/src/services/petQueries.ts
+++ b/src/services/petQueries.ts
@@ -1,0 +1,66 @@
+import { gqlRequest } from './graphqlClient';
+import { getPetById, getAllPets, type Pet } from './petService';
+import { getMedicalRecords, type MedicalRecord, type RecordFilters, type PaginatedResponse } from './medicalRecordService';
+
+// --- Queries ---
+
+const PET_QUERY = `
+  query GetPet($id: ID!) {
+    pet(id: $id) {
+      id name species breed dateOfBirth microchipId photoUrl createdAt updatedAt
+      owner { id name email }
+    }
+  }
+`;
+
+const ALL_PETS_QUERY = `
+  query GetAllPets {
+    pets {
+      id name species breed photoUrl ownerId createdAt updatedAt
+    }
+  }
+`;
+
+const MEDICAL_RECORDS_QUERY = `
+  query GetMedicalRecords($petId: ID!, $type: String, $startDate: String, $endDate: String, $page: Int, $limit: Int) {
+    medicalRecords(petId: $petId, type: $type, startDate: $startDate, endDate: $endDate, page: $page, limit: $limit) {
+      data { id petId type date veterinarian notes createdAt }
+      total page limit totalPages
+    }
+  }
+`;
+
+// --- Fetchers with REST fallback ---
+
+export async function fetchPet(petId: string): Promise<Pet> {
+  try {
+    const result = await gqlRequest<{ pet: Pet }>(PET_QUERY, { id: petId });
+    return result.pet;
+  } catch {
+    return getPetById(petId);
+  }
+}
+
+export async function fetchAllPets(): Promise<Pet[]> {
+  try {
+    const result = await gqlRequest<{ pets: Pet[] }>(ALL_PETS_QUERY);
+    return result.pets;
+  } catch {
+    return getAllPets();
+  }
+}
+
+export async function fetchMedicalRecords(
+  petId: string,
+  filters?: RecordFilters,
+): Promise<PaginatedResponse<MedicalRecord>> {
+  try {
+    const result = await gqlRequest<{ medicalRecords: PaginatedResponse<MedicalRecord> }>(
+      MEDICAL_RECORDS_QUERY,
+      { petId, ...filters },
+    );
+    return result.medicalRecords;
+  } catch {
+    return getMedicalRecords(petId, filters);
+  }
+}


### PR DESCRIPTION
## Here's a summary of what was added:                                                                                                                     
                                                                                                                                                                
  Changes Made                                                                                                                                                  
                                                                                                                                                                
  `package.json`                                                                                                                                                
                                                                                                                                                                
  Added two dependencies:                                                                                                                                       
                                                                                                                                                                
  - @urql/core ^5.0.0 — lightweight GraphQL client (no React dependency needed for service layer)                                                               
  - graphql ^16.0.0 — required peer dependency                                                                                                                  
                                                                                                                                                                
  `src/services/graphqlClient.ts` (new)                                                                                                                         
                                                                                                                                                                
  - Creates a urql client pointed at {baseUrl}/graphql                                                                                                          
  - Exports gqlRequest<T>(query, variables) — a simple async helper that injects the Bearer token from AsyncStorage per-request and throws a normalized error on
  failure                                                                                                                                                       
                                                                                                                                                                
  `src/services/petQueries.ts` (new)                                                                                                                            
                                                                                                                                                                
  Three fetchers, each trying GraphQL first and falling back to the existing REST service on any error:                                                         
                                                                                                                                                                
  ┌────────────────────────────────────────┬──────────────────────────────────────────────────────┬─────────────────────┐                                       
  │ Function                               │ GraphQL query                                        │ REST fallback       │                                       
  ├────────────────────────────────────────┼──────────────────────────────────────────────────────┼─────────────────────┤                                       
  │ `fetchPet(id)`                         │ `GetPet` — includes nested `owner` in one round-trip │ `getPetById`        │                                       
  │ `fetchAllPets()`                       │ `GetAllPets`                                         │ `getAllPets`        │                                       
  │ `fetchMedicalRecords(petId, filters?)` │ `GetMedicalRecords` with all filter args             │ `getMedicalRecords` │                                       
  └────────────────────────────────────────┴──────────────────────────────────────────────────────┴─────────────────────┘                                       
                                                                                                                                                                
  The REST services (petService.ts, medicalRecordService.ts) are untouched — the fallback is transparent to callers.                                            
                                                                                                                                                                
  │ Run `npm install` (or `yarn`) after pulling to install the new dependencies.         

closes #84 