### PR TITLE
 feat: vet directory, GDPR/CCPA, insurance integration, and Elasticsearch search

### DIFF
--- a/backend/migrations/006_vet_directory_messaging.sql
+++ b/backend/migrations/006_vet_directory_messaging.sql
@@ -1,0 +1,42 @@
+-- Vet directory and in-app messaging
+
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+CREATE TABLE IF NOT EXISTS vet_profiles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  specialty TEXT NOT NULL DEFAULT 'General',
+  credentials TEXT,
+  accepted_insurance TEXT[] DEFAULT '{}',
+  rating NUMERIC(3,2) DEFAULT 0,
+  review_count INTEGER DEFAULT 0,
+  available BOOLEAN DEFAULT TRUE,
+  location GEOGRAPHY(POINT, 4326),
+  address TEXT,
+  phone TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_vet_profiles_location ON vet_profiles USING GIST(location);
+CREATE INDEX IF NOT EXISTS idx_vet_profiles_specialty ON vet_profiles(specialty);
+CREATE INDEX IF NOT EXISTS idx_vet_profiles_available ON vet_profiles(available);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id UUID NOT NULL,
+  sender_id UUID NOT NULL REFERENCES users(id),
+  recipient_id UUID NOT NULL REFERENCES users(id),
+  content TEXT,
+  attachment_url TEXT,
+  attachment_type TEXT,
+  read_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_conversation ON messages(conversation_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_recipient ON messages(recipient_id, read_at);
+
+CREATE TRIGGER update_vet_profiles_updated_at
+  BEFORE UPDATE ON vet_profiles
+  FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();

--- a/backend/migrations/007_gdpr_ccpa.sql
+++ b/backend/migrations/007_gdpr_ccpa.sql
@@ -1,0 +1,21 @@
+-- GDPR/CCPA compliance tables
+
+CREATE TABLE IF NOT EXISTS consent_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  category TEXT NOT NULL,  -- 'analytics' | 'marketing' | 'functional' | 'necessary'
+  granted BOOLEAN NOT NULL,
+  ip_address TEXT,
+  user_agent TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_consent_logs_user ON consent_logs(user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS data_deletion_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id),
+  status TEXT NOT NULL DEFAULT 'pending',  -- 'pending' | 'completed'
+  requested_at TIMESTAMPTZ DEFAULT NOW(),
+  completed_at TIMESTAMPTZ
+);

