### PR TITLE
feat: integrate Sentry crash reporting

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 
@@ -6,8 +7,12 @@ import OfflineIndicator from './src/components/OfflineIndicator';
 import { useSplashGuard } from './src/components/SplashGuard';
 import AppNavigator from './src/navigation';
 import { PetProvider } from './src/context/PetContext';
+import crashReporting from './src/services/crashReporting';
 
-export default function App() {
+// Initialise Sentry before the first render
+crashReporting.init();
+
+function App() {
   const { appReady } = useSplashGuard();
 
   // Render nothing (splash is still visible) until critical init is done
@@ -26,3 +31,6 @@ export default function App() {
 const styles = StyleSheet.create({
   root: { flex: 1 },
 });
+
+// Wrap with Sentry to capture unhandled JS exceptions and ANRs
+export default Sentry.wrap(App);

--- a/app.config.js
+++ b/app.config.js
@@ -79,6 +79,9 @@ module.exports = {
         {
           organization: 'petchain',
           project: 'mobile-app',
+          // Upload source maps so stack traces are human-readable in the dashboard
+          uploadNativeSymbols: true,
+          uploadSourceMaps: true,
         },
       ],
     ],

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@react-navigation/bottom-tabs": "6.6.1",
     "@react-navigation/native": "6.1.18",
     "@react-navigation/native-stack": "6.11.0",
+    "@sentry/react-native": "^6.5.0",
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^15.0.1",
     "@types/jsonwebtoken": "^9.0.10",

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import errorLogger from '../services/errorLogger';
+import crashReporting from '../services/crashReporting';
 
 interface Props {
   children: React.ReactNode;
@@ -26,6 +27,10 @@ export class ErrorBoundary extends React.Component<Props, State> {
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     this.setState({ info });
     void errorLogger.logError(error, info.componentStack ?? '');
+    // Report to Sentry with component stack as extra context
+    crashReporting.captureException(error, {
+      componentStack: info.componentStack ?? '',
+    });
   }
 
   handleRetry = () => {

--- a/src/services/crashReporting.ts
+++ b/src/services/crashReporting.ts
@@ -1,0 +1,111 @@
+import * as Sentry from '@sentry/react-native';
+import Constants from 'expo-constants';
+
+declare const __DEV__: boolean;
+
+const extra = Constants.expoConfig?.extra ?? {};
+const SENTRY_DSN: string = extra.SENTRY_DSN ?? '';
+const SENTRY_ENABLE_IN_DEV: boolean = extra.SENTRY_ENABLE_IN_DEV === 'true';
+const APP_ENV: string = extra.APP_ENV ?? 'development';
+const APP_VERSION: string = Constants.expoConfig?.version ?? '1.0.0';
+
+export function initCrashReporting(): void {
+  if (!SENTRY_DSN) {
+    if (__DEV__) console.warn('[CrashReporting] SENTRY_DSN not set — skipping init');
+    return;
+  }
+
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment: APP_ENV,
+    release: `petchain-mobile@${APP_VERSION}`,
+    dist: APP_VERSION,
+    enabled: !__DEV__ || SENTRY_ENABLE_IN_DEV,
+    // Capture 100% of transactions in non-prod; tune down in production
+    tracesSampleRate: APP_ENV === 'production' ? 0.2 : 1.0,
+    // Attach JS stack traces to all captured events
+    attachStacktrace: true,
+    // Breadcrumbs help reconstruct what happened before a crash
+    maxBreadcrumbs: 50,
+    beforeSend(event) {
+      // Strip any PII from breadcrumb data before sending
+      if (event.breadcrumbs?.values) {
+        event.breadcrumbs.values = event.breadcrumbs.values.map((b) => ({
+          ...b,
+          data: b.data ? sanitize(b.data) : b.data,
+        }));
+      }
+      return event;
+    },
+  });
+}
+
+/** Capture an unhandled exception */
+export function captureException(error: unknown, context?: Record<string, unknown>): void {
+  if (!(error instanceof Error)) {
+    Sentry.captureMessage(String(error), 'error');
+    return;
+  }
+  if (context) {
+    Sentry.withScope((scope) => {
+      scope.setExtras(context);
+      Sentry.captureException(error);
+    });
+  } else {
+    Sentry.captureException(error);
+  }
+}
+
+/** Capture a non-fatal message */
+export function captureMessage(
+  message: string,
+  level: Sentry.SeverityLevel = 'info',
+  context?: Record<string, unknown>,
+): void {
+  if (context) {
+    Sentry.withScope((scope) => {
+      scope.setExtras(context);
+      Sentry.captureMessage(message, level);
+    });
+  } else {
+    Sentry.captureMessage(message, level);
+  }
+}
+
+/** Tag the current session with the authenticated user (call after login) */
+export function setUser(id: string, email?: string): void {
+  Sentry.setUser({ id, email });
+}
+
+/** Clear user on logout */
+export function clearUser(): void {
+  Sentry.setUser(null);
+}
+
+/** Add a breadcrumb for richer crash context */
+export function addBreadcrumb(
+  message: string,
+  category: string,
+  data?: Record<string, unknown>,
+): void {
+  Sentry.addBreadcrumb({ message, category, data, level: 'info' });
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const PII_KEYS = new Set(['email', 'password', 'token', 'phone', 'address', 'name']);
+
+function sanitize(data: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(data).map(([k, v]) => [k, PII_KEYS.has(k.toLowerCase()) ? '[redacted]' : v]),
+  );
+}
+
+export default {
+  init: initCrashReporting,
+  captureException,
+  captureMessage,
+  setUser,
+  clearUser,
+  addBreadcrumb,
+};

--- a/src/services/errorLogger.ts
+++ b/src/services/errorLogger.ts
@@ -1,4 +1,5 @@
 import apiClient, { resilientRequest } from './apiClient';
+import crashReporting from './crashReporting';
 
 async function sendToServer(payload: Record<string, unknown>) {
   try {
@@ -24,6 +25,10 @@ async function logError(err: unknown, meta: string | Record<string, unknown> = '
     // console log locally for developer visibility
     // eslint-disable-next-line no-console
     console.error('[ErrorLogger]', payload);
+    // Forward to Sentry for crash dashboard visibility
+    crashReporting.captureException(err instanceof Error ? err : new Error(String(err)), {
+      meta: typeof meta === 'string' ? { info: meta } : meta,
+    });
     await sendToServer(payload);
   } catch (e) {
     // final fallback — do nothing

--- a/src/utils/errorLogger.ts
+++ b/src/utils/errorLogger.ts
@@ -1,3 +1,5 @@
+import crashReporting from '../services/crashReporting';
+
 declare const __DEV__: boolean;
 
 type ErrorContext = {
@@ -45,7 +47,8 @@ export function logError(error: Error, context?: ErrorContext): void {
 }
 
 function sendToService(log: LoggedError, frequency: number): void {
-  void log;
-  void frequency;
-  // TODO: replace with real Sentry/Datadog call in production
+  crashReporting.captureException(
+    Object.assign(new Error(log.message), { stack: log.stack }),
+    { ...(log.context ?? {}), frequency },
+  );
 }


### PR DESCRIPTION
- Add src/services/crashReporting.ts — central Sentry wrapper with init, captureException, captureMessage, setUser, clearUser, addBreadcrumb
- Initialise Sentry in App.tsx before first render; wrap root component with Sentry.wrap() to catch unhandled JS exceptions and ANRs
- Wire ErrorBoundary.componentDidCatch into crashReporting.captureException with component stack as extra context
- Replace TODO stub in src/utils/errorLogger.ts with real Sentry call
- Forward errors in src/services/errorLogger.ts to Sentry alongside existing backend POST
- Add @sentry/react-native ^6.5.0 to package.json dependencies
- Enable source map + native symbol upload in app.config.js Sentry plugin
- Environment-aware: disabled in dev unless SENTRY_ENABLE_IN_DEV=true; tracesSampleRate 20% in production, 100% elsewhere
- PII sanitisation in beforeSend strips email/password/token fields

Closes #163 