### PR TITLE
feat: cloud sync with selective entity control and provider abstraction

### DIFF
--- a/src/services/__tests__/cloudSyncService.test.ts
+++ b/src/services/__tests__/cloudSyncService.test.ts
@@ -1,0 +1,71 @@
+import {
+  getCloudSyncConfig,
+  updateCloudSyncConfig,
+  toggleEntitySync,
+} from '../cloudSyncService';
+
+// Mock localDB
+jest.mock('../localDB', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { getItem, setItem } = jest.requireMock('../localDB') as {
+  getItem: jest.Mock;
+  setItem: jest.Mock;
+};
+
+describe('CloudSyncService config', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns default config when nothing stored', async () => {
+    getItem.mockResolvedValue(null);
+    const config = await getCloudSyncConfig();
+    expect(config.provider).toBe('server');
+    expect(config.autoSync).toBe(true);
+    expect(config.syncedEntities).toHaveLength(4);
+  });
+
+  it('merges stored config with defaults', async () => {
+    getItem.mockResolvedValue(JSON.stringify({ autoSync: false }));
+    const config = await getCloudSyncConfig();
+    expect(config.autoSync).toBe(false);
+    expect(config.provider).toBe('server');
+  });
+
+  it('updates and persists config', async () => {
+    getItem.mockResolvedValue(null);
+    await updateCloudSyncConfig({ autoSync: false });
+    expect(setItem).toHaveBeenCalledWith(
+      '@cloud_sync_config',
+      expect.stringContaining('"autoSync":false'),
+    );
+  });
+});
+
+describe('toggleEntitySync', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('adds entity type when enabled', async () => {
+    getItem.mockResolvedValue(
+      JSON.stringify({ syncedEntities: ['pet', 'appointment'] }),
+    );
+    const updated = await toggleEntitySync('medication', true);
+    expect(updated.syncedEntities).toContain('medication');
+  });
+
+  it('removes entity type when disabled', async () => {
+    getItem.mockResolvedValue(
+      JSON.stringify({ syncedEntities: ['pet', 'appointment', 'medication'] }),
+    );
+    const updated = await toggleEntitySync('medication', false);
+    expect(updated.syncedEntities).not.toContain('medication');
+    expect(updated.syncedEntities).toContain('pet');
+  });
+
+  it('does not duplicate entity types when enabling already-enabled entity', async () => {
+    getItem.mockResolvedValue(JSON.stringify({ syncedEntities: ['pet'] }));
+    const updated = await toggleEntitySync('pet', true);
+    expect(updated.syncedEntities.filter((e) => e === 'pet')).toHaveLength(1);
+  });
+});

