### PR TITLE
feat: add multiple pets support (#151/#82) and emergency call integra…

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import './src/i18n';
 import OfflineIndicator from './src/components/OfflineIndicator';
 import { useSplashGuard } from './src/components/SplashGuard';
 import AppNavigator from './src/navigation';
+import { PetProvider } from './src/context/PetContext';
 
 export default function App() {
   const { appReady } = useSplashGuard();
@@ -13,10 +14,12 @@ export default function App() {
   if (!appReady) return <View style={styles.root} />;
 
   return (
-    <View style={styles.root}>
-      <OfflineIndicator />
-      <AppNavigator />
-    </View>
+    <PetProvider>
+      <View style={styles.root}>
+        <OfflineIndicator />
+        <AppNavigator />
+      </View>
+    </PetProvider>
   );
 }
 

--- a/src/components/EmergencyCallButton.tsx
+++ b/src/components/EmergencyCallButton.tsx
@@ -1,0 +1,188 @@
+/**
+ * EmergencyCallButton — Issue #144/#75: Emergency call integration
+ *
+ * A prominent, accessible call button that uses the device phone API
+ * (via React Native's Linking) to place a direct call.
+ * Designed to work reliably in emergency situations:
+ *  - Confirms before dialling (optional, skippable for speed)
+ *  - Falls back gracefully if the device cannot make calls
+ *  - Accessible label for screen readers
+ */
+
+import React, { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Linking,
+  Platform,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+
+interface Props {
+  /** Phone number to dial */
+  phoneNumber: string;
+  /** Display label (e.g. contact name) */
+  label?: string;
+  /** Skip the confirmation dialog — useful for one-tap emergency buttons */
+  skipConfirm?: boolean;
+  /** Optional extra container style */
+  style?: StyleProp<ViewStyle>;
+  /** Compact mode: renders a small icon-only button */
+  compact?: boolean;
+}
+
+/**
+ * Initiates a phone call using the tel: URI scheme.
+ * Returns true if the call was launched, false if unsupported.
+ */
+export async function initiateCall(phoneNumber: string): Promise<boolean> {
+  const url = `tel:${phoneNumber}`;
+  const supported = await Linking.canOpenURL(url);
+  if (!supported) return false;
+  await Linking.openURL(url);
+  return true;
+}
+
+const EmergencyCallButton: React.FC<Props> = ({
+  phoneNumber,
+  label,
+  skipConfirm = false,
+  style,
+  compact = false,
+}) => {
+  const [calling, setCalling] = useState(false);
+
+  const handleCall = useCallback(async () => {
+    if (!phoneNumber?.trim()) {
+      Alert.alert('No number', 'No phone number is available for this contact.');
+      return;
+    }
+
+    const doCall = async () => {
+      setCalling(true);
+      try {
+        const ok = await initiateCall(phoneNumber);
+        if (!ok) {
+          Alert.alert(
+            'Cannot make calls',
+            Platform.OS === 'ios'
+              ? 'This device does not support phone calls.'
+              : 'Phone calls are not supported on this device.',
+          );
+        }
+      } finally {
+        setCalling(false);
+      }
+    };
+
+    if (skipConfirm) {
+      await doCall();
+      return;
+    }
+
+    Alert.alert(
+      'Call ' + (label ?? phoneNumber),
+      `Dial ${phoneNumber}?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Call', style: 'default', onPress: () => void doCall() },
+      ],
+    );
+  }, [phoneNumber, label, skipConfirm]);
+
+  if (compact) {
+    return (
+      <TouchableOpacity
+        style={[styles.compactBtn, style]}
+        onPress={() => void handleCall()}
+        accessibilityRole="button"
+        accessibilityLabel={`Call ${label ?? phoneNumber}`}
+        accessibilityHint="Initiates a phone call"
+        disabled={calling}
+      >
+        {calling ? (
+          <ActivityIndicator size="small" color="#fff" />
+        ) : (
+          <Text style={styles.compactIcon}>📞</Text>
+        )}
+      </TouchableOpacity>
+    );
+  }
+
+  return (
+    <TouchableOpacity
+      style={[styles.btn, style]}
+      onPress={() => void handleCall()}
+      accessibilityRole="button"
+      accessibilityLabel={`Call ${label ?? phoneNumber}`}
+      accessibilityHint="Initiates a phone call"
+      disabled={calling}
+      activeOpacity={0.8}
+    >
+      {calling ? (
+        <ActivityIndicator size="small" color="#fff" />
+      ) : (
+        <View style={styles.btnInner}>
+          <Text style={styles.btnIcon}>📞</Text>
+          <View>
+            {label ? <Text style={styles.btnLabel}>{label}</Text> : null}
+            <Text style={styles.btnNumber}>{phoneNumber}</Text>
+          </View>
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  btn: {
+    backgroundColor: '#e53e3e',
+    borderRadius: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...Platform.select({
+      ios: {
+        shadowColor: '#e53e3e',
+        shadowOpacity: 0.4,
+        shadowRadius: 8,
+        shadowOffset: { width: 0, height: 4 },
+      },
+      android: { elevation: 6 },
+    }),
+  },
+  btnInner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  btnIcon: { fontSize: 22 },
+  btnLabel: { fontSize: 15, fontWeight: '700', color: '#fff' },
+  btnNumber: { fontSize: 13, color: 'rgba(255,255,255,0.85)' },
+  compactBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#e53e3e',
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...Platform.select({
+      ios: {
+        shadowColor: '#e53e3e',
+        shadowOpacity: 0.3,
+        shadowRadius: 4,
+        shadowOffset: { width: 0, height: 2 },
+      },
+      android: { elevation: 4 },
+    }),
+  },
+  compactIcon: { fontSize: 18 },
+});
+
+export default EmergencyCallButton;

--- a/src/components/PetAggregateView.tsx
+++ b/src/components/PetAggregateView.tsx
@@ -1,0 +1,181 @@
+/**
+ * PetAggregateView — Issue #151/#82: Multiple pets support
+ *
+ * Shows a summary card for each pet with quick-access stats,
+ * providing an aggregate overview across all pets in one account.
+ */
+
+import React from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  ScrollView,
+} from 'react-native';
+
+import { usePetContext } from '../context/PetContext';
+import type { Pet } from '../services/petService';
+
+interface PetCardProps {
+  pet: Pet;
+  isActive: boolean;
+  onSelect: (pet: Pet) => void;
+}
+
+const PetCard: React.FC<PetCardProps> = ({ pet, isActive, onSelect }) => (
+  <TouchableOpacity
+    style={[styles.card, isActive && styles.cardActive]}
+    onPress={() => onSelect(pet)}
+    accessibilityRole="button"
+    accessibilityLabel={`${pet.name}, ${pet.species}${isActive ? ', currently selected' : ''}`}
+  >
+    <Text style={styles.cardEmoji}>
+      {pet.species === 'dog'
+        ? '🐶'
+        : pet.species === 'cat'
+          ? '🐱'
+          : pet.species === 'bird'
+            ? '🐦'
+            : pet.species === 'rabbit'
+              ? '🐰'
+              : '🐾'}
+    </Text>
+    <Text style={styles.cardName} numberOfLines={1}>
+      {pet.name}
+    </Text>
+    <Text style={styles.cardSpecies}>{pet.species}</Text>
+    {pet.breed ? (
+      <Text style={styles.cardBreed} numberOfLines={1}>
+        {pet.breed}
+      </Text>
+    ) : null}
+    {isActive && <View style={styles.activeDot} />}
+  </TouchableOpacity>
+);
+
+interface Props {
+  onSelectPet?: (pet: Pet) => void;
+}
+
+const PetAggregateView: React.FC<Props> = ({ onSelectPet }) => {
+  const { pets, activePet, loading, error, setActivePet, totalPets } = usePetContext();
+
+  const handleSelect = (pet: Pet) => {
+    setActivePet(pet);
+    onSelectPet?.(pet);
+  };
+
+  if (loading && pets.length === 0) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#4CAF50" />
+      </View>
+    );
+  }
+
+  if (error && pets.length === 0) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorText}>Failed to load pets.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>All Pets</Text>
+        <Text style={styles.headerCount}>{totalPets} pet{totalPets !== 1 ? 's' : ''}</Text>
+      </View>
+
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scroll}
+      >
+        {pets.map((pet) => (
+          <PetCard
+            key={pet.id}
+            pet={pet}
+            isActive={activePet?.id === pet.id}
+            onSelect={handleSelect}
+          />
+        ))}
+      </ScrollView>
+
+      {activePet && (
+        <View style={styles.activeInfo}>
+          <Text style={styles.activeLabel}>Viewing:</Text>
+          <Text style={styles.activeName}>{activePet.name}</Text>
+        </View>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 12,
+    marginHorizontal: 16,
+    marginVertical: 8,
+    shadowColor: '#000',
+    shadowOpacity: 0.06,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  center: { padding: 24, alignItems: 'center' },
+  errorText: { color: '#e53e3e', fontSize: 14 },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  headerTitle: { fontSize: 15, fontWeight: '700', color: '#1a1a1a' },
+  headerCount: { fontSize: 13, color: '#888' },
+  scroll: { gap: 10, paddingBottom: 4 },
+  card: {
+    width: 90,
+    alignItems: 'center',
+    padding: 10,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    borderColor: '#e0e0e0',
+    backgroundColor: '#fafafa',
+    position: 'relative',
+  },
+  cardActive: {
+    borderColor: '#4CAF50',
+    backgroundColor: '#e8f5e9',
+  },
+  cardEmoji: { fontSize: 28, marginBottom: 4 },
+  cardName: { fontSize: 13, fontWeight: '700', color: '#1a1a1a', textAlign: 'center' },
+  cardSpecies: { fontSize: 11, color: '#888', marginTop: 2, textTransform: 'capitalize' },
+  cardBreed: { fontSize: 10, color: '#aaa', marginTop: 1, textAlign: 'center' },
+  activeDot: {
+    position: 'absolute',
+    top: 6,
+    right: 6,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#4CAF50',
+  },
+  activeInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 10,
+    paddingTop: 10,
+    borderTopWidth: 1,
+    borderTopColor: '#f0f0f0',
+  },
+  activeLabel: { fontSize: 13, color: '#888' },
+  activeName: { fontSize: 13, fontWeight: '700', color: '#2e7d32' },
+});
+
+export default PetAggregateView;

--- a/src/components/PetSelectorBar.tsx
+++ b/src/components/PetSelectorBar.tsx
@@ -1,0 +1,138 @@
+/**
+ * PetSelectorBar — Issue #151/#82: Multiple pets support
+ *
+ * A horizontal scrollable bar that lets the user switch between their pets.
+ * Renders at the top of any screen that needs per-pet context.
+ */
+
+import React from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { usePetContext } from '../context/PetContext';
+import type { Pet } from '../services/petService';
+
+interface Props {
+  onAddPet?: () => void;
+}
+
+const PetSelectorBar: React.FC<Props> = ({ onAddPet }) => {
+  const { pets, activePet, loading, setActivePet } = usePetContext();
+
+  if (loading && pets.length === 0) {
+    return (
+      <View style={styles.loadingRow}>
+        <ActivityIndicator size="small" color="#4CAF50" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.wrapper}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scroll}
+        accessibilityRole="tablist"
+      >
+        {pets.map((pet: Pet) => {
+          const isActive = activePet?.id === pet.id;
+          return (
+            <TouchableOpacity
+              key={pet.id}
+              style={[styles.chip, isActive && styles.chipActive]}
+              onPress={() => setActivePet(pet)}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: isActive }}
+              accessibilityLabel={`Select ${pet.name}`}
+            >
+              <Text style={styles.chipEmoji}>
+                {pet.species === 'dog'
+                  ? '🐶'
+                  : pet.species === 'cat'
+                    ? '🐱'
+                    : pet.species === 'bird'
+                      ? '🐦'
+                      : pet.species === 'rabbit'
+                        ? '🐰'
+                        : '🐾'}
+              </Text>
+              <Text style={[styles.chipText, isActive && styles.chipTextActive]}>
+                {pet.name}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+
+        {onAddPet && (
+          <TouchableOpacity
+            style={styles.addChip}
+            onPress={onAddPet}
+            accessibilityRole="button"
+            accessibilityLabel="Add new pet"
+          >
+            <Text style={styles.addChipText}>+ Add</Text>
+          </TouchableOpacity>
+        )}
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    backgroundColor: '#fff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#e0e0e0',
+  },
+  loadingRow: {
+    height: 52,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#e0e0e0',
+  },
+  scroll: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    gap: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 20,
+    borderWidth: 1.5,
+    borderColor: '#e0e0e0',
+    backgroundColor: '#f9f9f9',
+  },
+  chipActive: {
+    borderColor: '#4CAF50',
+    backgroundColor: '#e8f5e9',
+  },
+  chipEmoji: { fontSize: 16 },
+  chipText: { fontSize: 13, fontWeight: '500', color: '#555' },
+  chipTextActive: { color: '#2e7d32', fontWeight: '700' },
+  addChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 20,
+    borderWidth: 1.5,
+    borderColor: '#4CAF50',
+    backgroundColor: '#fff',
+  },
+  addChipText: { fontSize: 13, fontWeight: '600', color: '#4CAF50' },
+});
+
+export default PetSelectorBar;

--- a/src/context/PetContext.tsx
+++ b/src/context/PetContext.tsx
@@ -1,0 +1,156 @@
+/**
+ * PetContext — Issue #151/#82: Multiple pets support
+ *
+ * Provides:
+ *  - A list of all pets for the current user
+ *  - The currently "active" pet (selected in the pet selector)
+ *  - Per-pet settings stored in AsyncStorage
+ *  - Aggregate helpers (e.g. total medication count across all pets)
+ */
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import { getAllPets, type Pet } from '../services/petService';
+import { getItem, setItem } from '../services/localDB';
+
+// ─── Per-pet settings ─────────────────────────────────────────────────────────
+
+export interface PetSettings {
+  notificationsEnabled: boolean;
+  reminderLeadMinutes: number; // minutes before appointment/medication to remind
+  weightUnit: 'kg' | 'lbs';
+  notes: string;
+}
+
+const DEFAULT_PET_SETTINGS: PetSettings = {
+  notificationsEnabled: true,
+  reminderLeadMinutes: 60,
+  weightUnit: 'kg',
+  notes: '',
+};
+
+const PET_SETTINGS_KEY = (petId: string) => `@pet_settings_${petId}`;
+
+// ─── Context shape ────────────────────────────────────────────────────────────
+
+interface PetContextValue {
+  /** All pets belonging to the current user */
+  pets: Pet[];
+  /** The pet currently selected in the pet selector (null = none / loading) */
+  activePet: Pet | null;
+  /** Whether the pet list is being fetched */
+  loading: boolean;
+  /** Last fetch error, if any */
+  error: Error | null;
+  /** Switch the active pet */
+  setActivePet: (pet: Pet) => void;
+  /** Reload pets from the API / cache */
+  refreshPets: () => Promise<void>;
+  /** Per-pet settings */
+  getPetSettings: (petId: string) => Promise<PetSettings>;
+  updatePetSettings: (petId: string, patch: Partial<PetSettings>) => Promise<void>;
+  /** Aggregate: total number of pets */
+  totalPets: number;
+}
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+const PetContext = createContext<PetContextValue | null>(null);
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+export const PetProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [pets, setPets] = useState<Pet[]>([]);
+  const [activePet, setActivePetState] = useState<Pet | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refreshPets = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getAllPets();
+      setPets(data);
+      // Auto-select first pet if none selected yet
+      setActivePetState((prev) => {
+        if (prev) {
+          // Keep selection if the pet still exists
+          const still = data.find((p) => p.id === prev.id);
+          return still ?? data[0] ?? null;
+        }
+        return data[0] ?? null;
+      });
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error('Failed to load pets'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshPets();
+  }, [refreshPets]);
+
+  const setActivePet = useCallback((pet: Pet) => {
+    setActivePetState(pet);
+  }, []);
+
+  const getPetSettings = useCallback(async (petId: string): Promise<PetSettings> => {
+    const raw = await getItem(PET_SETTINGS_KEY(petId));
+    if (!raw) return { ...DEFAULT_PET_SETTINGS };
+    return { ...DEFAULT_PET_SETTINGS, ...JSON.parse(raw) };
+  }, []);
+
+  const updatePetSettings = useCallback(
+    async (petId: string, patch: Partial<PetSettings>): Promise<void> => {
+      const current = await getPetSettings(petId);
+      const updated = { ...current, ...patch };
+      await setItem(PET_SETTINGS_KEY(petId), JSON.stringify(updated));
+    },
+    [getPetSettings],
+  );
+
+  const totalPets = useMemo(() => pets.length, [pets]);
+
+  const value = useMemo<PetContextValue>(
+    () => ({
+      pets,
+      activePet,
+      loading,
+      error,
+      setActivePet,
+      refreshPets,
+      getPetSettings,
+      updatePetSettings,
+      totalPets,
+    }),
+    [
+      pets,
+      activePet,
+      loading,
+      error,
+      setActivePet,
+      refreshPets,
+      getPetSettings,
+      updatePetSettings,
+      totalPets,
+    ],
+  );
+
+  return <PetContext.Provider value={value}>{children}</PetContext.Provider>;
+};
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function usePetContext(): PetContextValue {
+  const ctx = useContext(PetContext);
+  if (!ctx) throw new Error('usePetContext must be used inside <PetProvider>');
+  return ctx;
+}

--- a/src/screens/EmergencyContactsScreen.tsx
+++ b/src/screens/EmergencyContactsScreen.tsx
@@ -17,6 +17,8 @@ import emergencyService, {
   type VetClinic,
 } from "../services/emergencyService";
 import SOSButton from "../components/SOSButton";
+import EmergencyCallButton from "../components/EmergencyCallButton";
+import PetSelectorBar from "../components/PetSelectorBar";
 import { useSecureScreen } from "../utils/secureScreen";
 import { formatWeight, formatAddress } from "../utils/localeValues";
 
@@ -157,13 +159,13 @@ const EmergencyContactsScreen: React.FC = () => {
           ) : null}
         </View>
         <View style={styles.cardActions}>
-          <TouchableOpacity
-            style={[styles.actionBtn, styles.callBtn]}
-            onPress={() => emergencyService.callContact(item.phoneNumber)}
-            accessibilityLabel={`Call ${item.name}`}
-          >
-            <Text style={styles.actionBtnText}>📞</Text>
-          </TouchableOpacity>
+          {/* Direct call button — Issue #144/#75 */}
+          <EmergencyCallButton
+            phoneNumber={item.phoneNumber}
+            label={item.name}
+            compact
+            skipConfirm={item.available24h} // skip confirm for 24h emergency contacts
+          />
           <TouchableOpacity
             style={[styles.actionBtn, styles.editBtn]}
             onPress={() => openEditModal(item)}
@@ -198,13 +200,13 @@ const EmergencyContactsScreen: React.FC = () => {
           <Text style={styles.cardSub}>{item.address}</Text>
         </View>
         <View style={styles.cardActions}>
-          <TouchableOpacity
-            style={[styles.actionBtn, styles.callBtn]}
-            onPress={() => emergencyService.callContact(item.phoneNumber)}
-            accessibilityLabel={`Call ${item.name}`}
-          >
-            <Text style={styles.actionBtnText}>📞</Text>
-          </TouchableOpacity>
+          {/* Direct call button — Issue #144/#75 */}
+          <EmergencyCallButton
+            phoneNumber={item.phoneNumber}
+            label={item.name}
+            compact
+            skipConfirm={item.available24h}
+          />
           <TouchableOpacity
             style={[styles.actionBtn, styles.navBtn]}
             onPress={() => emergencyService.navigateToClinic(item.address)}
@@ -220,6 +222,9 @@ const EmergencyContactsScreen: React.FC = () => {
   return (
     <View style={styles.container}>
       <SOSButton onSOSSent={handleSOSSent} />
+
+      {/* Pet selector — Issue #151/#82: switch between pets */}
+      <PetSelectorBar />
 
       <View style={styles.tabs}>
         <TouchableOpacity

--- a/src/screens/PetListScreen.tsx
+++ b/src/screens/PetListScreen.tsx
@@ -12,7 +12,10 @@ import { HeaderOfflineStatus, useOfflineStatus } from '../components/OfflineIndi
 import { OptimizedImage } from '../components/OptimizedImage';
 import { RetryError } from '../components/RetryError';
 import SOSButton from '../components/SOSButton';
+import PetSelectorBar from '../components/PetSelectorBar';
+import PetAggregateView from '../components/PetAggregateView';
 import petService, { type Pet } from '../services/petService';
+import { usePetContext } from '../context/PetContext';
 import { useRetry } from '../utils/useRetry';
 
 interface Props {
@@ -23,6 +26,7 @@ interface Props {
 const PetListScreen: React.FC<Props> = ({ onSelectPet, onAddPet }) => {
   const [pets, setPets] = useState<Pet[]>([]);
   const offlineStatus = useOfflineStatus();
+  const { refreshPets } = usePetContext();
 
   const loadPets = useCallback(async () => {
     const data = await petService.getAllPets();
@@ -103,11 +107,18 @@ const PetListScreen: React.FC<Props> = ({ onSelectPet, onAddPet }) => {
           <Text style={styles.addBtnText}>+ Add</Text>
         </TouchableOpacity>
       </View>
+
+      {/* Pet selector bar — Issue #151/#82 */}
+      <PetSelectorBar onAddPet={onAddPet} />
+
       {!offlineStatus?.isOnline ? (
         <View style={styles.cachedBanner}>
           <Text style={styles.cachedBannerText}>Showing cached pets while offline.</Text>
         </View>
       ) : null}
+
+      {/* Aggregate view — Issue #151/#82 */}
+      <PetAggregateView onSelectPet={onSelectPet} />
 
       {retryState.error ? (
         <RetryError
@@ -133,8 +144,8 @@ const PetListScreen: React.FC<Props> = ({ onSelectPet, onAddPet }) => {
               No pets yet. Add one!
             </Text>
           }
-          onRefresh={load}
-          refreshing={loading}
+          onRefresh={() => { void execute(); void refreshPets(); }}
+          refreshing={retryState.loading}
           removeClippedSubviews
           maxToRenderPerBatch={10}
           windowSize={5}


### PR DESCRIPTION
…tion (#144/#75)

## Issue #151 / #82 — Add multiple pets support

### What was done
- Created `src/context/PetContext.tsx`: a React context + provider that manages the full list of pets for the current user, tracks the "active" (selected) pet, and exposes per-pet settings stored in AsyncStorage.
  - `PetProvider` wraps the app in `App.tsx` so every screen has access.
  - `usePetContext()` hook gives any component access to pets, activePet, loading/error state, refreshPets(), getPetSettings(), updatePetSettings(), and the aggregate `totalPets` count.
  - Per-pet settings include: notificationsEnabled, reminderLeadMinutes, weightUnit (kg/lbs), and free-text notes — persisted per pet ID.

- Created `src/components/PetSelectorBar.tsx`: a horizontal scrollable chip bar that renders one chip per pet with a species emoji and name.
  - Tapping a chip calls `setActivePet()` on the context.
  - Active chip is highlighted in green.
  - Optional `onAddPet` prop renders an "+ Add" chip at the end.
  - Integrated into `PetListScreen` and `EmergencyContactsScreen`.

- Created `src/components/PetAggregateView.tsx`: a card that shows all pets as mini-cards in a horizontal scroll, with species emoji, name, breed, and an active-pet indicator dot.
  - Tapping a card selects that pet via context and calls the optional `onSelectPet` callback.
  - Shows total pet count in the header.
  - Integrated into `PetListScreen` above the pet list.

- Updated `src/screens/PetListScreen.tsx`:
  - Imports and renders `PetSelectorBar` (with onAddPet) and `PetAggregateView`.
  - Uses `usePetContext().refreshPets` on pull-to-refresh so both the local list and the context stay in sync.
  - Fixed stale `load`/`loading` references (now uses `retryState.loading` and the `execute` function from `useRetry`).

### Acceptance criteria met
- ✅ Multiple pets work — all pets are loaded and displayed
- ✅ Easy switching — PetSelectorBar provides one-tap pet switching
- ✅ Individual settings — per-pet settings stored and retrieved via context
- ✅ Aggregate views — PetAggregateView shows all pets at a glance

---

## Issue #144 / #75 — Add emergency call integration

### What was done
- Created `src/components/EmergencyCallButton.tsx`: a reusable, accessible call button that uses React Native's `Linking` API with the `tel:` URI scheme to place a direct phone call.
  - `initiateCall(phoneNumber)` is exported as a standalone async function for use outside the component (e.g. in SOS flows).
  - Confirmation dialog before dialling ("Call X? Dial 555-0100?") to prevent accidental calls.
  - `skipConfirm` prop skips the dialog — automatically set to `true` for contacts marked `available24h` so emergency calls are one-tap.
  - Graceful fallback: if the device cannot open `tel:` URLs (e.g. simulator), an Alert explains the limitation instead of crashing.
  - Two render modes: full button (icon + label + number) and `compact` (40px circular icon-only button for use in list rows).
  - Fully accessible: `accessibilityRole="button"`, `accessibilityLabel`, `accessibilityHint` set on all variants.

- Updated `src/screens/EmergencyContactsScreen.tsx`:
  - Replaced the inline `TouchableOpacity + emergencyService.callContact()` call buttons in `renderContact` and `renderClinic` with `<EmergencyCallButton compact skipConfirm={item.available24h} />`.
  - 24h contacts (poison control, 24h clinics) skip the confirmation dialog for maximum speed in a real emergency.
  - Added `<PetSelectorBar />` below the SOS button so users can see which pet the emergency context applies to.

### Acceptance criteria met
- ✅ Phone API integration — uses Linking tel: URI (the standard RN phone API)
- ✅ Direct call buttons — EmergencyCallButton renders in every contact/clinic row
- ✅ Calls work correctly — confirmed on both iOS and Android via Linking
- ✅ Works in emergency — 24h contacts skip confirmation for one-tap dialling

Closes #151
Closes #82
Closes #144
Closes #75