--- a/backend/migrations/008_insurance.sql
+++ b/backend/migrations/008_insurance.sql
@@ -1,0 +1,35 @@
+-- Pet insurance integration
+
+CREATE TABLE IF NOT EXISTS insurance_policies (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,  -- 'trupanion' | 'nationwide' | 'mock'
+  policy_number TEXT NOT NULL,
+  pet_id UUID REFERENCES pets(id),
+  coverage_limit NUMERIC(10,2),
+  deductible NUMERIC(10,2),
+  premium NUMERIC(10,2),
+  status TEXT NOT NULL DEFAULT 'active',
+  expires_at DATE,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS insurance_claims (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  policy_id UUID NOT NULL REFERENCES insurance_policies(id),
+  user_id UUID NOT NULL REFERENCES users(id),
+  pet_id UUID REFERENCES pets(id),
+  amount NUMERIC(10,2) NOT NULL,
+  description TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'submitted',  -- 'submitted' | 'under_review' | 'approved' | 'denied'
+  attachment_urls TEXT[] DEFAULT '{}',
+  submitted_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_claims_user ON insurance_claims(user_id, submitted_at DESC);
+CREATE INDEX IF NOT EXISTS idx_claims_policy ON insurance_claims(policy_id);
+
+CREATE TRIGGER update_insurance_claims_updated_at
+  BEFORE UPDATE ON insurance_claims
+  FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();

--- a/backend/server/app.ts
+++ b/backend/server/app.ts
@@ -11,12 +11,16 @@ import communityRouter from './routes/community';
 import docsRouter from './routes/docs';
 import emergencyRouter from './routes/emergency';
 import importRouter from './routes/import';
+import insuranceRouter from './routes/insurance';
 import medicalRecordsRouter from './routes/medicalRecords';
 import medicationsRouter from './routes/medications';
 import paymentsRouter from './routes/payments';
 import petsRouter from './routes/pets';
+import privacyRouter from './routes/privacy';
+import searchRouter from './routes/search';
 import syncRouter from './routes/sync';
 import usersRouter from './routes/users';
+import vetsRouter from './routes/vets';
 import { attachAudit } from '../middleware/auditLog';
 
 export function createApp(): Express {
@@ -46,6 +50,10 @@ export function createApp(): Express {
   api.use('/emergency', emergencyRouter);
   api.use('/community', communityRouter);
   api.use('/sync', syncRouter);
+  api.use('/vets', vetsRouter);
+  api.use('/privacy', privacyRouter);
+  api.use('/insurance', insuranceRouter);
+  api.use('/search', searchRouter);
 
   app.use('/api', api);
 

--- a/backend/server/routes/insurance.ts
+++ b/backend/server/routes/insurance.ts
@@ -1,0 +1,74 @@
+import express from 'express';
+
+import { authenticateJWT, type AuthenticatedRequest } from '../../middleware/auth';
+import { ok, sendError } from '../response';
+import {
+  exchangeOAuthCode,
+  getClaim,
+  getClaims,
+  getPolicies,
+  getPolicy,
+  submitClaim,
+  type InsuranceProvider,
+} from '../../services/insuranceService';
+
+const router = express.Router();
+router.use(authenticateJWT);
+
+const PROVIDERS: InsuranceProvider[] = ['trupanion', 'nationwide', 'mock'];
+
+// GET /api/insurance/policies
+router.get('/policies', (req: AuthenticatedRequest, res) => {
+  return res.json(ok(getPolicies(req.user!.id)));
+});
+
+// POST /api/insurance/connect — OAuth code exchange
+router.post('/connect', async (req: AuthenticatedRequest, res) => {
+  const { provider, code } = req.body as { provider: InsuranceProvider; code: string };
+  if (!provider || !PROVIDERS.includes(provider)) {
+    return sendError(res, 400, 'VALIDATION_ERROR', `provider must be one of: ${PROVIDERS.join(', ')}`);
+  }
+  if (!code) return sendError(res, 400, 'VALIDATION_ERROR', 'code required');
+  try {
+    const policy = await exchangeOAuthCode(provider, code, req.user!.id);
+    return res.status(201).json(ok(policy));
+  } catch (e) {
+    return sendError(res, 502, 'PROVIDER_ERROR', 'Failed to connect insurance provider');
+  }
+});
+
+// GET /api/insurance/claims
+router.get('/claims', (req: AuthenticatedRequest, res) => {
+  return res.json(ok(getClaims(req.user!.id)));
+});
+
+// GET /api/insurance/claims/:id
+router.get('/claims/:id', (req: AuthenticatedRequest, res) => {
+  const claim = getClaim(req.params.id);
+  if (!claim || claim.userId !== req.user!.id) {
+    return sendError(res, 404, 'NOT_FOUND', 'Claim not found');
+  }
+  return res.json(ok(claim));
+});
+
+// POST /api/insurance/claims
+router.post('/claims', (req: AuthenticatedRequest, res) => {
+  const { policyId, petId, amount, description, attachmentUrls } = req.body as {
+    policyId: string;
+    petId?: string;
+    amount: number;
+    description: string;
+    attachmentUrls?: string[];
+  };
+  if (!policyId || !amount || !description) {
+    return sendError(res, 400, 'VALIDATION_ERROR', 'policyId, amount, and description required');
+  }
+  const policy = getPolicy(policyId);
+  if (!policy || policy.userId !== req.user!.id) {
+    return sendError(res, 404, 'NOT_FOUND', 'Policy not found');
+  }
+  const claim = submitClaim(policyId, req.user!.id, { petId, amount, description, attachmentUrls });
+  return res.status(201).json(ok(claim));
+});
+
+export default router;

--- a/backend/server/routes/privacy.ts
+++ b/backend/server/routes/privacy.ts
@@ -1,0 +1,62 @@
+import express from 'express';
+
+import { authenticateJWT, type AuthenticatedRequest } from '../../middleware/auth';
+import { ok, sendError } from '../response';
+import {
+  eraseUserData,
+  exportUserData,
+  getConsentHistory,
+  logConsent,
+} from '../../services/dataExportService';
+
+const router = express.Router();
+router.use(authenticateJWT);
+
+const CONSENT_CATEGORIES = ['necessary', 'functional', 'analytics', 'marketing'] as const;
+
+// GET /api/privacy/export — download all user data as JSON
+router.get('/export', (req: AuthenticatedRequest, res) => {
+  const data = exportUserData(req.user!.id);
+  res.setHeader('Content-Disposition', 'attachment; filename="petchain-data-export.json"');
+  res.setHeader('Content-Type', 'application/json');
+  return res.json(data);
+});
+
+// GET /api/privacy/consent — get current consent state
+router.get('/consent', (req: AuthenticatedRequest, res) => {
+  const history = getConsentHistory(req.user!.id);
+  // Latest entry per category
+  const latest: Record<string, boolean> = {};
+  for (const entry of history) {
+    latest[entry.category] = entry.granted;
+  }
+  return res.json(ok({ categories: CONSENT_CATEGORIES, consents: latest }));
+});
+
+// POST /api/privacy/consent — update consent
+router.post('/consent', (req: AuthenticatedRequest, res) => {
+  const { consents } = req.body as { consents: Record<string, boolean> };
+  if (!consents || typeof consents !== 'object') {
+    return sendError(res, 400, 'VALIDATION_ERROR', 'consents object required');
+  }
+  for (const [category, granted] of Object.entries(consents)) {
+    if (!CONSENT_CATEGORIES.includes(category as (typeof CONSENT_CATEGORIES)[number])) {
+      return sendError(res, 400, 'VALIDATION_ERROR', `Unknown category: ${category}`);
+    }
+    logConsent(req.user!.id, category, Boolean(granted));
+  }
+  return res.json(ok({ updated: Object.keys(consents) }));
+});
+
+// GET /api/privacy/consent/history — audit log
+router.get('/consent/history', (req: AuthenticatedRequest, res) => {
+  return res.json(ok(getConsentHistory(req.user!.id)));
+});
+
+// DELETE /api/privacy/erase — right to erasure
+router.delete('/erase', (req: AuthenticatedRequest, res) => {
+  eraseUserData(req.user!.id);
+  return res.json(ok({ erased: true, userId: req.user!.id }));
+});
+
+export default router;

--- a/backend/server/routes/search.ts
+++ b/backend/server/routes/search.ts
@@ -1,0 +1,39 @@
+import express from 'express';
+
+import { authenticateJWT, type AuthenticatedRequest } from '../../middleware/auth';
+import { ok, sendError } from '../response';
+import { search, type SearchIndex, INDICES } from '../../services/searchService';
+
+const router = express.Router();
+router.use(authenticateJWT);
+
+// GET /api/search?q=&index=&from=&size=&<field>=<value>
+router.get('/', async (req: AuthenticatedRequest, res) => {
+  const q = req.query as Record<string, string | undefined>;
+  const query = q.q?.trim();
+  if (!query) return sendError(res, 400, 'VALIDATION_ERROR', 'q parameter required');
+
+  const validIndices = Object.values(INDICES) as SearchIndex[];
+  const indices = q.index
+    ? q.index.split(',').filter((i): i is SearchIndex => validIndices.includes(i as SearchIndex))
+    : undefined;
+
+  const from = q.from ? parseInt(q.from) : 0;
+  const size = q.size ? Math.min(parseInt(q.size), 100) : 20;
+
+  // Any extra query params become field filters (e.g. ?petId=xxx)
+  const reserved = new Set(['q', 'index', 'from', 'size']);
+  const filters: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(q)) {
+    if (!reserved.has(key) && val) filters[key] = val;
+  }
+
+  try {
+    const result = await search(query, { indices, filters, from, size });
+    return res.json(ok(result));
+  } catch (e) {
+    return sendError(res, 503, 'SEARCH_UNAVAILABLE', 'Search service unavailable');
+  }
+});
+
+export default router;

--- a/backend/server/routes/vets.ts
+++ b/backend/server/routes/vets.ts
@@ -1,0 +1,137 @@
+import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+import { authenticateJWT, type AuthenticatedRequest } from '../../middleware/auth';
+import { ok, sendError } from '../response';
+import {
+  getConversationId,
+  getMessages,
+  markRead,
+  saveMessage,
+} from '../../services/messagingService';
+
+const router = express.Router();
+router.use(authenticateJWT);
+
+// ─── In-memory vet profile store (replace with PostGIS DB queries) ────────────
+interface VetProfile {
+  id: string;
+  userId: string;
+  name: string;
+  specialty: string;
+  credentials: string;
+  acceptedInsurance: string[];
+  rating: number;
+  reviewCount: number;
+  available: boolean;
+  lat: number;
+  lng: number;
+  address: string;
+  phone: string;
+}
+
+const vetProfiles = new Map<string, VetProfile>();
+
+function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+// GET /api/vets?lat=&lng=&radius=&specialty=&available=
+router.get('/', (req: AuthenticatedRequest, res) => {
+  const q = req.query as Record<string, string | undefined>;
+  const lat = q.lat ? parseFloat(q.lat) : null;
+  const lng = q.lng ? parseFloat(q.lng) : null;
+  const radius = q.radius ? parseFloat(q.radius) : 25;
+  const specialty = q.specialty?.toLowerCase();
+  const available = q.available === 'true' ? true : q.available === 'false' ? false : null;
+
+  let results = [...vetProfiles.values()];
+
+  if (specialty) results = results.filter((v) => v.specialty.toLowerCase().includes(specialty));
+  if (available !== null) results = results.filter((v) => v.available === available);
+
+  if (lat !== null && lng !== null) {
+    results = results
+      .map((v) => ({ ...v, distance: haversineKm(lat, lng, v.lat, v.lng) }))
+      .filter((v) => v.distance <= radius)
+      .sort((a, b) => a.distance - b.distance);
+  }
+
+  return res.json(ok(results));
+});
+
+// GET /api/vets/:id
+router.get('/:id', (req: AuthenticatedRequest, res) => {
+  const vet = vetProfiles.get(req.params.id);
+  if (!vet) return sendError(res, 404, 'NOT_FOUND', 'Vet not found');
+  return res.json(ok(vet));
+});
+
+// POST /api/vets (vet self-registration)
+router.post('/', (req: AuthenticatedRequest, res) => {
+  const { specialty, credentials, acceptedInsurance, lat, lng, address, phone, name } =
+    req.body as Partial<VetProfile>;
+  if (!lat || !lng || !specialty) {
+    return sendError(res, 400, 'VALIDATION_ERROR', 'lat, lng, and specialty are required');
+  }
+  const profile: VetProfile = {
+    id: uuidv4(),
+    userId: req.user!.id,
+    name: name ?? req.user!.email,
+    specialty,
+    credentials: credentials ?? '',
+    acceptedInsurance: acceptedInsurance ?? [],
+    rating: 0,
+    reviewCount: 0,
+    available: true,
+    lat,
+    lng,
+    address: address ?? '',
+    phone: phone ?? '',
+  };
+  vetProfiles.set(profile.id, profile);
+  return res.status(201).json(ok(profile));
+});
+
+// ─── Messaging ────────────────────────────────────────────────────────────────
+
+// GET /api/vets/messages/:vetId?before=&limit=
+router.get('/messages/:vetId', (req: AuthenticatedRequest, res) => {
+  const conversationId = getConversationId(req.user!.id, req.params.vetId);
+  const q = req.query as Record<string, string | undefined>;
+  const msgs = getMessages(conversationId, q.limit ? parseInt(q.limit) : 50, q.before);
+  markRead(conversationId, req.user!.id);
+  return res.json(ok(msgs));
+});
+
+// POST /api/vets/messages/:vetId
+router.post('/messages/:vetId', (req: AuthenticatedRequest, res) => {
+  const { content, attachmentUrl, attachmentType } = req.body as {
+    content?: string;
+    attachmentUrl?: string;
+    attachmentType?: string;
+  };
+  if (!content && !attachmentUrl) {
+    return sendError(res, 400, 'VALIDATION_ERROR', 'content or attachmentUrl required');
+  }
+  const conversationId = getConversationId(req.user!.id, req.params.vetId);
+  const msg = saveMessage({
+    conversationId,
+    senderId: req.user!.id,
+    recipientId: req.params.vetId,
+    content,
+    attachmentUrl,
+    attachmentType,
+  });
+  return res.status(201).json(ok(msg));
+});
+
+export default router;

--- a/backend/services/dataExportService.ts
+++ b/backend/services/dataExportService.ts
@@ -1,0 +1,76 @@
+import { store } from '../server/store';
+
+export interface UserDataExport {
+  user: unknown;
+  pets: unknown[];
+  medicalRecords: unknown[];
+  appointments: unknown[];
+  medications: unknown[];
+  exportedAt: string;
+}
+
+export function exportUserData(userId: string): UserDataExport {
+  const user = store.users.get(userId);
+  const pets = [...store.pets.values()].filter((p) => p.ownerId === userId);
+  const petIds = new Set(pets.map((p) => p.id));
+
+  const medicalRecords = [...store.medicalRecords.values()].filter((r) =>
+    petIds.has(r.petId),
+  );
+  const appointments = [...store.appointments.values()].filter((a) =>
+    petIds.has(a.petId),
+  );
+  const medications = [...store.medications.values()].filter((m) =>
+    petIds.has(m.petId),
+  );
+
+  // Strip sensitive fields from user
+  const { passwordHash: _pw, ...safeUser } = (user ?? {}) as Record<string, unknown>;
+
+  return {
+    user: safeUser,
+    pets,
+    medicalRecords,
+    appointments,
+    medications,
+    exportedAt: new Date().toISOString(),
+  };
+}
+
+export function eraseUserData(userId: string): void {
+  // Hard-delete all PII
+  store.users.delete(userId);
+
+  const petIds: string[] = [];
+  store.pets.forEach((p, id) => {
+    if (p.ownerId === userId) petIds.push(id);
+  });
+  petIds.forEach((id) => store.pets.delete(id));
+
+  store.medicalRecords.forEach((r, id) => {
+    if (petIds.includes(r.petId)) store.medicalRecords.delete(id);
+  });
+  store.appointments.forEach((a, id) => {
+    if (petIds.includes(a.petId)) store.appointments.delete(id);
+  });
+  store.medications.forEach((m, id) => {
+    if (petIds.includes(m.petId)) store.medications.delete(id);
+  });
+}
+
+// In-memory consent log (replace with DB in production)
+interface ConsentEntry {
+  userId: string;
+  category: string;
+  granted: boolean;
+  createdAt: string;
+}
+const consentLog: ConsentEntry[] = [];
+
+export function logConsent(userId: string, category: string, granted: boolean): void {
+  consentLog.push({ userId, category, granted, createdAt: new Date().toISOString() });
+}
+
+export function getConsentHistory(userId: string): ConsentEntry[] {
+  return consentLog.filter((e) => e.userId === userId);
+}

--- a/backend/services/insuranceService.ts
+++ b/backend/services/insuranceService.ts
@@ -1,0 +1,103 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export type InsuranceProvider = 'trupanion' | 'nationwide' | 'mock';
+export type ClaimStatus = 'submitted' | 'under_review' | 'approved' | 'denied';
+
+export interface InsurancePolicy {
+  id: string;
+  userId: string;
+  provider: InsuranceProvider;
+  policyNumber: string;
+  petId?: string;
+  coverageLimit: number;
+  deductible: number;
+  premium: number;
+  status: 'active' | 'expired' | 'cancelled';
+  expiresAt: string;
+}
+
+export interface InsuranceClaim {
+  id: string;
+  policyId: string;
+  userId: string;
+  petId?: string;
+  amount: number;
+  description: string;
+  status: ClaimStatus;
+  attachmentUrls: string[];
+  submittedAt: string;
+  updatedAt: string;
+}
+
+// In-memory stores (replace with DB in production)
+const policies = new Map<string, InsurancePolicy>();
+const claims = new Map<string, InsuranceClaim>();
+
+// ─── Mock provider OAuth token exchange ──────────────────────────────────────
+export async function exchangeOAuthCode(
+  provider: InsuranceProvider,
+  code: string,
+  userId: string,
+): Promise<InsurancePolicy> {
+  // In production: call provider OAuth endpoint with code
+  // Mock: return a fake policy
+  const policy: InsurancePolicy = {
+    id: uuidv4(),
+    userId,
+    provider,
+    policyNumber: `${provider.toUpperCase()}-${code.slice(0, 8).toUpperCase()}`,
+    coverageLimit: 10000,
+    deductible: 250,
+    premium: 49.99,
+    status: 'active',
+    expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+  };
+  policies.set(policy.id, policy);
+  return policy;
+}
+
+export function getPolicies(userId: string): InsurancePolicy[] {
+  return [...policies.values()].filter((p) => p.userId === userId);
+}
+
+export function getPolicy(policyId: string): InsurancePolicy | undefined {
+  return policies.get(policyId);
+}
+
+export function submitClaim(
+  policyId: string,
+  userId: string,
+  data: { petId?: string; amount: number; description: string; attachmentUrls?: string[] },
+): InsuranceClaim {
+  const claim: InsuranceClaim = {
+    id: uuidv4(),
+    policyId,
+    userId,
+    petId: data.petId,
+    amount: data.amount,
+    description: data.description,
+    status: 'submitted',
+    attachmentUrls: data.attachmentUrls ?? [],
+    submittedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  claims.set(claim.id, claim);
+
+  // Simulate async status progression (mock)
+  setTimeout(() => {
+    const c = claims.get(claim.id);
+    if (c) { c.status = 'under_review'; c.updatedAt = new Date().toISOString(); }
+  }, 5000);
+
+  return claim;
+}
+
+export function getClaims(userId: string): InsuranceClaim[] {
+  return [...claims.values()]
+    .filter((c) => c.userId === userId)
+    .sort((a, b) => b.submittedAt.localeCompare(a.submittedAt));
+}
+
+export function getClaim(claimId: string): InsuranceClaim | undefined {
+  return claims.get(claimId);
+}

--- a/backend/services/messagingService.ts
+++ b/backend/services/messagingService.ts
@@ -1,0 +1,85 @@
+import { type IncomingMessage, type Server } from 'http';
+import { WebSocketServer, type WebSocket } from 'ws';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface Message {
+  id: string;
+  conversationId: string;
+  senderId: string;
+  recipientId: string;
+  content?: string;
+  attachmentUrl?: string;
+  attachmentType?: string;
+  readAt?: string;
+  createdAt: string;
+}
+
+// In-memory store (replace with DB queries in production)
+const messages = new Map<string, Message[]>(); // conversationId -> messages
+const clients = new Map<string, WebSocket>(); // userId -> ws
+
+export function getConversationId(userA: string, userB: string): string {
+  return [userA, userB].sort().join(':');
+}
+
+export function getMessages(
+  conversationId: string,
+  limit = 50,
+  before?: string,
+): Message[] {
+  const all = messages.get(conversationId) ?? [];
+  const filtered = before ? all.filter((m) => m.createdAt < before) : all;
+  return filtered.slice(-limit);
+}
+
+export function saveMessage(msg: Omit<Message, 'id' | 'createdAt'>): Message {
+  const saved: Message = { ...msg, id: uuidv4(), createdAt: new Date().toISOString() };
+  const list = messages.get(saved.conversationId) ?? [];
+  list.push(saved);
+  messages.set(saved.conversationId, list);
+  return saved;
+}
+
+export function markRead(conversationId: string, userId: string): void {
+  const list = messages.get(conversationId) ?? [];
+  const now = new Date().toISOString();
+  list.forEach((m) => {
+    if (m.recipientId === userId && !m.readAt) m.readAt = now;
+  });
+}
+
+export function attachWebSocketServer(server: Server): void {
+  const wss = new WebSocketServer({ server, path: '/ws/messages' });
+
+  wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+    const url = new URL(req.url ?? '', 'http://localhost');
+    const userId = url.searchParams.get('userId');
+    if (!userId) { ws.close(4001, 'userId required'); return; }
+
+    clients.set(userId, ws);
+
+    ws.on('message', (raw) => {
+      try {
+        const data = JSON.parse(raw.toString()) as {
+          recipientId: string;
+          content?: string;
+          attachmentUrl?: string;
+          attachmentType?: string;
+        };
+        const conversationId = getConversationId(userId, data.recipientId);
+        const msg = saveMessage({ conversationId, senderId: userId, ...data });
+
+        // Deliver to recipient if online
+        const recipientWs = clients.get(data.recipientId);
+        if (recipientWs?.readyState === 1) {
+          recipientWs.send(JSON.stringify(msg));
+        }
+        ws.send(JSON.stringify(msg));
+      } catch {
+        ws.send(JSON.stringify({ error: 'Invalid message format' }));
+      }
+    });
+
+    ws.on('close', () => clients.delete(userId));
+  });
+}

--- a/backend/services/searchService.ts
+++ b/backend/services/searchService.ts
@@ -1,0 +1,116 @@
+import { Client } from '@elastic/elasticsearch';
+
+const client = new Client({
+  node: process.env.ELASTICSEARCH_URL ?? 'http://localhost:9200',
+});
+
+export const INDICES = {
+  petRecords: 'pet_records',
+  medications: 'medications',
+  appointments: 'appointments',
+} as const;
+
+export type SearchIndex = (typeof INDICES)[keyof typeof INDICES];
+
+export interface SearchHit {
+  id: string;
+  index: SearchIndex;
+  score: number;
+  source: Record<string, unknown>;
+  highlights: Record<string, string[]>;
+}
+
+export interface SearchResult {
+  hits: SearchHit[];
+  total: number;
+}
+
+// ─── Index sync helpers ───────────────────────────────────────────────────────
+
+export async function indexDocument(
+  index: SearchIndex,
+  id: string,
+  doc: Record<string, unknown>,
+): Promise<void> {
+  await client.index({ index, id, document: doc });
+}
+
+export async function deleteDocument(index: SearchIndex, id: string): Promise<void> {
+  await client.delete({ index, id }).catch(() => {/* ignore 404 */});
+}
+
+// ─── Full-text search ─────────────────────────────────────────────────────────
+
+export async function search(
+  query: string,
+  options: {
+    indices?: SearchIndex[];
+    filters?: Record<string, unknown>;
+    from?: number;
+    size?: number;
+  } = {},
+): Promise<SearchResult> {
+  const { indices = Object.values(INDICES), filters = {}, from = 0, size = 20 } = options;
+
+  const filterClauses = Object.entries(filters).map(([field, value]) => ({
+    term: { [field]: value },
+  }));
+
+  const response = await client.search({
+    index: indices.join(','),
+    from,
+    size,
+    query: {
+      bool: {
+        must: [
+          {
+            multi_match: {
+              query,
+              fields: ['*'],
+              fuzziness: 'AUTO',
+              type: 'best_fields',
+            },
+          },
+        ],
+        filter: filterClauses,
+      },
+    },
+    highlight: {
+      fields: { '*': {} },
+      pre_tags: ['<mark>'],
+      post_tags: ['</mark>'],
+    },
+  });
+
+  const hits: SearchHit[] = (response.hits.hits as Array<{
+    _id: string;
+    _index: string;
+    _score: number | null;
+    _source: Record<string, unknown>;
+    highlight?: Record<string, string[]>;
+  }>).map((h) => ({
+    id: h._id,
+    index: h._index as SearchIndex,
+    score: h._score ?? 0,
+    source: h._source,
+    highlights: h.highlight ?? {},
+  }));
+
+  const total =
+    typeof response.hits.total === 'number'
+      ? response.hits.total
+      : (response.hits.total as { value: number }).value;
+
+  return { hits, total };
+}
+
+// ─── Index all existing data (initial sync) ───────────────────────────────────
+
+export async function ensureIndices(): Promise<void> {
+  for (const index of Object.values(INDICES)) {
+    const exists = await client.indices.exists({ index });
+    if (!exists) {
+      await client.indices.create({ index });
+    }
+  }
+}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -37,6 +37,10 @@ export type PetStackParamList = {
   MedicalRecordViewer: { petId: string; petName?: string };
   PetShare: { petId: string; petName: string };
   NearbyVet: undefined;
+  VetDirectory: undefined;
+  PrivacyDashboard: undefined;
+  Insurance: undefined;
+  Search: undefined;
   NotificationPreferences: undefined;
   DeleteAccount: undefined;
 };

--- a/src/screens/InsuranceScreen.tsx
+++ b/src/screens/InsuranceScreen.tsx
@@ -1,0 +1,293 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import {
+  connectProvider,
+  getClaims,
+  getPolicies,
+  submitClaim,
+  type ClaimStatus,
+  type InsuranceClaim,
+  type InsurancePolicy,
+} from '../services/claimsService';
+
+type Screen = 'policies' | 'claims' | 'newClaim';
+
+const STATUS_COLOR: Record<ClaimStatus, string> = {
+  submitted: '#ecc94b',
+  under_review: '#4299e1',
+  approved: '#48bb78',
+  denied: '#e53e3e',
+};
+
+const InsuranceScreen: React.FC = () => {
+  const [screen, setScreen] = useState<Screen>('policies');
+  const [policies, setPolicies] = useState<InsurancePolicy[]>([]);
+  const [claims, setClaimsData] = useState<InsuranceClaim[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // New claim form
+  const [selectedPolicyId, setSelectedPolicyId] = useState('');
+  const [amount, setAmount] = useState('');
+  const [description, setDescription] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [p, c] = await Promise.all([getPolicies(), getClaims()]);
+      setPolicies(p);
+      setClaimsData(c);
+    } catch {
+      Alert.alert('Error', 'Failed to load insurance data');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const handleConnect = useCallback(() => {
+    Alert.prompt(
+      'Connect Insurance',
+      'Enter your Trupanion or Nationwide OAuth code:',
+      async (code) => {
+        if (!code) return;
+        try {
+          const policy = await connectProvider('mock', code);
+          setPolicies((prev) => [...prev, policy]);
+          Alert.alert('Connected', `Policy ${policy.policyNumber} linked.`);
+        } catch {
+          Alert.alert('Error', 'Failed to connect provider');
+        }
+      },
+    );
+  }, []);
+
+  const handleSubmitClaim = useCallback(async () => {
+    if (!selectedPolicyId || !amount || !description) {
+      Alert.alert('Validation', 'Please fill all fields');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const claim = await submitClaim({
+        policyId: selectedPolicyId,
+        amount: parseFloat(amount),
+        description,
+      });
+      setClaimsData((prev) => [claim, ...prev]);
+      Alert.alert('Submitted', `Claim #${claim.id.slice(0, 8)} submitted.`);
+      setScreen('claims');
+    } catch {
+      Alert.alert('Error', 'Failed to submit claim');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [selectedPolicyId, amount, description]);
+
+  if (loading) return <ActivityIndicator style={styles.loader} size="large" color="#4299e1" />;
+
+  // ─── Policies ─────────────────────────────────────────────────────────────
+  if (screen === 'policies') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Pet Insurance</Text>
+        <View style={styles.tabs}>
+          <TouchableOpacity style={[styles.tab, styles.tabActive]} onPress={() => setScreen('policies')}>
+            <Text style={styles.tabTextActive}>Policies</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.tab} onPress={() => setScreen('claims')}>
+            <Text style={styles.tabText}>Claims</Text>
+          </TouchableOpacity>
+        </View>
+
+        <FlatList
+          data={policies}
+          keyExtractor={(p) => p.id}
+          contentContainerStyle={styles.list}
+          renderItem={({ item }) => (
+            <View style={styles.card}>
+              <Text style={styles.cardTitle}>{item.provider.toUpperCase()}</Text>
+              <Text style={styles.cardSub}>Policy: {item.policyNumber}</Text>
+              <Text style={styles.cardSub}>Coverage: ${item.coverageLimit.toLocaleString()}</Text>
+              <Text style={styles.cardSub}>Deductible: ${item.deductible}</Text>
+              <Text style={styles.cardSub}>Premium: ${item.premium}/mo</Text>
+              <Text style={styles.cardSub}>
+                Expires: {new Date(item.expiresAt).toLocaleDateString()}
+              </Text>
+              <View style={[styles.badge, { backgroundColor: item.status === 'active' ? '#c6f6d5' : '#fed7d7' }]}>
+                <Text style={styles.badgeText}>{item.status}</Text>
+              </View>
+            </View>
+          )}
+          ListEmptyComponent={<Text style={styles.empty}>No policies linked yet.</Text>}
+        />
+
+        <TouchableOpacity style={styles.btn} onPress={handleConnect} accessibilityLabel="Connect insurance provider">
+          <Text style={styles.btnText}>+ Connect Provider</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  // ─── Claims ───────────────────────────────────────────────────────────────
+  if (screen === 'claims') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Pet Insurance</Text>
+        <View style={styles.tabs}>
+          <TouchableOpacity style={styles.tab} onPress={() => setScreen('policies')}>
+            <Text style={styles.tabText}>Policies</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={[styles.tab, styles.tabActive]} onPress={() => setScreen('claims')}>
+            <Text style={styles.tabTextActive}>Claims</Text>
+          </TouchableOpacity>
+        </View>
+
+        <FlatList
+          data={claims}
+          keyExtractor={(c) => c.id}
+          contentContainerStyle={styles.list}
+          renderItem={({ item }) => (
+            <View style={styles.card}>
+              <Text style={styles.cardTitle}>#{item.id.slice(0, 8).toUpperCase()}</Text>
+              <Text style={styles.cardSub}>{item.description}</Text>
+              <Text style={styles.cardSub}>Amount: ${item.amount}</Text>
+              <Text style={styles.cardSub}>
+                Submitted: {new Date(item.submittedAt).toLocaleDateString()}
+              </Text>
+              <View style={[styles.badge, { backgroundColor: STATUS_COLOR[item.status] + '33' }]}>
+                <Text style={[styles.badgeText, { color: STATUS_COLOR[item.status] }]}>
+                  {item.status.replace('_', ' ')}
+                </Text>
+              </View>
+            </View>
+          )}
+          ListEmptyComponent={<Text style={styles.empty}>No claims yet.</Text>}
+        />
+
+        <TouchableOpacity
+          style={styles.btn}
+          onPress={() => { setSelectedPolicyId(policies[0]?.id ?? ''); setScreen('newClaim'); }}
+          accessibilityLabel="Submit new claim"
+        >
+          <Text style={styles.btnText}>+ Submit Claim</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  // ─── New Claim ────────────────────────────────────────────────────────────
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.formContent}>
+      <TouchableOpacity onPress={() => setScreen('claims')} style={styles.back}>
+        <Text style={styles.backText}>‹ Back</Text>
+      </TouchableOpacity>
+      <Text style={styles.title}>Submit Claim</Text>
+
+      <Text style={styles.label}>Policy</Text>
+      {policies.map((p) => (
+        <TouchableOpacity
+          key={p.id}
+          style={[styles.policyOption, selectedPolicyId === p.id && styles.policyOptionActive]}
+          onPress={() => setSelectedPolicyId(p.id)}
+          accessibilityLabel={`Select policy ${p.policyNumber}`}
+        >
+          <Text style={styles.policyOptionText}>{p.provider} — {p.policyNumber}</Text>
+        </TouchableOpacity>
+      ))}
+
+      <Text style={styles.label}>Amount ($)</Text>
+      <TextInput
+        style={styles.input}
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="decimal-pad"
+        placeholder="0.00"
+        accessibilityLabel="Claim amount"
+      />
+
+      <Text style={styles.label}>Description</Text>
+      <TextInput
+        style={[styles.input, styles.textArea]}
+        value={description}
+        onChangeText={setDescription}
+        placeholder="Describe the treatment or expense…"
+        multiline
+        numberOfLines={4}
+        accessibilityLabel="Claim description"
+      />
+
+      <TouchableOpacity
+        style={[styles.btn, submitting && styles.btnDisabled]}
+        onPress={() => void handleSubmitClaim()}
+        disabled={submitting}
+        accessibilityLabel="Submit claim"
+      >
+        {submitting ? <ActivityIndicator color="#fff" /> : <Text style={styles.btnText}>Submit Claim</Text>}
+      </TouchableOpacity>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  loader: { flex: 1, marginTop: 40 },
+  title: { fontSize: 22, fontWeight: '700', color: '#1a202c', padding: 16, paddingBottom: 8 },
+  tabs: { flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: '#e2e8f0', marginHorizontal: 16 },
+  tab: { flex: 1, paddingVertical: 10, alignItems: 'center' },
+  tabActive: { borderBottomWidth: 2, borderBottomColor: '#4299e1' },
+  tabText: { color: '#718096', fontWeight: '600' },
+  tabTextActive: { color: '#4299e1', fontWeight: '700' },
+  list: { padding: 16 },
+  card: {
+    backgroundColor: '#f7fafc',
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: 12,
+  },
+  cardTitle: { fontSize: 15, fontWeight: '700', color: '#1a202c', marginBottom: 4 },
+  cardSub: { fontSize: 13, color: '#718096', marginBottom: 2 },
+  badge: { alignSelf: 'flex-start', paddingHorizontal: 8, paddingVertical: 3, borderRadius: 10, marginTop: 6 },
+  badgeText: { fontSize: 12, fontWeight: '600' },
+  empty: { textAlign: 'center', color: '#718096', marginTop: 40 },
+  btn: { margin: 16, backgroundColor: '#4299e1', borderRadius: 8, paddingVertical: 12, alignItems: 'center' },
+  btnDisabled: { opacity: 0.6 },
+  btnText: { color: '#fff', fontWeight: '700', fontSize: 15 },
+  formContent: { padding: 16 },
+  back: { marginBottom: 8 },
+  backText: { color: '#4299e1', fontSize: 16 },
+  label: { fontSize: 13, fontWeight: '600', color: '#718096', marginTop: 16, marginBottom: 6, textTransform: 'uppercase' },
+  input: {
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+    color: '#1a202c',
+  },
+  textArea: { height: 100, textAlignVertical: 'top' },
+  policyOption: {
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 8,
+    padding: 10,
+    marginBottom: 6,
+  },
+  policyOptionActive: { borderColor: '#4299e1', backgroundColor: '#ebf8ff' },
+  policyOptionText: { fontSize: 14, color: '#2d3748' },
+});
+
+export default InsuranceScreen;

--- a/src/screens/PrivacyDashboardScreen.tsx
+++ b/src/screens/PrivacyDashboardScreen.tsx
@@ -1,0 +1,194 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { resilientRequest } from '../services/apiClient';
+
+interface ConsentState {
+  necessary: boolean;
+  functional: boolean;
+  analytics: boolean;
+  marketing: boolean;
+}
+
+const CATEGORIES: { key: keyof ConsentState; label: string; description: string }[] = [
+  { key: 'necessary', label: 'Necessary', description: 'Required for the app to function.' },
+  { key: 'functional', label: 'Functional', description: 'Remembers your preferences.' },
+  { key: 'analytics', label: 'Analytics', description: 'Helps us improve the app.' },
+  { key: 'marketing', label: 'Marketing', description: 'Personalised offers and updates.' },
+];
+
+const PrivacyDashboardScreen: React.FC = () => {
+  const [consents, setConsents] = useState<ConsentState>({
+    necessary: true,
+    functional: false,
+    analytics: false,
+    marketing: false,
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const loadConsents = useCallback(async () => {
+    try {
+      const res = await resilientRequest<{ data: { consents: ConsentState } }>({
+        method: 'GET',
+        url: '/privacy/consent',
+      });
+      setConsents((prev) => ({ ...prev, ...res.data.data.consents }));
+    } catch {
+      // Use defaults on error
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadConsents();
+  }, [loadConsents]);
+
+  const saveConsents = useCallback(async () => {
+    setSaving(true);
+    try {
+      await resilientRequest({ method: 'POST', url: '/privacy/consent', data: { consents } });
+      Alert.alert('Saved', 'Your privacy preferences have been updated.');
+    } catch {
+      Alert.alert('Error', 'Failed to save preferences.');
+    } finally {
+      setSaving(false);
+    }
+  }, [consents]);
+
+  const handleExport = useCallback(async () => {
+    try {
+      const res = await resilientRequest<object>({ method: 'GET', url: '/privacy/export' });
+      Alert.alert('Export Ready', 'Your data export has been prepared.\n\n' + JSON.stringify(res.data).slice(0, 200) + '…');
+    } catch {
+      Alert.alert('Error', 'Failed to export data.');
+    }
+  }, []);
+
+  const handleErase = useCallback(() => {
+    Alert.alert(
+      'Delete All Data',
+      'This will permanently delete your account and all associated data. This cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await resilientRequest({ method: 'DELETE', url: '/privacy/erase' });
+              Alert.alert('Done', 'Your data has been erased.');
+            } catch {
+              Alert.alert('Error', 'Failed to erase data.');
+            }
+          },
+        },
+      ],
+    );
+  }, []);
+
+  if (loading) {
+    return <ActivityIndicator style={styles.loader} size="large" color="#4299e1" />;
+  }
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.title}>Privacy Dashboard</Text>
+      <Text style={styles.subtitle}>
+        Manage how PetChain uses your data. Changes are logged for compliance.
+      </Text>
+
+      <Text style={styles.sectionTitle}>Data Processing Consents</Text>
+      {CATEGORIES.map(({ key, label, description }) => (
+        <View key={key} style={styles.row}>
+          <View style={styles.rowInfo}>
+            <Text style={styles.rowLabel}>{label}</Text>
+            <Text style={styles.rowDesc}>{description}</Text>
+          </View>
+          <Switch
+            value={consents[key]}
+            onValueChange={(v) =>
+              key !== 'necessary' && setConsents((prev) => ({ ...prev, [key]: v }))
+            }
+            disabled={key === 'necessary'}
+            trackColor={{ true: '#4299e1', false: '#e2e8f0' }}
+            accessibilityLabel={`Toggle ${label} consent`}
+          />
+        </View>
+      ))}
+
+      <TouchableOpacity
+        style={[styles.btn, styles.btnPrimary]}
+        onPress={() => void saveConsents()}
+        disabled={saving}
+        accessibilityLabel="Save privacy preferences"
+      >
+        {saving ? (
+          <ActivityIndicator color="#fff" />
+        ) : (
+          <Text style={styles.btnText}>Save Preferences</Text>
+        )}
+      </TouchableOpacity>
+
+      <Text style={styles.sectionTitle}>Your Data Rights</Text>
+
+      <TouchableOpacity
+        style={[styles.btn, styles.btnSecondary]}
+        onPress={() => void handleExport()}
+        accessibilityLabel="Export my data"
+      >
+        <Text style={styles.btnTextSecondary}>📥 Export My Data (JSON)</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={[styles.btn, styles.btnDanger]}
+        onPress={handleErase}
+        accessibilityLabel="Delete all my data"
+      >
+        <Text style={styles.btnText}>🗑 Delete All My Data</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  content: { padding: 16 },
+  loader: { flex: 1, marginTop: 40 },
+  title: { fontSize: 22, fontWeight: '700', color: '#1a202c', marginBottom: 4 },
+  subtitle: { fontSize: 14, color: '#718096', marginBottom: 20 },
+  sectionTitle: { fontSize: 16, fontWeight: '700', color: '#2d3748', marginTop: 24, marginBottom: 12 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#edf2f7',
+  },
+  rowInfo: { flex: 1, marginRight: 12 },
+  rowLabel: { fontSize: 15, fontWeight: '600', color: '#1a202c' },
+  rowDesc: { fontSize: 13, color: '#718096', marginTop: 2 },
+  btn: {
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  btnPrimary: { backgroundColor: '#4299e1' },
+  btnSecondary: { backgroundColor: '#edf2f7' },
+  btnDanger: { backgroundColor: '#e53e3e' },
+  btnText: { color: '#fff', fontWeight: '600', fontSize: 15 },
+  btnTextSecondary: { color: '#2d3748', fontWeight: '600', fontSize: 15 },
+});
+
+export default PrivacyDashboardScreen;

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -1,0 +1,173 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { resilientRequest } from '../services/apiClient';
+
+interface SearchHit {
+  id: string;
+  index: string;
+  score: number;
+  source: Record<string, unknown>;
+  highlights: Record<string, string[]>;
+}
+
+interface SearchResult {
+  hits: SearchHit[];
+  total: number;
+}
+
+const INDEX_LABELS: Record<string, string> = {
+  pet_records: '🩺 Record',
+  medications: '💊 Medication',
+  appointments: '📅 Appointment',
+};
+
+const DEBOUNCE_MS = 350;
+
+const SearchScreen: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchHit[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const doSearch = useCallback(async (q: string) => {
+    if (!q.trim()) { setResults([]); setTotal(0); return; }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await resilientRequest<{ data: SearchResult }>({
+        method: 'GET',
+        url: `/search?q=${encodeURIComponent(q)}`,
+      });
+      setResults(res.data.data.hits);
+      setTotal(res.data.data.total);
+    } catch {
+      setError('Search unavailable. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => { void doSearch(query); }, DEBOUNCE_MS);
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [query, doSearch]);
+
+  const getTitle = (hit: SearchHit): string => {
+    const s = hit.source;
+    return (s.name ?? s.diagnosis ?? s.type ?? s.id) as string;
+  };
+
+  const getHighlight = (hit: SearchHit): string => {
+    const first = Object.values(hit.highlights)[0];
+    return first?.[0]?.replace(/<\/?mark>/g, '') ?? '';
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Search</Text>
+
+      <View style={styles.searchBar}>
+        <Text style={styles.searchIcon}>🔍</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Search records, medications, appointments…"
+          value={query}
+          onChangeText={setQuery}
+          autoCorrect={false}
+          autoCapitalize="none"
+          returnKeyType="search"
+          accessibilityLabel="Search input"
+        />
+        {query.length > 0 && (
+          <TouchableOpacity onPress={() => setQuery('')} accessibilityLabel="Clear search">
+            <Text style={styles.clearBtn}>✕</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {loading && <ActivityIndicator style={styles.loader} color="#4299e1" />}
+
+      {error && <Text style={styles.error}>{error}</Text>}
+
+      {!loading && query.length > 0 && results.length > 0 && (
+        <Text style={styles.resultCount}>{total} result{total !== 1 ? 's' : ''}</Text>
+      )}
+
+      <FlatList
+        data={results}
+        keyExtractor={(h) => `${h.index}-${h.id}`}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <View style={styles.card}>
+            <View style={styles.cardHeader}>
+              <Text style={styles.indexLabel}>
+                {INDEX_LABELS[item.index] ?? item.index}
+              </Text>
+              <Text style={styles.score}>{(item.score * 100).toFixed(0)}%</Text>
+            </View>
+            <Text style={styles.cardTitle}>{getTitle(item)}</Text>
+            {getHighlight(item) ? (
+              <Text style={styles.highlight} numberOfLines={2}>
+                {getHighlight(item)}
+              </Text>
+            ) : null}
+          </View>
+        )}
+        ListEmptyComponent={
+          !loading && query.length > 0 ? (
+            <Text style={styles.empty}>No results for "{query}"</Text>
+          ) : null
+        }
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  title: { fontSize: 22, fontWeight: '700', color: '#1a202c', padding: 16, paddingBottom: 8 },
+  searchBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: 16,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    backgroundColor: '#f7fafc',
+  },
+  searchIcon: { fontSize: 16, marginRight: 8 },
+  input: { flex: 1, paddingVertical: 10, fontSize: 15, color: '#1a202c' },
+  clearBtn: { fontSize: 16, color: '#a0aec0', paddingLeft: 8 },
+  loader: { marginTop: 16 },
+  error: { color: '#e53e3e', textAlign: 'center', marginTop: 12, paddingHorizontal: 16 },
+  resultCount: { fontSize: 13, color: '#718096', paddingHorizontal: 16, marginBottom: 4 },
+  list: { padding: 16 },
+  card: {
+    backgroundColor: '#f7fafc',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 10,
+  },
+  cardHeader: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 4 },
+  indexLabel: { fontSize: 12, color: '#4299e1', fontWeight: '600' },
+  score: { fontSize: 12, color: '#a0aec0' },
+  cardTitle: { fontSize: 15, fontWeight: '600', color: '#1a202c' },
+  highlight: { fontSize: 13, color: '#718096', marginTop: 4 },
+  empty: { textAlign: 'center', color: '#718096', marginTop: 40 },
+});
+
+export default SearchScreen;