--- a/src/services/cloudSyncService.ts
+++ b/src/services/cloudSyncService.ts
@@ -1,0 +1,166 @@
+import apiClient from './apiClient';
+import { getItem, setItem } from './localDB';
+import { logError } from '../utils/errorLogger';
+import { SyncEntityType } from './syncService';
+
+// ─────────────────────────────────────────────────────────────
+// TYPES
+// ─────────────────────────────────────────────────────────────
+
+export type CloudProvider = 'server' | 'icloud' | 'google_drive';
+
+export interface CloudSyncConfig {
+  /** Which provider to use (default: server) */
+  provider: CloudProvider;
+  /** Entity types included in sync (default: all) */
+  syncedEntities: SyncEntityType[];
+  /** Auto-sync on network reconnect */
+  autoSync: boolean;
+}
+
+export interface BackupMetadata {
+  backupId: string;
+  provider: CloudProvider;
+  createdAt: string;
+  sizeBytes: number;
+  entityCounts: Record<SyncEntityType, number>;
+}
+
+export interface RestoreResult {
+  restoredAt: string;
+  entityCounts: Record<SyncEntityType, number>;
+  conflicts: number;
+}
+
+// ─────────────────────────────────────────────────────────────
+// CONSTANTS
+// ─────────────────────────────────────────────────────────────
+
+const CONFIG_KEY = '@cloud_sync_config';
+const LAST_BACKUP_KEY = '@cloud_sync_last_backup';
+
+const DEFAULT_CONFIG: CloudSyncConfig = {
+  provider: 'server',
+  syncedEntities: ['pet', 'appointment', 'medication', 'medicalRecord'],
+  autoSync: true,
+};
+
+// ─────────────────────────────────────────────────────────────
+// CONFIG
+// ─────────────────────────────────────────────────────────────
+
+export async function getCloudSyncConfig(): Promise<CloudSyncConfig> {
+  try {
+    const stored = await getItem(CONFIG_KEY);
+    return stored ? { ...DEFAULT_CONFIG, ...JSON.parse(stored) } : DEFAULT_CONFIG;
+  } catch {
+    return DEFAULT_CONFIG;
+  }
+}
+
+export async function updateCloudSyncConfig(
+  updates: Partial<CloudSyncConfig>,
+): Promise<CloudSyncConfig> {
+  const current = await getCloudSyncConfig();
+  const updated = { ...current, ...updates };
+  await setItem(CONFIG_KEY, JSON.stringify(updated));
+  return updated;
+}
+
+// ─────────────────────────────────────────────────────────────
+// BACKUP
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Create a cloud backup.
+ *
+ * Server provider: calls the app's own REST API.
+ * iCloud / Google Drive: stubs for native module integration.
+ */
+export async function createBackup(
+  userId: string,
+  config?: CloudSyncConfig,
+): Promise<BackupMetadata> {
+  const cfg = config ?? (await getCloudSyncConfig());
+
+  if (cfg.provider === 'server') {
+    const response = await apiClient.post<BackupMetadata>('/cloud-sync/backup', {
+      userId,
+      syncedEntities: cfg.syncedEntities,
+    });
+    await setItem(LAST_BACKUP_KEY, JSON.stringify(response.data));
+    return response.data;
+  }
+
+  if (cfg.provider === 'icloud') {
+    // iCloud integration requires the `react-native-icloud-storage` native module.
+    // The backup data is retrieved from the server and stored to the iCloud key-value store.
+    throw new Error(
+      'iCloud sync requires the react-native-icloud-storage native module. ' +
+        'Install and link it, then replace this stub with the native calls.',
+    );
+  }
+
+  if (cfg.provider === 'google_drive') {
+    // Google Drive integration requires `@react-native-google-signin/google-signin`
+    // and the Google Drive REST API with an OAuth token.
+    throw new Error(
+      'Google Drive sync requires @react-native-google-signin/google-signin. ' +
+        'Install and configure it, then replace this stub with Drive API calls.',
+    );
+  }
+
+  throw new Error(`Unknown cloud provider: ${cfg.provider}`);
+}
+
+// ─────────────────────────────────────────────────────────────
+// RESTORE
+// ─────────────────────────────────────────────────────────────
+
+export async function restoreFromBackup(
+  userId: string,
+  backupId: string,
+): Promise<RestoreResult> {
+  const response = await apiClient.post<RestoreResult>('/cloud-sync/restore', {
+    userId,
+    backupId,
+  });
+  return response.data;
+}
+
+// ─────────────────────────────────────────────────────────────
+// SELECTIVE SYNC
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Toggle sync for a specific entity type without affecting others.
+ */
+export async function toggleEntitySync(
+  entityType: SyncEntityType,
+  enabled: boolean,
+): Promise<CloudSyncConfig> {
+  const config = await getCloudSyncConfig();
+  const syncedEntities = enabled
+    ? [...new Set([...config.syncedEntities, entityType])]
+    : config.syncedEntities.filter((e) => e !== entityType);
+
+  return updateCloudSyncConfig({ syncedEntities });
+}
+
+// ─────────────────────────────────────────────────────────────
+// STATUS
+// ─────────────────────────────────────────────────────────────
+
+export async function getLastBackupMetadata(): Promise<BackupMetadata | null> {
+  try {
+    const stored = await getItem(LAST_BACKUP_KEY);
+    return stored ? (JSON.parse(stored) as BackupMetadata) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function listBackups(userId: string): Promise<BackupMetadata[]> {
+  const response = await apiClient.get<BackupMetadata[]>(`/cloud-sync/backups/${userId}`);
+  return response.data;
+}


### PR DESCRIPTION
## Summary

- `cloudSyncService.ts` with `createBackup`, `restoreFromBackup`, `listBackups`
- **Server provider** (default): calls `/cloud-sync/backup` and `/cloud-sync/restore` on the app API
- **iCloud** and **Google Drive** stubs raise informative errors explaining native module setup
- **Selective sync:** `toggleEntitySync(entityType, enabled)` enables/disables individual entity types without affecting others
- Config persisted locally and merged with defaults; `autoSync` flag for auto-sync on reconnect

## Test plan

- [ ] Default config has all 4 entity types enabled and `autoSync: true`
- [ ] `updateCloudSyncConfig({ autoSync: false })` persists the change
- [ ] `toggleEntitySync('medication', false)` removes only medication, others remain
- [ ] `toggleEntitySync('pet', true)` on already-enabled type does not duplicate it
- [ ] iCloud/Google Drive provider throws helpful error message

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)