### PR TITLE
feat: implement Content Security Policy and security headers

### DIFF
--- a/backend/middleware/securityHeaders.ts
+++ b/backend/middleware/securityHeaders.ts
@@ -1,0 +1,119 @@
+/**
+ * Security headers middleware.
+ *
+ * Configures Helmet.js with a strict Content Security Policy, HSTS with
+ * preload, and complementary headers that harden the Express API against
+ * common web-layer attacks (XSS, clickjacking, MIME-sniffing, etc.).
+ *
+ * Usage:
+ *   import { applySecurityHeaders } from '../middleware/securityHeaders';
+ *   applySecurityHeaders(app);
+ */
+
+import helmet from 'helmet';
+import type { Express } from 'express';
+
+const IS_PROD = process.env.NODE_ENV === 'production';
+
+/**
+ * Whitelist of trusted origins for CSP `connect-src`.
+ * Extend via the ALLOWED_ORIGINS env var (comma-separated).
+ */
+const TRUSTED_ORIGINS: string[] = [
+  "'self'",
+  'https://api.petchain.app',
+  'https://staging.petchain.app',
+  ...(process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(',').map((o) => o.trim()) : []),
+];
+
+/**
+ * Applies all security headers to the Express application.
+ *
+ * - Helmet core headers (X-Frame-Options, X-Content-Type-Options, etc.)
+ * - Strict Content Security Policy
+ * - HSTS with 1-year max-age and preload (production only)
+ */
+export function applySecurityHeaders(app: Express): void {
+  // --- Basic Helmet headers (no CSP yet — we configure it separately) ---
+  app.use(
+    helmet({
+      contentSecurityPolicy: false, // overridden below
+      crossOriginEmbedderPolicy: IS_PROD,
+      hsts: IS_PROD
+        ? {
+            maxAge: 31_536_000, // 1 year in seconds
+            includeSubDomains: true,
+            preload: true,
+          }
+        : false,
+    }),
+  );
+
+  // --- Strict Content Security Policy ---
+  app.use(
+    helmet.contentSecurityPolicy({
+      useDefaults: false,
+      directives: {
+        defaultSrc: ["'none'"],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", "'unsafe-inline'"], // inline styles needed by Swagger UI
+        imgSrc: ["'self'", 'data:', 'https://cdn.petchain.app'],
+        fontSrc: ["'self'"],
+        connectSrc: TRUSTED_ORIGINS,
+        mediaSrc: ["'self'"],
+        objectSrc: ["'none'"],
+        frameSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+        formAction: ["'self'"],
+        baseUri: ["'self'"],
+        upgradeInsecureRequests: IS_PROD ? [] : null,
+      },
+    }),
+  );
+
+  // Prevent browsers from guessing MIME types
+  app.use(helmet.noSniff());
+
+  // Disable X-Powered-By header
+  app.disable('x-powered-by');
+
+  // Referrer policy — do not leak origin to third parties
+  app.use(helmet.referrerPolicy({ policy: 'strict-origin-when-cross-origin' }));
+
+  // Permissions policy — restrict browser feature access
+  app.use((_req, res, next) => {
+    res.setHeader(
+      'Permissions-Policy',
+      'camera=(), microphone=(), geolocation=(), payment=()',
+    );
+    next();
+  });
+}
+
+/**
+ * Field-level whitelist validators.
+ *
+ * Use these in route handlers to enforce strict input shapes before
+ * passing values to the database layer.
+ */
+export const inputWhitelist = {
+  /** Alphanumeric + common punctuation, max 200 chars */
+  name: /^[\w\s\-'.]{1,200}$/,
+  /** RFC-5321 e-mail (simplified) */
+  email: /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/,
+  /** UUID v4 */
+  uuid: /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+  /** ISO-8601 date (YYYY-MM-DD) */
+  date: /^\d{4}-\d{2}-\d{2}$/,
+  /** Positive integer strings */
+  positiveInt: /^\d{1,10}$/,
+  /** Alphanumeric + underscore + hyphen identifiers */
+  identifier: /^[\w-]{1,100}$/,
+} as const;
+
+/**
+ * Returns true when the value passes the named whitelist rule.
+ */
+export function isWhitelisted(rule: keyof typeof inputWhitelist, value: string): boolean {
+  return inputWhitelist[rule].test(value);
+}

--- a/backend/server/app.ts
+++ b/backend/server/app.ts
@@ -2,6 +2,7 @@ import cors from 'cors';
 import express, { type Express, type NextFunction, type Request, type Response } from 'express';
 
 import { errBody } from './response';
+import { applySecurityHeaders } from '../middleware/securityHeaders';
 import { sanitizeInputs } from '../middleware/sanitize';
 import analyticsRouter from './routes/analytics';
 import appointmentsRouter from './routes/appointments';
@@ -21,6 +22,10 @@ import { attachAudit } from '../middleware/auditLog';
 
 export function createApp(): Express {
   const app = express();
+
+  // Security headers (Helmet + CSP + HSTS) — applied before any routes
+  applySecurityHeaders(app);
+
   app.use(cors());
   app.use(express.json());
   app.use(sanitizeInputs);

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,154 @@
+# PetChain Security Posture
+
+This document describes the security controls implemented in the PetChain backend and the procedures for ongoing security maintenance.
+
+---
+
+## 1. Security Headers
+
+All HTTP responses are hardened with [Helmet.js](https://helmetjs.github.io/) (`backend/middleware/securityHeaders.ts`).
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `Content-Security-Policy` | `default-src 'none'; script-src 'self'; ...` | Restrict resource origins; mitigate XSS |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains; preload` | Force HTTPS; enable HSTS preload list (production) |
+| `X-Frame-Options` | `DENY` (via `frameAncestors 'none'`) | Prevent clickjacking |
+| `X-Content-Type-Options` | `nosniff` | Prevent MIME-type sniffing |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limit referrer leakage |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=()` | Restrict browser features |
+| `X-Powered-By` | *(removed)* | Hide framework fingerprint |
+
+### Content Security Policy
+
+The CSP follows a **deny-by-default** strategy:
+
+```
+default-src 'none';
+script-src 'self';
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: https://cdn.petchain.app;
+font-src 'self';
+connect-src 'self' https://api.petchain.app https://staging.petchain.app;
+media-src 'self';
+object-src 'none';
+frame-src 'none';
+frame-ancestors 'none';
+form-action 'self';
+base-uri 'self';
+upgrade-insecure-requests;   (production only)
+```
+
+To add a trusted third-party origin, set the `ALLOWED_ORIGINS` environment variable (comma-separated):
+
+```bash
+ALLOWED_ORIGINS=https://partner.example.com,https://cdn.example.com
+```
+
+### HSTS Pre-loading
+
+HSTS is enabled only in `production` (`NODE_ENV=production`). Before submitting to the HSTS preload list:
+
+1. Confirm the `max-age` has been live for ≥ 18 weeks.
+2. Verify `includeSubDomains` is appropriate for all sub-domains.
+3. Submit at [hstspreload.org](https://hstspreload.org).
+
+---
+
+## 2. Input Sanitization
+
+All request bodies, query strings, and route parameters are sanitized by `backend/middleware/sanitize.ts` before they reach route handlers:
+
+- **XSS stripping** — HTML tags and `on*` / `javascript:` / `data:` attribute patterns are removed.
+- **SQL injection detection** — Requests containing SQL keywords or injection operators are rejected with `400 INVALID_INPUT`.
+- **Length truncation** — Individual string fields are capped at `MAX_INPUT_LENGTH` (10 000 chars).
+
+### Field-level Whitelisting
+
+Route handlers that accept structured identifiers should additionally validate with `inputWhitelist` from `backend/middleware/securityHeaders.ts`:
+
+```ts
+import { isWhitelisted } from '../middleware/securityHeaders';
+
+if (!isWhitelisted('uuid', req.params.petId)) {
+  return sendError(res, 400, 'INVALID_INPUT', 'petId must be a valid UUID');
+}
+```
+
+Available rules: `name`, `email`, `uuid`, `date`, `positiveInt`, `identifier`.
+
+---
+
+## 3. Parameterized Query Audit
+
+All database access **must** use parameterized queries. The following patterns are prohibited:
+
+```ts
+// PROHIBITED — string concatenation
+db.query(`SELECT * FROM pets WHERE id = '${id}'`);
+
+// REQUIRED — parameterized
+db.query('SELECT * FROM pets WHERE id = $1', [id]);
+```
+
+The repository layer in `backend/src/repositories/` enforces this via the pg `Pool` / `PoolClient` API with positional parameters (`$1`, `$2`, …). Any new repository method must follow the same pattern.
+
+---
+
+## 4. Authentication & Authorization
+
+- **JWT** tokens are verified on every protected route via `backend/middleware/auth.ts`.
+- Tokens are signed with `config.app.jwtSecret`; this secret must be ≥ 32 random bytes in production.
+- Role-based access control (RBAC) is enforced via `authorizeRoles(...)` middleware.
+- Passwords are hashed with **bcrypt** (cost factor ≥ 12).
+
+---
+
+## 5. OWASP ZAP Scanning
+
+Run ZAP against a local instance before each release:
+
+```bash
+# Start the backend
+NODE_ENV=development tsx backend/server/index.ts &
+
+# Active scan (replace <port> as needed)
+docker run --rm --network host \
+  ghcr.io/zaproxy/zaproxy:stable \
+  zap-full-scan.py \
+  -t http://localhost:3000 \
+  -r zap-report.html \
+  -l WARN
+```
+
+**Acceptance criteria:** zero High findings, zero Medium findings in the ZAP HTML report before merging to `main`.
+
+Findings and remediations are tracked in the GitHub Security Advisories section of this repository.
+
+---
+
+## 6. Dependency Auditing
+
+```bash
+npm audit --audit-level=high
+```
+
+Run on every CI build. PRs with unresolved High or Critical audit warnings are blocked from merging.
+
+---
+
+## 7. Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `NODE_ENV` | Yes | `development` / `staging` / `production` |
+| `JWT_SECRET` | Yes | ≥ 32 random bytes, base64-encoded |
+| `QR_SIGNING_SECRET` | Yes | ≥ 32 random bytes for HMAC QR signing |
+| `ALLOWED_ORIGINS` | No | Extra CSP `connect-src` origins (comma-separated) |
+
+See `.env.example` for the full list.
+
+---
+
+## 8. Reporting a Vulnerability
+
+Please report security vulnerabilities via GitHub's private vulnerability reporting tool or by e-mailing **security@petchain.app**. Do not open public issues for security problems.

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "react-native-image-resizer": "^1.4.5",
     "react-native-keychain": "^10.0.0",
     "react-native-ssl-pinning": "^1.5.3",
+    "helmet": "^8.0.0",
     "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
@@ -129,6 +130,7 @@
     "@storybook/blocks": "^8.6.0",
     "@storybook/react-native": "^8.6.0",
     "@types/cors": "^2.8.19",
+    "@types/helmet": "^0.0.48",
     "@types/crypto-js": "^4.2.2",
     "@types/express": "^5.0.6",
     "@types/jest": "^29.5.14",


### PR DESCRIPTION
## Summary

- Adds `helmet` middleware with a strict **deny-by-default Content Security Policy**, HSTS with 1-year max-age and preload flag, X-Frame-Options, Referrer-Policy, and Permissions-Policy
- Mounts `applySecurityHeaders()` as the first middleware in `createApp()` so every response is protected before reaching route logic
- Introduces field-level **input whitelist validators** (`uuid`, `email`, `name`, `date`, `positiveInt`, `identifier`) that route handlers can use alongside the existing XSS/SQL-injection sanitizer
- Documents the full security posture in `docs/SECURITY.md`: CSP directives, HSTS pre-loading steps, parameterized query audit rules, OWASP ZAP scanning procedure, and environment variable requirements

## Test plan

- [ ] Start the backend and confirm `curl -I http://localhost:3000/api/health` returns `Content-Security-Policy`, `Strict-Transport-Security` (production), `X-Frame-Options`, and `X-Content-Type-Options` headers
- [ ] Verify a request with an SQL injection pattern (e.g. `' OR '1'='1`) is rejected with `400 INVALID_INPUT`
- [ ] Verify an XSS payload (`<script>alert(1)</script>`) is stripped from request body before reaching the handler
- [ ] Confirm `x-powered-by` header is absent from all responses
- [ ] Run `npm audit --audit-level=high` and confirm no new High/Critical findings
- [ ] Review `docs/SECURITY.md` for accuracy

Closes #356