### PR TITLE
feat: configure build variants (#113)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/no-require-imports, no-undef */
+
+// Load .env.<APP_ENV> via dotenv
+const APP_ENV = process.env.APP_ENV ?? 'development';
+
+require('dotenv').config({ path: `.env.${APP_ENV}` });
+
+// Version codes: dev=1, staging=2, prod=3
+const VERSION_CODE = { development: 1, staging: 2, production: 3 }[APP_ENV] ?? 1;
+const APP_VERSION = '1.0.0';
+
+const APP_NAME_MAP = {
+  development: 'PetChain (Dev)',
+  staging: 'PetChain (Staging)',
+  production: 'PetChain',
+};
+
+module.exports = {
+  expo: {
+    name: APP_NAME_MAP[APP_ENV] ?? 'PetChain',
+    slug: 'petchain-mobile',
+    version: APP_VERSION,
+    orientation: 'portrait',
+    icon: './assets/icon.png',
+    userInterfaceStyle: 'light',
+    splash: {
+      image: './assets/splash.png',
+      resizeMode: 'contain',
+      backgroundColor: '#ffffff',
+    },
+    assetBundlePatterns: ['**/*'],
+    ios: {
+      supportsTablet: true,
+      bundleIdentifier:
+        APP_ENV === 'production' ? 'app.petchain.mobile' : `app.petchain.mobile.${APP_ENV}`,
+      buildNumber: String(VERSION_CODE),
+    },
+    android: {
+      adaptiveIcon: {
+        foregroundImage: './assets/adaptive-icon.png',
+        backgroundColor: '#ffffff',
+      },
+      package: APP_ENV === 'production' ? 'app.petchain.mobile' : `app.petchain.mobile.${APP_ENV}`,
+      versionCode: VERSION_CODE,
+    },
+    web: {
+      favicon: './assets/favicon.png',
+    },
+    plugins: [
+      [
+        '@sentry/react-native/expo',
+        {
+          organization: 'petchain',
+          project: 'mobile-app',
+        },
+      ],
+    ],
+    extra: {
+      APP_ENV,
+      API_BASE_URL: process.env.API_BASE_URL ?? 'http://localhost:3000/api',
+      STAGING_API_URL: process.env.STAGING_API_URL ?? 'https://staging.petchain.app/api',
+      PROD_API_URL: process.env.PROD_API_URL ?? 'https://api.petchain.app/api',
+      API_TIMEOUT: process.env.API_TIMEOUT ?? '10000',
+      SENTRY_DSN: process.env.SENTRY_DSN ?? '',
+      SENTRY_ENABLE_IN_DEV: process.env.SENTRY_ENABLE_IN_DEV ?? 'false',
+      MAX_CACHE_SIZE: process.env.MAX_CACHE_SIZE ?? '50',
+      PAGINATION_LIMIT: process.env.PAGINATION_LIMIT ?? '20',
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,5 +1,11 @@
 {
   "scripts": {
+    "start": "APP_ENV=development expo start",
+    "start:staging": "APP_ENV=staging expo start",
+    "start:production": "APP_ENV=production expo start",
+    "build:development": "APP_ENV=development expo build",
+    "build:staging": "APP_ENV=staging expo build",
+    "build:production": "APP_ENV=production expo build",
     "test": "jest --runInBand",
     "test:ci": "jest --runInBand --ci --coverage",
     "typecheck": "tsc --noEmit",
@@ -63,8 +69,7 @@
     "expo-secure-store": "^14.0.1",
     "react-native-image-picker": "^7.0.0",
     "react-native-image-resizer": "^1.4.5",
-    "react-native-keychain": "^10.0.0"
-    ,
+    "react-native-keychain": "^10.0.0",
     "react-native-ssl-pinning": "^1.5.3"
   },
   "devDependencies": {

--- a/src/__mocks__/expo-constants.ts
+++ b/src/__mocks__/expo-constants.ts
@@ -1,10 +1,30 @@
 /**
  * Manual mock for expo-constants.
+ * Reads APP_ENV from process.env so tests can set it per-variant.
  */
+const APP_ENV = (process.env.APP_ENV as string | undefined) ?? 'development';
+
+const API_BASE_URL_MAP: Record<string, string> = {
+  development: 'http://localhost:3000/api',
+  staging: 'https://staging.petchain.app/api',
+  production: 'https://api.petchain.app/api',
+};
+
 const Constants = {
   expoConfig: {
     version: '1.0.0',
-    extra: {},
+    extra: {
+      APP_ENV,
+      API_BASE_URL:
+        process.env.API_BASE_URL ?? API_BASE_URL_MAP[APP_ENV] ?? 'http://localhost:3000/api',
+      STAGING_API_URL: process.env.STAGING_API_URL ?? 'https://staging.petchain.app/api',
+      PROD_API_URL: process.env.PROD_API_URL ?? 'https://api.petchain.app/api',
+      API_TIMEOUT: process.env.API_TIMEOUT ?? '10000',
+      SENTRY_DSN: process.env.SENTRY_DSN ?? '',
+      SENTRY_ENABLE_IN_DEV: process.env.SENTRY_ENABLE_IN_DEV ?? 'false',
+      MAX_CACHE_SIZE: process.env.MAX_CACHE_SIZE ?? '50',
+      PAGINATION_LIMIT: process.env.PAGINATION_LIMIT ?? '20',
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
Configures development, staging, and production build variants for the Expo app.

## Changes
- **`app.config.js`** — dynamic Expo config (replaces static `app.json`); reads `APP_ENV` and loads `.env.<variant>` via dotenv
- **`.env.development/staging/production`** — per-variant env files (gitignored)
- **`package.json`** — added `start` and `build` scripts for each variant
- **`src/__mocks__/expo-constants.ts`** — updated mock to be variant-aware for tests

## Variant differences
| Variant | API | Bundle ID | versionCode |
|---|---|---|---|
| development | localhost:3000 | app.petchain.mobile.development | 1 |
| staging | staging.petchain.app | app.petchain.mobile.staging | 2 |
| production | api.petchain.app | app.petchain.mobile | 3 |

## Testing
Run a variant: `APP_ENV=staging npm run start:staging`

Closes #113