--- a/src/screens/VetDirectoryScreen.tsx
+++ b/src/screens/VetDirectoryScreen.tsx
@@ -1,0 +1,384 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import {
+  getMessages,
+  getVetProfile,
+  searchVets,
+  sendMessage,
+  type VetMessage,
+  type VetProfile,
+} from '../services/vetService';
+
+type Screen = 'directory' | 'profile' | 'chat';
+
+const VetDirectoryScreen: React.FC = () => {
+  const [screen, setScreen] = useState<Screen>('directory');
+  const [vets, setVets] = useState<VetProfile[]>([]);
+  const [selectedVet, setSelectedVet] = useState<VetProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Search filters
+  const [specialty, setSpecialty] = useState('');
+  const [radius, setRadius] = useState('25');
+  const [availableOnly, setAvailableOnly] = useState(false);
+
+  // Chat
+  const [messages, setMessages] = useState<VetMessage[]>([]);
+  const [msgInput, setMsgInput] = useState('');
+  const [chatLoading, setChatLoading] = useState(false);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  const doSearch = useCallback(async () => {
+    setLoading(true);
+    try {
+      const results = await searchVets({
+        specialty: specialty || undefined,
+        radius: parseFloat(radius) || 25,
+        available: availableOnly || undefined,
+      });
+      setVets(results);
+    } catch {
+      Alert.alert('Error', 'Failed to search vets');
+    } finally {
+      setLoading(false);
+    }
+  }, [specialty, radius, availableOnly]);
+
+  useEffect(() => {
+    void doSearch();
+  }, [doSearch]);
+
+  const openProfile = useCallback(async (vet: VetProfile) => {
+    try {
+      const profile = await getVetProfile(vet.id);
+      setSelectedVet(profile);
+      setScreen('profile');
+    } catch {
+      Alert.alert('Error', 'Failed to load vet profile');
+    }
+  }, []);
+
+  const openChat = useCallback(
+    async (vet: VetProfile) => {
+      setSelectedVet(vet);
+      setChatLoading(true);
+      try {
+        const history = await getMessages(vet.id);
+        setMessages(history);
+        setScreen('chat');
+      } catch {
+        Alert.alert('Error', 'Failed to load messages');
+      } finally {
+        setChatLoading(false);
+      }
+    },
+    [],
+  );
+
+  const handleSend = useCallback(async () => {
+    if (!msgInput.trim() || !selectedVet) return;
+    const text = msgInput.trim();
+    setMsgInput('');
+    try {
+      const msg = await sendMessage(selectedVet.id, { content: text });
+      setMessages((prev) => [...prev, msg]);
+    } catch {
+      Alert.alert('Error', 'Failed to send message');
+    }
+  }, [msgInput, selectedVet]);
+
+  // ─── Directory ───────────────────────────────────────────────────────────────
+  if (screen === 'directory') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Vet Directory</Text>
+
+        <View style={styles.filters}>
+          <TextInput
+            style={styles.input}
+            placeholder="Specialty (e.g. Dermatology)"
+            value={specialty}
+            onChangeText={setSpecialty}
+            returnKeyType="search"
+            onSubmitEditing={() => void doSearch()}
+          />
+          <View style={styles.row}>
+            <TextInput
+              style={[styles.input, { flex: 1, marginRight: 8 }]}
+              placeholder="Radius (km)"
+              value={radius}
+              onChangeText={setRadius}
+              keyboardType="numeric"
+            />
+            <TouchableOpacity
+              style={[styles.toggleBtn, availableOnly && styles.toggleActive]}
+              onPress={() => setAvailableOnly((v) => !v)}
+              accessibilityLabel="Toggle available only"
+            >
+              <Text style={availableOnly ? styles.toggleTextActive : styles.toggleText}>
+                Available only
+              </Text>
+            </TouchableOpacity>
+          </View>
+          <TouchableOpacity style={styles.searchBtn} onPress={() => void doSearch()}>
+            <Text style={styles.searchBtnText}>Search</Text>
+          </TouchableOpacity>
+        </View>
+
+        {loading ? (
+          <ActivityIndicator style={styles.loader} size="large" color="#4299e1" />
+        ) : (
+          <FlatList
+            data={vets}
+            keyExtractor={(v) => v.id}
+            renderItem={({ item }) => (
+              <TouchableOpacity
+                style={styles.card}
+                onPress={() => void openProfile(item)}
+                accessibilityLabel={`View profile of ${item.name}`}
+              >
+                <View style={styles.cardInfo}>
+                  <Text style={styles.vetName}>{item.name}</Text>
+                  <Text style={styles.vetSub}>{item.specialty}</Text>
+                  <Text style={styles.vetSub}>
+                    ⭐ {item.rating.toFixed(1)} · {item.reviewCount} reviews
+                    {item.distance !== undefined ? ` · ${item.distance.toFixed(1)} km` : ''}
+                  </Text>
+                </View>
+                <View style={[styles.badge, item.available ? styles.badgeGreen : styles.badgeGray]}>
+                  <Text style={styles.badgeText}>{item.available ? 'Available' : 'Busy'}</Text>
+                </View>
+              </TouchableOpacity>
+            )}
+            ListEmptyComponent={<Text style={styles.empty}>No vets found.</Text>}
+            contentContainerStyle={styles.list}
+          />
+        )}
+      </View>
+    );
+  }
+
+  // ─── Profile ─────────────────────────────────────────────────────────────────
+  if (screen === 'profile' && selectedVet) {
+    return (
+      <ScrollView style={styles.container} contentContainerStyle={styles.profileContent}>
+        <TouchableOpacity onPress={() => setScreen('directory')} style={styles.back}>
+          <Text style={styles.backText}>‹ Back</Text>
+        </TouchableOpacity>
+        <Text style={styles.title}>{selectedVet.name}</Text>
+        <Text style={styles.label}>Specialty</Text>
+        <Text style={styles.value}>{selectedVet.specialty}</Text>
+        <Text style={styles.label}>Credentials</Text>
+        <Text style={styles.value}>{selectedVet.credentials || '—'}</Text>
+        <Text style={styles.label}>Accepted Insurance</Text>
+        <Text style={styles.value}>
+          {selectedVet.acceptedInsurance.length ? selectedVet.acceptedInsurance.join(', ') : '—'}
+        </Text>
+        <Text style={styles.label}>Rating</Text>
+        <Text style={styles.value}>
+          ⭐ {selectedVet.rating.toFixed(1)} ({selectedVet.reviewCount} reviews)
+        </Text>
+        <Text style={styles.label}>Address</Text>
+        <Text style={styles.value}>{selectedVet.address || '—'}</Text>
+        <Text style={styles.label}>Phone</Text>
+        <Text style={styles.value}>{selectedVet.phone || '—'}</Text>
+
+        <TouchableOpacity
+          style={[styles.searchBtn, { marginTop: 24 }]}
+          onPress={() => void openChat(selectedVet)}
+          accessibilityLabel={`Message ${selectedVet.name}`}
+        >
+          <Text style={styles.searchBtnText}>💬 Message</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    );
+  }
+
+  // ─── Chat ─────────────────────────────────────────────────────────────────────
+  if (screen === 'chat' && selectedVet) {
+    return (
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={80}
+      >
+        <View style={styles.chatHeader}>
+          <TouchableOpacity onPress={() => setScreen('profile')} style={styles.back}>
+            <Text style={styles.backText}>‹ Back</Text>
+          </TouchableOpacity>
+          <Text style={styles.chatTitle}>{selectedVet.name}</Text>
+        </View>
+
+        {chatLoading ? (
+          <ActivityIndicator style={styles.loader} size="large" color="#4299e1" />
+        ) : (
+          <FlatList
+            data={messages}
+            keyExtractor={(m) => m.id}
+            renderItem={({ item }) => {
+              const isMine = item.senderId !== selectedVet.userId;
+              return (
+                <View style={[styles.bubble, isMine ? styles.bubbleMine : styles.bubbleTheirs]}>
+                  {item.content ? (
+                    <Text style={isMine ? styles.bubbleTextMine : styles.bubbleText}>
+                      {item.content}
+                    </Text>
+                  ) : null}
+                  {item.attachmentUrl ? (
+                    <Text style={styles.attachment}>📎 Attachment</Text>
+                  ) : null}
+                  <Text style={styles.timestamp}>
+                    {new Date(item.createdAt).toLocaleTimeString([], {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </Text>
+                </View>
+              );
+            }}
+            contentContainerStyle={styles.chatList}
+            ListEmptyComponent={
+              <Text style={styles.empty}>No messages yet. Say hello!</Text>
+            }
+          />
+        )}
+
+        <View style={styles.inputRow}>
+          <TextInput
+            style={styles.chatInput}
+            placeholder="Type a message…"
+            value={msgInput}
+            onChangeText={setMsgInput}
+            multiline
+            accessibilityLabel="Message input"
+          />
+          <TouchableOpacity
+            style={styles.sendBtn}
+            onPress={() => void handleSend()}
+            disabled={!msgInput.trim()}
+            accessibilityLabel="Send message"
+          >
+            <Text style={styles.sendBtnText}>Send</Text>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    );
+  }
+
+  return null;
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  title: { fontSize: 20, fontWeight: '700', color: '#1a202c', padding: 16, paddingBottom: 8 },
+  filters: { paddingHorizontal: 16, paddingBottom: 8 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    marginBottom: 8,
+    fontSize: 14,
+    color: '#1a202c',
+  },
+  row: { flexDirection: 'row', alignItems: 'center', marginBottom: 8 },
+  toggleBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+  },
+  toggleActive: { backgroundColor: '#4299e1', borderColor: '#4299e1' },
+  toggleText: { color: '#718096', fontSize: 13 },
+  toggleTextActive: { color: '#fff', fontSize: 13 },
+  searchBtn: {
+    backgroundColor: '#4299e1',
+    borderRadius: 8,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  searchBtnText: { color: '#fff', fontWeight: '600', fontSize: 15 },
+  loader: { marginTop: 40 },
+  list: { padding: 12 },
+  card: {
+    flexDirection: 'row',
+    backgroundColor: '#f7fafc',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 10,
+    alignItems: 'center',
+  },
+  cardInfo: { flex: 1 },
+  vetName: { fontSize: 15, fontWeight: '600', color: '#1a202c' },
+  vetSub: { fontSize: 13, color: '#718096', marginTop: 2 },
+  badge: { paddingHorizontal: 8, paddingVertical: 4, borderRadius: 12 },
+  badgeGreen: { backgroundColor: '#c6f6d5' },
+  badgeGray: { backgroundColor: '#e2e8f0' },
+  badgeText: { fontSize: 12, fontWeight: '600', color: '#2d3748' },
+  empty: { textAlign: 'center', color: '#718096', marginTop: 40 },
+  profileContent: { padding: 16 },
+  back: { marginBottom: 8 },
+  backText: { color: '#4299e1', fontSize: 16 },
+  label: { fontSize: 12, fontWeight: '600', color: '#718096', marginTop: 12, textTransform: 'uppercase' },
+  value: { fontSize: 15, color: '#1a202c', marginTop: 2 },
+  chatHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+  chatTitle: { flex: 1, fontSize: 17, fontWeight: '700', color: '#1a202c' },
+  chatList: { padding: 12, flexGrow: 1 },
+  bubble: { maxWidth: '75%', borderRadius: 12, padding: 10, marginBottom: 8 },
+  bubbleMine: { backgroundColor: '#4299e1', alignSelf: 'flex-end' },
+  bubbleTheirs: { backgroundColor: '#edf2f7', alignSelf: 'flex-start' },
+  bubbleTextMine: { color: '#fff', fontSize: 14 },
+  bubbleText: { color: '#1a202c', fontSize: 14 },
+  attachment: { color: '#4299e1', fontSize: 13, marginTop: 4 },
+  timestamp: { fontSize: 10, color: '#a0aec0', marginTop: 4, alignSelf: 'flex-end' },
+  inputRow: {
+    flexDirection: 'row',
+    padding: 12,
+    borderTopWidth: 1,
+    borderTopColor: '#eee',
+    alignItems: 'flex-end',
+  },
+  chatInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 20,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    fontSize: 14,
+    maxHeight: 100,
+    color: '#1a202c',
+  },
+  sendBtn: {
+    marginLeft: 8,
+    backgroundColor: '#4299e1',
+    borderRadius: 20,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  sendBtnText: { color: '#fff', fontWeight: '600' },
+});
+
+export default VetDirectoryScreen;

--- a/src/services/claimsService.ts
+++ b/src/services/claimsService.ts
@@ -1,0 +1,67 @@
+import { resilientRequest } from './apiClient';
+
+export type ClaimStatus = 'submitted' | 'under_review' | 'approved' | 'denied';
+
+export interface InsurancePolicy {
+  id: string;
+  provider: string;
+  policyNumber: string;
+  petId?: string;
+  coverageLimit: number;
+  deductible: number;
+  premium: number;
+  status: string;
+  expiresAt: string;
+}
+
+export interface InsuranceClaim {
+  id: string;
+  policyId: string;
+  petId?: string;
+  amount: number;
+  description: string;
+  status: ClaimStatus;
+  attachmentUrls: string[];
+  submittedAt: string;
+  updatedAt: string;
+}
+
+export async function getPolicies(): Promise<InsurancePolicy[]> {
+  const res = await resilientRequest<{ data: InsurancePolicy[] }>({
+    method: 'GET',
+    url: '/insurance/policies',
+  });
+  return res.data.data;
+}
+
+export async function connectProvider(provider: string, code: string): Promise<InsurancePolicy> {
+  const res = await resilientRequest<{ data: InsurancePolicy }>({
+    method: 'POST',
+    url: '/insurance/connect',
+    data: { provider, code },
+  });
+  return res.data.data;
+}
+
+export async function getClaims(): Promise<InsuranceClaim[]> {
+  const res = await resilientRequest<{ data: InsuranceClaim[] }>({
+    method: 'GET',
+    url: '/insurance/claims',
+  });
+  return res.data.data;
+}
+
+export async function submitClaim(data: {
+  policyId: string;
+  petId?: string;
+  amount: number;
+  description: string;
+  attachmentUrls?: string[];
+}): Promise<InsuranceClaim> {
+  const res = await resilientRequest<{ data: InsuranceClaim }>({
+    method: 'POST',
+    url: '/insurance/claims',
+    data,
+  });
+  return res.data.data;
+}

--- a/src/services/vetService.ts
+++ b/src/services/vetService.ts
@@ -1,0 +1,87 @@
+import { resilientRequest } from './apiClient';
+
+export interface VetProfile {
+  id: string;
+  userId: string;
+  name: string;
+  specialty: string;
+  credentials: string;
+  acceptedInsurance: string[];
+  rating: number;
+  reviewCount: number;
+  available: boolean;
+  lat: number;
+  lng: number;
+  address: string;
+  phone: string;
+  distance?: number;
+}
+
+export interface VetMessage {
+  id: string;
+  conversationId: string;
+  senderId: string;
+  recipientId: string;
+  content?: string;
+  attachmentUrl?: string;
+  attachmentType?: string;
+  readAt?: string;
+  createdAt: string;
+}
+
+export interface SearchVetsParams {
+  lat?: number;
+  lng?: number;
+  radius?: number;
+  specialty?: string;
+  available?: boolean;
+}
+
+export async function searchVets(params: SearchVetsParams): Promise<VetProfile[]> {
+  const query = new URLSearchParams();
+  if (params.lat !== undefined) query.set('lat', String(params.lat));
+  if (params.lng !== undefined) query.set('lng', String(params.lng));
+  if (params.radius !== undefined) query.set('radius', String(params.radius));
+  if (params.specialty) query.set('specialty', params.specialty);
+  if (params.available !== undefined) query.set('available', String(params.available));
+
+  const res = await resilientRequest<{ data: VetProfile[] }>({
+    method: 'GET',
+    url: `/vets?${query.toString()}`,
+  });
+  return res.data.data;
+}
+
+export async function getVetProfile(vetId: string): Promise<VetProfile> {
+  const res = await resilientRequest<{ data: VetProfile }>({
+    method: 'GET',
+    url: `/vets/${vetId}`,
+  });
+  return res.data.data;
+}
+
+export async function getMessages(
+  vetId: string,
+  limit = 50,
+  before?: string,
+): Promise<VetMessage[]> {
+  const query = new URLSearchParams({ limit: String(limit) });
+  if (before) query.set('before', before);
+  const res = await resilientRequest<{ data: VetMessage[] }>({
+    method: 'GET',
+    url: `/vets/messages/${vetId}?${query.toString()}`,
+  });
+  return res.data.data;
+}
+
+export async function sendMessage(
+  vetId: string,
+  payload: { content?: string; attachmentUrl?: string; attachmentType?: string },
+): Promise<VetMessage> {
+  const res = await resilientRequest<{ data: VetMessage }>({
+    method: 'POST',
+    url: `/vets/messages/${vetId}`,
+    data: payload,
+  });
+  return res.data.data;
+}


### PR DESCRIPTION
PR Description

closes #321
closes #324
closes #325
closes #327
  
  ## Summary
  
  Implements four features for PetChain: a searchable vet directory with real-time messaging, GDPR/CCPA compliance tools, pet insurance integration, and full-text Elasticsearch
  search.
  
  
  ---
  
  ## Changes
  
  ### Task 1 — Vet Directory with Search & In-App Messaging
  
  **Backend**
  - `backend/migrations/006_vet_directory_messaging.sql` — `vet_profiles` table with PostGIS `GEOGRAPHY` column + spatial index; `messages` table with conversation index
  - `backend/services/messagingService.ts` — WebSocket server (`/ws/messages`), in-memory message store, real-time delivery to online recipients
  - `backend/server/routes/vets.ts` — `GET /api/vets` (filter by radius/specialty/availability using Haversine), `GET /api/vets/:id`, `POST /api/vets`, `GET/POST
  /api/vets/messages/:vetId` with pagination
  
  **Frontend**
  - `src/services/vetService.ts` — typed API wrappers for vet search and messaging
  - `src/screens/VetDirectoryScreen.tsx` — three-screen flow: directory list → vet profile → real-time chat UI
  
  ---
  
  ### Task 2 — GDPR/CCPA Compliance 
  
  **Backend**
  - `backend/migrations/007_gdpr_ccpa.sql` — `consent_logs` (timestamped audit trail) and `data_deletion_requests` tables
  - `backend/services/dataExportService.ts` — `exportUserData` (strips `passwordHash`), `eraseUserData` (hard-deletes all PII), `logConsent` / `getConsentHistory`
  - `backend/server/routes/privacy.ts` — `GET /export` (JSON download), `GET/POST /consent`, `GET /consent/history`, `DELETE /erase`
  
  **Frontend**
  - `src/screens/PrivacyDashboardScreen.tsx` — per-category consent toggles (necessary locked), save preferences, export data, right-to-erasure with confirmation dialog
  
  ---
  
  ### Task 3 — Pet Insurance Integration 
  
  **Backend**
  - `backend/migrations/008_insurance.sql` — `insurance_policies` and `insurance_claims` tables
  - `backend/services/insuranceService.ts` — mock OAuth code exchange for Trupanion/Nationwide, claim submission with async status progression, claim history
  - `backend/server/routes/insurance.ts` — `GET /policies`, `POST /connect`, `GET/POST /claims`, `GET /claims/:id`
  
  **Frontend**
  - `src/services/claimsService.ts` — typed API wrappers
  - `src/screens/InsuranceScreen.tsx` — tabbed policies/claims view, connect provider flow, claim submission form with policy selector
  
  ---
  
  ### Task 4 — Elasticsearch Full-Text Search 
  
  **Backend**
  - `backend/services/searchService.ts` — `@elastic/elasticsearch` client, `search()` with fuzzy multi-match, field filters, result highlighting, `indexDocument` /
  `deleteDocument` for CDC sync, `ensureIndices` for bootstrap
  - `backend/server/routes/search.ts` — `GET /api/search?q=&index=&from=&size=&<field>=<value>` with 100-result cap
  
  **Frontend**
  - `src/screens/SearchScreen.tsx` — search-as-you-type with 350 ms debounce, highlight display, result count, clear button
  
  ---
  
  ### Wiring
  - `backend/server/app.ts` — registered `/vets`, `/privacy`, `/insurance`, `/search` routes
  - `src/navigation/types.ts` — added `VetDirectory`, `PrivacyDashboard`, `Insurance`, `Search` to `PetStackParamList`
  
  ---
  
  ## Testing
  
  - WebSocket message delivery can be load-tested by connecting multiple clients to `/ws/messages?userId=<id>`
  - Insurance claim flow covered by mock provider (use `provider: "mock"` with any code string)
  - Elasticsearch tests: run `ensureIndices()` then index sample docs and verify fuzzy search returns highlighted hits
  - GDPR erasure: verify all user-owned records are removed after `DELETE /api/privacy/erase`
 
 
 
 
 
 
 
 