### PR TITLE
[439] Complete get-pet access-control test coverage (403 Forbidden & 401 Unauthorized)

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,8 @@
+module.exports = function (api) {
+  api.cache(true);
+
+  return {
+    presets: ['@babel/preset-typescript'],
+    plugins: ['@babel/plugin-transform-modules-commonjs'],
+  };
+};

--- a/package.json
+++ b/package.json
@@ -19,10 +19,19 @@
     ]
   },
   "jest": {
-    "preset": "ts-jest",
     "testEnvironment": "node",
     "testMatch": [
       "**/__tests__/**/*.test.ts"
+    ],
+    "transform": {
+      "^.+\\.[jt]sx?$": "babel-jest"
+    },
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json"
     ],
     "moduleNameMapper": {
       "^react-native-keychain$": "<rootDir>/src/__mocks__/react-native-keychain.ts",
@@ -44,7 +53,7 @@
     "expo-notifications": "^0.31.1",
     "expo-secure-store": "^14.0.1",
     "react-native-image-picker": "^7.0.0",
-    "react-native-image-resizer": "^3.0.0",
+    "react-native-image-resizer": "^1.4.5",
     "react-native-keychain": "^10.0.0"
   },
   "devDependencies": {

--- a/src/services/__tests__/petService.test.ts
+++ b/src/services/__tests__/petService.test.ts
@@ -1,23 +1,27 @@
-const mockGet = jest.fn();
-const mockPost = jest.fn();
-const mockPut = jest.fn();
-const mockDelete = jest.fn();
-
 jest.mock('../apiClient', () => ({
   __esModule: true,
   default: {
-    get: mockGet,
-    post: mockPost,
-    put: mockPut,
-    delete: mockDelete,
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
   },
 }));
 
-const mockParseQRCodeData = jest.fn();
-jest.mock('../qrCodeService', () => ({
-  parseQRCodeData: (...args: unknown[]) => mockParseQRCodeData(...args),
+jest.mock('../../utils/imageUtils', () => ({
+  pickImage: jest.fn(),
+  compressImage: jest.fn(),
+  generateThumbnail: jest.fn(),
+  uploadToStorage: jest.fn(),
 }));
 
+jest.mock('../qrCodeService', () => ({
+  parseQRCodeData: jest.fn(),
+}));
+
+import { AxiosError } from 'axios';
+import apiClient from '../apiClient';
+import { parseQRCodeData } from '../qrCodeService';
 import {
   getAllPets,
   getPetById,
@@ -27,6 +31,20 @@ import {
   deletePet,
   PetServiceError,
 } from '../petService';
+
+const mockClient = jest.mocked(apiClient);
+const mockGet = mockClient.get as jest.Mock;
+const mockPost = mockClient.post as jest.Mock;
+const mockPut = mockClient.put as jest.Mock;
+const mockDelete = mockClient.delete as jest.Mock;
+const mockParseQRCodeData = parseQRCodeData as jest.Mock;
+
+function makeAxiosError(status: number, data: unknown, message = 'Request failed') {
+  const err = new Error(message) as any;
+  err.isAxiosError = true;
+  err.response = { status, statusText: String(status), headers: {}, config: {}, data };
+  return err;
+}
 
 const PET = {
   id: 'pet-1',
@@ -60,6 +78,26 @@ describe('petService', () => {
     expect(result).toEqual(PET);
   });
 
+  it('getPetById surfaces forbidden access as PetServiceError', async () => {
+    mockGet.mockRejectedValueOnce(
+      makeAxiosError(403, {
+        error: {
+          code: 'PET_ACCESS_DENIED',
+          message: 'You do not have access to this pet',
+        },
+      }, 'Forbidden'),
+    );
+
+    await expect(getPetById('pet-1')).rejects.toMatchObject({
+      name: 'PetServiceError',
+      code: 'PET_ACCESS_DENIED',
+      message: 'You do not have access to this pet',
+      status: 403,
+    });
+
+    expect(mockGet).toHaveBeenCalledWith('/pets/pet-1');
+  });
+
   it('getPetByQRCode uses QR endpoint for scan data', async () => {
     mockGet.mockResolvedValueOnce({ data: { success: true, data: PET } });
 
@@ -70,11 +108,7 @@ describe('petService', () => {
   });
 
   it('getPetByQRCode falls back to petId extraction on 404', async () => {
-    const notFoundError = {
-      isAxiosError: true,
-      message: 'Not Found',
-      response: { status: 404, data: { message: 'Not found' } },
-    };
+    const notFoundError = makeAxiosError(404, { message: 'Not found' }, 'Not Found');
 
     mockGet
       .mockRejectedValueOnce(notFoundError)
@@ -88,6 +122,28 @@ describe('petService', () => {
     expect(mockGet).toHaveBeenNthCalledWith(1, '/pets/qr/base64-payload-from-scanner');
     expect(mockGet).toHaveBeenNthCalledWith(2, '/pets/pet-1');
     expect(result).toEqual(PET);
+  });
+
+  it('getPetByQRCode surfaces unauthorized access without fallback when lookup is denied', async () => {
+    mockGet.mockRejectedValueOnce(
+      makeAxiosError(401, {
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Authentication required',
+        },
+      }, 'Unauthorized'),
+    );
+
+    await expect(getPetByQRCode('scanned-qr-value')).rejects.toMatchObject({
+      name: 'PetServiceError',
+      code: 'UNAUTHORIZED',
+      message: 'Authentication required',
+      status: 401,
+    });
+
+    expect(mockParseQRCodeData).not.toHaveBeenCalled();
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledWith('/pets/qr/scanned-qr-value');
   });
 
   it('createPet posts payload and returns typed data', async () => {
@@ -126,19 +182,12 @@ describe('petService', () => {
   });
 
   it('surfaces API errors as PetServiceError', async () => {
-    const badRequestError = {
-      isAxiosError: true,
-      message: 'Request failed',
-      response: {
-        status: 400,
-        data: {
-          error: {
-            code: 'INVALID_INPUT',
-            message: 'Name is required',
-          },
-        },
+    const badRequestError = makeAxiosError(400, {
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'Name is required',
       },
-    };
+    });
 
     mockPost.mockRejectedValueOnce(badRequestError);
 


### PR DESCRIPTION
Closes #439

## Summary

Completes the `petService` test suite by adding the two missing access-control cases and fixing the broken test infrastructure so all 11 tests pass.

## New tests

- **`getPetById surfaces forbidden access as PetServiceError`** — verifies a 403 response is surfaced as `PetServiceError` with `code: 'PET_ACCESS_DENIED'` and `status: 403`
- **`getPetByQRCode surfaces unauthorized access without fallback when lookup is denied`** — verifies a 401 response propagates as `PetServiceError` with `code: 'UNAUTHORIZED'` and that `parseQRCodeData` is **not** called (no QR fallback for auth errors)

## Infrastructure fixes

- **Jest config** (`package.json`): switched from `ts-jest` (crashing on `bs-logger/cache_getters`) to `babel-jest`
- **`babel.config.cjs`** (new): uses `@babel/preset-typescript` + `@babel/plugin-transform-modules-commonjs`
- **Mock interop**: replaced outer `var` mock handles with `jest.fn()` inside the factory, retrieved via `jest.mocked(apiClient)` after import
- **AxiosError detection**: replaced `new AxiosError(...)` with plain `Error` + `isAxiosError: true` flag
- **`package.json`**: fixed `react-native-image-resizer` version `^3.0.0` to `^1.4.5` (v3 does not exist on npm)

## Test results

```
PASS src/services/__tests__/petService.test.ts
  petService
    11 passed, 11 total
```
