### PR TITLE
feat: Pet Travel Health Certificate Generator

### DIFF
--- a/backend/data/countryTravelRequirements.ts
+++ b/backend/data/countryTravelRequirements.ts
@@ -1,0 +1,188 @@
+/**
+ * Backend country travel requirements database.
+ * Issue #123 — Pet Travel Health Certificate Generator
+ */
+
+export interface VaccinationRequirement {
+  vaccineName: string;
+  minWeeksBeforeTravel?: number;
+  validForMonths?: number;
+  mandatory: boolean;
+  notes?: string;
+}
+
+export interface HealthCheckRequirement {
+  checkType: string;
+  description: string;
+  maxDaysBeforeTravel?: number;
+  mandatory: boolean;
+}
+
+export interface DocumentRequirement {
+  documentType: string;
+  description: string;
+  mandatory: boolean;
+  issuingAuthority?: string;
+}
+
+export interface CountryTravelRequirements {
+  countryCode: string;
+  countryName: string;
+  applicableSpecies: string[];
+  vaccinations: VaccinationRequirement[];
+  healthChecks: HealthCheckRequirement[];
+  documents: DocumentRequirement[];
+  lastUpdated: string;
+  officialReferenceUrl?: string;
+  additionalNotes?: string;
+}
+
+export const COUNTRY_REQUIREMENTS: CountryTravelRequirements[] = [
+  {
+    countryCode: 'GB',
+    countryName: 'United Kingdom',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    vaccinations: [
+      { vaccineName: 'Rabies', minWeeksBeforeTravel: 3, validForMonths: 36, mandatory: true, notes: 'Must be administered after microchipping' },
+    ],
+    healthChecks: [
+      { checkType: 'tapeworm_treatment', description: 'Tapeworm treatment by a vet (dogs only)', maxDaysBeforeTravel: 5, mandatory: true },
+      { checkType: 'microchip', description: 'ISO 11784/11785 compliant microchip', mandatory: true },
+    ],
+    documents: [
+      { documentType: 'pet_health_certificate', description: 'Official veterinary health certificate (AHC)', mandatory: true, issuingAuthority: 'Official Veterinarian (OV)' },
+    ],
+  },
+  {
+    countryCode: 'DE',
+    countryName: 'Germany',
+    applicableSpecies: ['dog', 'cat', 'rabbit'],
+    lastUpdated: '2026-01-15',
+    vaccinations: [
+      { vaccineName: 'Rabies', minWeeksBeforeTravel: 3, validForMonths: 36, mandatory: true },
+    ],
+    healthChecks: [
+      { checkType: 'microchip', description: 'ISO 11784/11785 compliant microchip', mandatory: true },
+    ],
+    documents: [
+      { documentType: 'eu_pet_passport', description: 'EU Pet Passport or official health certificate', mandatory: true, issuingAuthority: 'Accredited Veterinarian' },
+    ],
+  },
+  {
+    countryCode: 'FR',
+    countryName: 'France',
+    applicableSpecies: ['dog', 'cat', 'rabbit'],
+    lastUpdated: '2026-01-15',
+    vaccinations: [
+      { vaccineName: 'Rabies', minWeeksBeforeTravel: 3, validForMonths: 36, mandatory: true },
+    ],
+    healthChecks: [
+      { checkType: 'microchip', description: 'ISO 11784/11785 compliant microchip', mandatory: true },
+    ],
+    documents: [
+      { documentType: 'eu_pet_passport', description: 'EU Pet Passport or official health certificate', mandatory: true, issuingAuthority: 'Accredited Veterinarian' },
+    ],
+  },
+  {
+    countryCode: 'US',
+    countryName: 'United States',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    vaccinations: [
+      { vaccineName: 'Rabies', mandatory: true, validForMonths: 36, notes: 'Required for dogs; cats recommended' },
+    ],
+    healthChecks: [
+      { checkType: 'general_health_exam', description: 'General health examination by a licensed vet', maxDaysBeforeTravel: 10, mandatory: true },
+    ],
+    documents: [
+      { documentType: 'usda_health_certificate', description: 'USDA-endorsed health certificate (APHIS 7001)', mandatory: true, issuingAuthority: 'USDA-accredited veterinarian' },
+    ],
+  },
+  {
+    countryCode: 'AU',
+    countryName: 'Australia',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    vaccinations: [
+      { vaccineName: 'Rabies', mandatory: true, validForMonths: 12 },
+    ],
+    healthChecks: [
+      { checkType: 'microchip', description: 'ISO 11784/11785 compliant microchip', mandatory: true },
+      { checkType: 'rabies_titre_test', description: 'Rabies neutralising antibody titre test (RNATT)', maxDaysBeforeTravel: 180, mandatory: true },
+      { checkType: 'parasite_treatment', description: 'Treatment for internal and external parasites', maxDaysBeforeTravel: 5, mandatory: true },
+    ],
+    documents: [
+      { documentType: 'import_permit', description: 'Import permit from Australian Department of Agriculture', mandatory: true, issuingAuthority: 'Australian Department of Agriculture' },
+      { documentType: 'health_certificate', description: 'Official veterinary health certificate', mandatory: true, issuingAuthority: 'Government-accredited veterinarian' },
+    ],
+    additionalNotes: 'Australia has strict biosecurity laws. Quarantine period may apply.',
+  },
+  {
+    countryCode: 'JP',
+    countryName: 'Japan',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    vaccinations: [
+      { vaccineName: 'Rabies', mandatory: true, validForMonths: 24 },
+    ],
+    healthChecks: [
+      { checkType: 'microchip', description: 'ISO 11784/11785 compliant microchip', mandatory: true },
+      { checkType: 'rabies_titre_test', description: 'Rabies antibody titre test (≥0.5 IU/mL)', maxDaysBeforeTravel: 180, mandatory: true },
+      { checkType: 'waiting_period', description: '180-day waiting period after titre test', mandatory: true },
+    ],
+    documents: [
+      { documentType: 'advance_notification', description: 'Advance notification to Animal Quarantine Service (40 days before arrival)', mandatory: true, issuingAuthority: 'Japan Animal Quarantine Service' },
+      { documentType: 'health_certificate', description: 'Official veterinary health certificate', mandatory: true, issuingAuthority: 'Government-accredited veterinarian' },
+    ],
+    additionalNotes: 'Quarantine period of up to 180 days may apply if requirements are not met.',
+  },
+  {
+    countryCode: 'CA',
+    countryName: 'Canada',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    vaccinations: [
+      { vaccineName: 'Rabies', mandatory: true, notes: 'Required for dogs 3 months and older' },
+    ],
+    healthChecks: [
+      { checkType: 'general_health_exam', description: 'General health examination', maxDaysBeforeTravel: 30, mandatory: false },
+    ],
+    documents: [
+      { documentType: 'rabies_vaccination_certificate', description: 'Rabies vaccination certificate signed by a licensed vet', mandatory: true, issuingAuthority: 'Licensed Veterinarian' },
+    ],
+  },
+  {
+    countryCode: 'SG',
+    countryName: 'Singapore',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    vaccinations: [
+      { vaccineName: 'Rabies', mandatory: true, minWeeksBeforeTravel: 4, validForMonths: 36 },
+      { vaccineName: 'Distemper', mandatory: true },
+      { vaccineName: 'Parvovirus', mandatory: true },
+    ],
+    healthChecks: [
+      { checkType: 'microchip', description: 'ISO 11784/11785 compliant microchip', mandatory: true },
+      { checkType: 'rabies_titre_test', description: 'Rabies antibody titre test', mandatory: true },
+    ],
+    documents: [
+      { documentType: 'import_licence', description: 'Import licence from AVS', mandatory: true, issuingAuthority: 'Singapore AVS' },
+      { documentType: 'health_certificate', description: 'Official veterinary health certificate', mandatory: true, issuingAuthority: 'Government-accredited veterinarian' },
+    ],
+    additionalNotes: 'Apply for import licence at least 30 days before travel.',
+  },
+];
+
+export function getCountryRequirements(countryCode: string, species?: string): CountryTravelRequirements | undefined {
+  const req = COUNTRY_REQUIREMENTS.find((r) => r.countryCode.toUpperCase() === countryCode.toUpperCase());
+  if (!req) return undefined;
+  if (species && req.applicableSpecies.length > 0 && !req.applicableSpecies.includes(species.toLowerCase())) {
+    return undefined;
+  }
+  return req;
+}
+
+export function getSupportedCountries(): { code: string; name: string }[] {
+  return COUNTRY_REQUIREMENTS.map((r) => ({ code: r.countryCode, name: r.countryName }));
+}

--- a/backend/server/app.ts
+++ b/backend/server/app.ts
@@ -21,6 +21,7 @@ import petsRouter from './routes/pets';
 import privacyRouter from './routes/privacy';
 import searchRouter from './routes/search';
 import syncRouter from './routes/sync';
+import travelCertificatesRouter from './routes/travelCertificates';
 import usersRouter from './routes/users';
 import vetsRouter from './routes/vets';
 import { attachAudit } from '../middleware/auditLog';
@@ -80,6 +81,7 @@ export function createApp(): Express {
   api.use('/community', communityRouter);
   api.use('/photos', photosRouter);
   api.use('/sync', syncRouter);
+  api.use('/travel-certificates', travelCertificatesRouter);
   api.use('/vets', vetsRouter);
   api.use('/privacy', privacyRouter);
   api.use('/insurance', insuranceRouter);

--- a/backend/server/routes/travelCertificates.ts
+++ b/backend/server/routes/travelCertificates.ts
@@ -1,0 +1,146 @@
+/**
+ * Travel Certificate Routes
+ * Issue #123 — Pet Travel Health Certificate Generator
+ *
+ * POST   /travel-certificates/generate          — generate a certificate
+ * GET    /travel-certificates/countries          — list supported countries
+ * GET    /travel-certificates/pet/:petId         — list certificates for a pet
+ * GET    /travel-certificates/:id                — get a single certificate
+ * POST   /travel-certificates/:id/anchor         — anchor to Stellar blockchain
+ * GET    /travel-certificates/:id/pdf            — get PDF HTML content
+ */
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import express from 'express';
+
+import { authenticateJWT, type AuthenticatedRequest } from '../../middleware/auth';
+import { UserRole } from '../../models/UserRole';
+import travelCertificateService from '../../services/travelCertificateService';
+import { store } from '../store';
+import { ok, sendError } from '../response';
+
+const router = express.Router();
+
+router.use(authenticateJWT);
+
+// ── List supported countries ──────────────────────────────────────────────────
+router.get('/countries', (_req, res) => {
+  const countries = travelCertificateService.getSupportedCountries();
+  return res.json(ok(countries));
+});
+
+// ── Generate certificate ──────────────────────────────────────────────────────
+router.post('/generate', async (req: AuthenticatedRequest, res) => {
+  const { petId, destinationCountryCode, travelDate } = req.body as {
+    petId?: string;
+    destinationCountryCode?: string;
+    travelDate?: string;
+  };
+
+  if (!petId?.trim() || !destinationCountryCode?.trim() || !travelDate?.trim()) {
+    return sendError(res, 400, 'VALIDATION_ERROR', 'petId, destinationCountryCode, and travelDate are required');
+  }
+
+  // Owners can only generate certificates for their own pets
+  const pet = store.pets.get(petId.trim());
+  if (!pet) return sendError(res, 404, 'NOT_FOUND', 'Pet not found');
+
+  if (req.user!.role === UserRole.OWNER && req.user!.id !== pet.ownerId) {
+    return sendError(res, 403, 'FORBIDDEN', 'You do not have permission to generate a certificate for this pet');
+  }
+
+  try {
+    const certificate = await travelCertificateService.generate({
+      petId: petId.trim(),
+      destinationCountryCode: destinationCountryCode.trim().toUpperCase(),
+      travelDate: travelDate.trim(),
+    });
+
+    const missingRequirements = certificate.requirementChecks.filter((c) => !c.met);
+
+    return res.status(201).json(
+      ok({ certificate, missingRequirements }, 'Travel health certificate generated'),
+    );
+  } catch (error) {
+    return sendError(
+      res,
+      422,
+      'CERTIFICATE_GENERATION_FAILED',
+      error instanceof Error ? error.message : 'Failed to generate certificate',
+    );
+  }
+});
+
+// ── List certificates for a pet ───────────────────────────────────────────────
+router.get('/pet/:petId', (req: AuthenticatedRequest, res) => {
+  const { petId } = req.params;
+  const pet = store.pets.get(petId);
+  if (!pet) return sendError(res, 404, 'NOT_FOUND', 'Pet not found');
+
+  if (req.user!.role === UserRole.OWNER && req.user!.id !== pet.ownerId) {
+    return sendError(res, 403, 'FORBIDDEN', 'You do not have permission to view these certificates');
+  }
+
+  const certs = [...store.travelCertificates.values()]
+    .filter((c) => c.petId === petId)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+  return res.json(ok(certs));
+});
+
+// ── Get single certificate ────────────────────────────────────────────────────
+router.get('/:id', (req: AuthenticatedRequest, res) => {
+  const cert = store.travelCertificates.get(req.params.id);
+  if (!cert) return sendError(res, 404, 'NOT_FOUND', 'Certificate not found');
+
+  const pet = store.pets.get(cert.petId);
+  if (pet && req.user!.role === UserRole.OWNER && req.user!.id !== pet.ownerId) {
+    return sendError(res, 403, 'FORBIDDEN', 'You do not have permission to view this certificate');
+  }
+
+  return res.json(ok(cert));
+});
+
+// ── Anchor to Stellar blockchain ──────────────────────────────────────────────
+router.post('/:id/anchor', async (req: AuthenticatedRequest, res) => {
+  const cert = store.travelCertificates.get(req.params.id);
+  if (!cert) return sendError(res, 404, 'NOT_FOUND', 'Certificate not found');
+
+  const pet = store.pets.get(cert.petId);
+  if (pet && req.user!.role === UserRole.OWNER && req.user!.id !== pet.ownerId) {
+    return sendError(res, 403, 'FORBIDDEN', 'You do not have permission to anchor this certificate');
+  }
+
+  try {
+    const updated = await travelCertificateService.anchorToBlockchain(req.params.id);
+    return res.json(ok(updated, 'Certificate anchored to Stellar blockchain'));
+  } catch (error) {
+    return sendError(
+      res,
+      502,
+      'ANCHOR_FAILED',
+      error instanceof Error ? error.message : 'Failed to anchor certificate',
+    );
+  }
+});
+
+// ── Get PDF (HTML) ────────────────────────────────────────────────────────────
+router.get('/:id/pdf', (req: AuthenticatedRequest, res) => {
+  const cert = store.travelCertificates.get(req.params.id);
+  if (!cert) return sendError(res, 404, 'NOT_FOUND', 'Certificate not found');
+
+  const pet = store.pets.get(cert.petId);
+  if (pet && req.user!.role === UserRole.OWNER && req.user!.id !== pet.ownerId) {
+    return sendError(res, 403, 'FORBIDDEN', 'You do not have permission to download this certificate');
+  }
+
+  const html = travelCertificateService.generateCertificateHtml(cert);
+  res.setHeader('Content-Type', 'text/html');
+  res.setHeader(
+    'Content-Disposition',
+    `attachment; filename="travel-certificate-${cert.id}.html"`,
+  );
+  return res.send(html);
+});
+
+export default router;

--- a/backend/server/store.ts
+++ b/backend/server/store.ts
@@ -200,6 +200,37 @@ const backups = new Map<string, StoredBackup>();
 const petQrIdentities = new Map<string, StoredPetQrIdentity>();
 const emergencySessions = new Map<string, StoredEmergencySession>();
 
+// ─── Travel Certificates ──────────────────────────────────────────────────────
+
+export interface StoredTravelCertificate {
+  id: string;
+  petId: string;
+  petName: string;
+  destinationCountryCode: string;
+  destinationCountryName: string;
+  travelDate: string;
+  generatedAt: string;
+  status: 'draft' | 'ready' | 'incomplete' | 'anchored' | 'anchor_failed';
+  requirementChecks: Array<{
+    requirementType: 'vaccination' | 'health_check' | 'document';
+    requirementName: string;
+    met: boolean;
+    details?: string;
+    satisfiedAt?: string;
+    actionRequired?: string;
+  }>;
+  complianceScore: number;
+  pdfUrl?: string;
+  blockchainTxHash?: string;
+  blockchainHash?: string;
+  isBlockchainAnchored: boolean;
+  blockchainAnchoredAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const travelCertificates = new Map<string, StoredTravelCertificate>();
+
 export function newId(): string {
   return randomUUID();
 }
@@ -209,5 +240,6 @@ export const store = {
   backups,
   petQrIdentities,
   emergencySessions,
+  travelCertificates,
   newId,
 };

--- a/backend/services/travelCertificateService.ts
+++ b/backend/services/travelCertificateService.ts
@@ -1,0 +1,385 @@
+/**
+ * Travel Certificate Service — backend
+ * Issue #123 — Pet Travel Health Certificate Generator
+ *
+ * Responsibilities:
+ * - Check pet health records against destination country requirements
+ * - Generate a formatted travel health certificate (PDF via HTML template)
+ * - Anchor the certificate to Stellar blockchain
+ */
+
+import { randomUUID } from 'crypto';
+
+import { getCountryRequirements, getSupportedCountries } from '../data/countryTravelRequirements';
+import stellarAnchorService from './stellarService';
+import { store, type StoredTravelCertificate } from '../server/store';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface RequirementCheck {
+  requirementType: 'vaccination' | 'health_check' | 'document';
+  requirementName: string;
+  met: boolean;
+  details?: string;
+  satisfiedAt?: string;
+  actionRequired?: string;
+}
+
+interface GenerateInput {
+  petId: string;
+  destinationCountryCode: string;
+  travelDate: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function weeksAgo(isoDate: string): number {
+  const ms = Date.now() - new Date(isoDate).getTime();
+  return ms / (1000 * 60 * 60 * 24 * 7);
+}
+
+function monthsAgo(isoDate: string): number {
+  const ms = Date.now() - new Date(isoDate).getTime();
+  return ms / (1000 * 60 * 60 * 24 * 30.44);
+}
+
+function daysUntilTravel(travelDate: string): number {
+  const ms = new Date(travelDate).getTime() - Date.now();
+  return ms / (1000 * 60 * 60 * 24);
+}
+
+// ─── Core service ─────────────────────────────────────────────────────────────
+
+export class TravelCertificateService {
+  /**
+   * Generate a travel health certificate by checking the pet's records
+   * against the destination country's requirements.
+   */
+  async generate(input: GenerateInput): Promise<StoredTravelCertificate> {
+    const { petId, destinationCountryCode, travelDate } = input;
+
+    const pet = store.pets.get(petId);
+    if (!pet) throw new Error('Pet not found');
+
+    const countryReqs = getCountryRequirements(destinationCountryCode, pet.species);
+    if (!countryReqs) {
+      throw new Error(
+        `No travel requirements found for country "${destinationCountryCode}" and species "${pet.species}"`,
+      );
+    }
+
+    // Gather pet's medical records
+    const petRecords = [...store.medicalRecords.values()].filter((r) => r.petId === petId);
+    const vaccinationRecords = petRecords.filter((r) => r.type === 'vaccination');
+
+    const checks: RequirementCheck[] = [];
+
+    // ── Check vaccinations ──────────────────────────────────────────────────
+    for (const req of countryReqs.vaccinations) {
+      const match = vaccinationRecords.find((r) =>
+        r.treatment?.toLowerCase().includes(req.vaccineName.toLowerCase()) ||
+        r.diagnosis?.toLowerCase().includes(req.vaccineName.toLowerCase()) ||
+        r.notes?.toLowerCase().includes(req.vaccineName.toLowerCase()),
+      );
+
+      if (!match) {
+        checks.push({
+          requirementType: 'vaccination',
+          requirementName: req.vaccineName,
+          met: false,
+          actionRequired: `Schedule a ${req.vaccineName} vaccination with your vet${req.minWeeksBeforeTravel ? ` at least ${req.minWeeksBeforeTravel} weeks before travel` : ''}.`,
+        });
+        continue;
+      }
+
+      // Check timing constraints
+      const weeksAgoAdministered = weeksAgo(match.visitDate);
+      const monthsAgoAdministered = monthsAgo(match.visitDate);
+
+      if (req.minWeeksBeforeTravel && weeksAgoAdministered < req.minWeeksBeforeTravel) {
+        const daysLeft = Math.ceil((req.minWeeksBeforeTravel - weeksAgoAdministered) * 7);
+        checks.push({
+          requirementType: 'vaccination',
+          requirementName: req.vaccineName,
+          met: false,
+          details: `Vaccination administered ${Math.floor(weeksAgoAdministered)} weeks ago; must be at least ${req.minWeeksBeforeTravel} weeks before travel.`,
+          satisfiedAt: match.visitDate,
+          actionRequired: `Wait ${daysLeft} more days before traveling, or re-vaccinate.`,
+        });
+        continue;
+      }
+
+      if (req.validForMonths && monthsAgoAdministered > req.validForMonths) {
+        checks.push({
+          requirementType: 'vaccination',
+          requirementName: req.vaccineName,
+          met: false,
+          details: `Vaccination expired (administered ${Math.floor(monthsAgoAdministered)} months ago; valid for ${req.validForMonths} months).`,
+          satisfiedAt: match.visitDate,
+          actionRequired: `Renew the ${req.vaccineName} vaccination before travel.`,
+        });
+        continue;
+      }
+
+      checks.push({
+        requirementType: 'vaccination',
+        requirementName: req.vaccineName,
+        met: true,
+        details: `Administered on ${new Date(match.visitDate).toLocaleDateString()}`,
+        satisfiedAt: match.visitDate,
+      });
+    }
+
+    // ── Check health checks ─────────────────────────────────────────────────
+    for (const req of countryReqs.healthChecks) {
+      // Microchip: check pet record
+      if (req.checkType === 'microchip') {
+        const hasMicrochip = Boolean(pet.microchipId);
+        checks.push({
+          requirementType: 'health_check',
+          requirementName: req.description,
+          met: hasMicrochip,
+          details: hasMicrochip ? `Microchip ID: ${pet.microchipId}` : undefined,
+          actionRequired: hasMicrochip
+            ? undefined
+            : 'Have your vet implant an ISO 11784/11785 compliant microchip.',
+        });
+        continue;
+      }
+
+      // General health exam / other checks: look for a recent checkup record
+      const recentCheckup = petRecords
+        .filter((r) => r.type === 'checkup' || r.type === 'treatment')
+        .sort((a, b) => new Date(b.visitDate).getTime() - new Date(a.visitDate).getTime())[0];
+
+      if (!recentCheckup) {
+        checks.push({
+          requirementType: 'health_check',
+          requirementName: req.description,
+          met: false,
+          actionRequired: `Schedule a veterinary ${req.checkType.replace(/_/g, ' ')} before travel.`,
+        });
+        continue;
+      }
+
+      if (req.maxDaysBeforeTravel) {
+        const daysUntil = daysUntilTravel(travelDate);
+        const daysSinceCheck =
+          (Date.now() - new Date(recentCheckup.visitDate).getTime()) / (1000 * 60 * 60 * 24);
+        const effectiveDaysBeforeTravel = daysSinceCheck + daysUntil;
+
+        if (effectiveDaysBeforeTravel > req.maxDaysBeforeTravel) {
+          checks.push({
+            requirementType: 'health_check',
+            requirementName: req.description,
+            met: false,
+            details: `Last check was ${Math.floor(daysSinceCheck)} days ago; must be within ${req.maxDaysBeforeTravel} days of travel.`,
+            actionRequired: `Schedule a ${req.checkType.replace(/_/g, ' ')} within ${req.maxDaysBeforeTravel} days of your travel date.`,
+          });
+          continue;
+        }
+      }
+
+      checks.push({
+        requirementType: 'health_check',
+        requirementName: req.description,
+        met: true,
+        details: `Completed on ${new Date(recentCheckup.visitDate).toLocaleDateString()}`,
+        satisfiedAt: recentCheckup.visitDate,
+      });
+    }
+
+    // ── Check documents ─────────────────────────────────────────────────────
+    // Documents are flagged as actionable steps — they must be obtained by the owner
+    for (const req of countryReqs.documents) {
+      checks.push({
+        requirementType: 'document',
+        requirementName: req.description,
+        met: false, // Documents must be physically obtained; flagged as action items
+        actionRequired: `Obtain: ${req.description}${req.issuingAuthority ? ` from ${req.issuingAuthority}` : ''}.`,
+      });
+    }
+
+    // ── Compute compliance score (mandatory requirements only) ──────────────
+    const mandatoryVaccChecks = checks.filter((c) => c.requirementType === 'vaccination');
+    const mandatoryHealthChecks = checks.filter(
+      (c) => c.requirementType === 'health_check',
+    );
+    const mandatoryChecks = [...mandatoryVaccChecks, ...mandatoryHealthChecks];
+    const metCount = mandatoryChecks.filter((c) => c.met).length;
+    const complianceScore =
+      mandatoryChecks.length > 0 ? Math.round((metCount / mandatoryChecks.length) * 100) : 100;
+
+    const allMandatoryMet = mandatoryChecks.every((c) => c.met);
+    const status: StoredTravelCertificate['status'] = allMandatoryMet ? 'ready' : 'incomplete';
+
+    const now = new Date().toISOString();
+    const id = randomUUID();
+
+    const certificate: StoredTravelCertificate = {
+      id,
+      petId,
+      petName: pet.name,
+      destinationCountryCode: countryReqs.countryCode,
+      destinationCountryName: countryReqs.countryName,
+      travelDate,
+      generatedAt: now,
+      status,
+      requirementChecks: checks,
+      complianceScore,
+      isBlockchainAnchored: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    store.travelCertificates.set(id, certificate);
+    return certificate;
+  }
+
+  /** Anchor a certificate to the Stellar blockchain */
+  async anchorToBlockchain(certificateId: string): Promise<StoredTravelCertificate> {
+    const cert = store.travelCertificates.get(certificateId);
+    if (!cert) throw new Error('Certificate not found');
+
+    const result = await stellarAnchorService.anchorRecord({
+      recordId: cert.id,
+      payload: cert,
+      network: 'testnet',
+    });
+
+    const updated: StoredTravelCertificate = {
+      ...cert,
+      blockchainTxHash: result.transactionId,
+      blockchainHash: result.recordHash,
+      isBlockchainAnchored: result.status !== 'failed',
+      blockchainAnchoredAt: new Date().toISOString(),
+      status: result.status !== 'failed' ? 'anchored' : 'anchor_failed',
+      updatedAt: new Date().toISOString(),
+    };
+
+    store.travelCertificates.set(cert.id, updated);
+    return updated;
+  }
+
+  /** Generate a simple HTML-based PDF certificate */
+  generateCertificateHtml(cert: StoredTravelCertificate): string {
+    const metChecks = cert.requirementChecks.filter((c) => c.met);
+    const missingChecks = cert.requirementChecks.filter((c) => !c.met);
+
+    const checkRow = (c: (typeof cert.requirementChecks)[0]) => `
+      <tr>
+        <td style="padding:8px;border-bottom:1px solid #eee;">${c.requirementName}</td>
+        <td style="padding:8px;border-bottom:1px solid #eee;text-transform:capitalize;">${c.requirementType.replace('_', ' ')}</td>
+        <td style="padding:8px;border-bottom:1px solid #eee;color:${c.met ? '#16a34a' : '#dc2626'};font-weight:600;">${c.met ? '✓ Met' : '✗ Missing'}</td>
+        <td style="padding:8px;border-bottom:1px solid #eee;font-size:12px;color:#555;">${c.details ?? c.actionRequired ?? ''}</td>
+      </tr>`;
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <title>Pet Travel Health Certificate</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; color: #111; }
+    h1 { color: #065f46; border-bottom: 3px solid #10b981; padding-bottom: 10px; }
+    .badge { display:inline-block; padding:4px 12px; border-radius:20px; font-size:13px; font-weight:700; }
+    .badge-ready { background:#d1fae5; color:#065f46; }
+    .badge-incomplete { background:#fee2e2; color:#991b1b; }
+    .badge-anchored { background:#dbeafe; color:#1e40af; }
+    table { width:100%; border-collapse:collapse; margin-top:16px; }
+    th { background:#f3f4f6; padding:10px 8px; text-align:left; font-size:13px; color:#374151; }
+    .section { margin-top:28px; }
+    .meta { display:flex; gap:32px; margin:16px 0; }
+    .meta-item { }
+    .meta-label { font-size:12px; color:#6b7280; margin-bottom:2px; }
+    .meta-value { font-size:15px; font-weight:600; }
+    .blockchain { margin-top:24px; padding:14px; background:#eff6ff; border:1px solid #bfdbfe; border-radius:8px; font-size:12px; color:#1e40af; }
+    .score { font-size:28px; font-weight:700; color:${cert.complianceScore === 100 ? '#16a34a' : cert.complianceScore >= 60 ? '#d97706' : '#dc2626'}; }
+    .missing-section { margin-top:24px; padding:16px; background:#fef2f2; border:1px solid #fecaca; border-radius:8px; }
+    .missing-section h3 { color:#991b1b; margin:0 0 12px; }
+    .action-item { padding:6px 0; border-bottom:1px solid #fecaca; font-size:13px; }
+    .action-item:last-child { border-bottom:none; }
+    .disclaimer { margin-top:32px; font-size:11px; color:#9ca3af; border-top:1px solid #e5e7eb; padding-top:12px; }
+  </style>
+</head>
+<body>
+  <h1>🐾 Pet Travel Health Certificate</h1>
+
+  <div class="meta">
+    <div class="meta-item">
+      <div class="meta-label">Pet Name</div>
+      <div class="meta-value">${cert.petName}</div>
+    </div>
+    <div class="meta-item">
+      <div class="meta-label">Destination</div>
+      <div class="meta-value">${cert.destinationCountryName} (${cert.destinationCountryCode})</div>
+    </div>
+    <div class="meta-item">
+      <div class="meta-label">Travel Date</div>
+      <div class="meta-value">${new Date(cert.travelDate).toLocaleDateString()}</div>
+    </div>
+    <div class="meta-item">
+      <div class="meta-label">Generated</div>
+      <div class="meta-value">${new Date(cert.generatedAt).toLocaleString()}</div>
+    </div>
+    <div class="meta-item">
+      <div class="meta-label">Status</div>
+      <div class="meta-value">
+        <span class="badge badge-${cert.status}">${cert.status.toUpperCase()}</span>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <div class="meta-label">Compliance Score</div>
+    <div class="score">${cert.complianceScore}%</div>
+    <div style="font-size:13px;color:#6b7280;">${metChecks.length} of ${cert.requirementChecks.length} requirements met</div>
+  </div>
+
+  <div class="section">
+    <h2>Requirement Checks</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Requirement</th>
+          <th>Type</th>
+          <th>Status</th>
+          <th>Details / Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${cert.requirementChecks.map(checkRow).join('')}
+      </tbody>
+    </table>
+  </div>
+
+  ${missingChecks.length > 0 ? `
+  <div class="missing-section">
+    <h3>⚠️ Action Required — ${missingChecks.length} Missing Requirement${missingChecks.length > 1 ? 's' : ''}</h3>
+    ${missingChecks.map((c) => `<div class="action-item">• <strong>${c.requirementName}:</strong> ${c.actionRequired ?? 'Contact your vet.'}</div>`).join('')}
+  </div>` : ''}
+
+  ${cert.isBlockchainAnchored ? `
+  <div class="blockchain">
+    <strong>🔗 Blockchain Verified</strong><br/>
+    Transaction: ${cert.blockchainTxHash}<br/>
+    Anchored: ${cert.blockchainAnchoredAt ? new Date(cert.blockchainAnchoredAt).toLocaleString() : 'N/A'}<br/>
+    Certificate ID: ${cert.id}
+  </div>` : ''}
+
+  <div class="disclaimer">
+    This certificate was generated by PetChain and is based on the pet's recorded health data.
+    Always verify requirements with official government sources before travel.
+    Certificate ID: ${cert.id}
+  </div>
+</body>
+</html>`;
+  }
+
+  getSupportedCountries() {
+    return getSupportedCountries();
+  }
+}
+
+export const travelCertificateService = new TravelCertificateService();
+export default travelCertificateService;

--- a/src/data/countryTravelRequirements.ts
+++ b/src/data/countryTravelRequirements.ts
@@ -1,0 +1,351 @@
+/**
+ * Static database of pet travel requirements per country.
+ * Issue #123 — Pet Travel Health Certificate Generator
+ *
+ * Sources: USDA APHIS, EU Pet Travel Scheme, DEFRA, and official government portals.
+ * Last verified: 2026-05-01. Always confirm with official sources before travel.
+ */
+
+import type { CountryTravelRequirements } from '../models/TravelCertificate';
+
+export const COUNTRY_REQUIREMENTS: CountryTravelRequirements[] = [
+  {
+    countryCode: 'GB',
+    countryName: 'United Kingdom',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    officialReferenceUrl: 'https://www.gov.uk/bring-pet-to-great-britain',
+    vaccinations: [
+      {
+        vaccineName: 'Rabies',
+        minWeeksBeforeTravel: 3,
+        validForMonths: 36,
+        mandatory: true,
+        notes: 'Must be administered after microchipping',
+      },
+    ],
+    healthChecks: [
+      {
+        checkType: 'tapeworm_treatment',
+        description: 'Tapeworm treatment by a vet (dogs only)',
+        maxDaysBeforeTravel: 5,
+        mandatory: true,
+      },
+      {
+        checkType: 'microchip',
+        description: 'ISO 11784/11785 compliant microchip',
+        mandatory: true,
+      },
+    ],
+    documents: [
+      {
+        documentType: 'pet_health_certificate',
+        description: 'Official veterinary health certificate (AHC)',
+        mandatory: true,
+        issuingAuthority: 'Official Veterinarian (OV)',
+      },
+    ],
+    additionalNotes: 'Pet must enter via an approved route and port.',
+  },
+  {
+    countryCode: 'DE',
+    countryName: 'Germany',
+    applicableSpecies: ['dog', 'cat', 'rabbit'],
+    lastUpdated: '2026-01-15',
+    officialReferenceUrl: 'https://ec.europa.eu/food/animals/pet-movement_en',
+    vaccinations: [
+      {
+        vaccineName: 'Rabies',
+        minWeeksBeforeTravel: 3,
+        validForMonths: 36,
+        mandatory: true,
+      },
+    ],
+    healthChecks: [
+      {
+        checkType: 'microchip',
+        description: 'ISO 11784/11785 compliant microchip',
+        mandatory: true,
+      },
+    ],
+    documents: [
+      {
+        documentType: 'eu_pet_passport',
+        description: 'EU Pet Passport or official health certificate',
+        mandatory: true,
+        issuingAuthority: 'Accredited Veterinarian',
+      },
+    ],
+  },
+  {
+    countryCode: 'FR',
+    countryName: 'France',
+    applicableSpecies: ['dog', 'cat', 'rabbit'],
+    lastUpdated: '2026-01-15',
+    officialReferenceUrl: 'https://agriculture.gouv.fr/animaux-de-compagnie',
+    vaccinations: [
+      {
+        vaccineName: 'Rabies',
+        minWeeksBeforeTravel: 3,
+        validForMonths: 36,
+        mandatory: true,
+      },
+    ],
+    healthChecks: [
+      {
+        checkType: 'microchip',
+        description: 'ISO 11784/11785 compliant microchip',
+        mandatory: true,
+      },
+    ],
+    documents: [
+      {
+        documentType: 'eu_pet_passport',
+        description: 'EU Pet Passport or official health certificate',
+        mandatory: true,
+        issuingAuthority: 'Accredited Veterinarian',
+      },
+    ],
+  },
+  {
+    countryCode: 'US',
+    countryName: 'United States',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    officialReferenceUrl: 'https://www.aphis.usda.gov/pet-travel',
+    vaccinations: [
+      {
+        vaccineName: 'Rabies',
+        minWeeksBeforeTravel: 0,
+        validForMonths: 36,
+        mandatory: true,
+        notes: 'Required for dogs; cats recommended',
+      },
+    ],
+    healthChecks: [
+      {
+        checkType: 'general_health_exam',
+        description: 'General health examination by a licensed vet',
+        maxDaysBeforeTravel: 10,
+        mandatory: true,
+      },
+      {
+        checkType: 'screwworm_inspection',
+        description: 'Screwworm inspection (if traveling from affected countries)',
+        mandatory: false,
+      },
+    ],
+    documents: [
+      {
+        documentType: 'usda_health_certificate',
+        description: 'USDA-endorsed health certificate (APHIS 7001)',
+        mandatory: true,
+        issuingAuthority: 'USDA-accredited veterinarian',
+      },
+    ],
+    additionalNotes: 'Dogs must be vaccinated against rabies if traveling from high-risk countries.',
+  },
+  {
+    countryCode: 'AU',
+    countryName: 'Australia',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    officialReferenceUrl: 'https://www.agriculture.gov.au/biosecurity-trade/cats-dogs',
+    vaccinations: [
+      {
+        vaccineName: 'Rabies',
+        minWeeksBeforeTravel: 0,
+        validForMonths: 12,
+        mandatory: true,
+      },
+      {
+        vaccineName: 'Leptospirosis',
+        mandatory: false,
+        notes: 'Recommended for dogs',
+      },
+    ],
+    healthChecks: [
+      {
+        checkType: 'microchip',
+        description: 'ISO 11784/11785 compliant microchip',
+        mandatory: true,
+      },
+      {
+        checkType: 'rabies_titre_test',
+        description: 'Rabies neutralising antibody titre test (RNATT)',
+        maxDaysBeforeTravel: 180,
+        mandatory: true,
+      },
+      {
+        checkType: 'parasite_treatment',
+        description: 'Treatment for internal and external parasites',
+        maxDaysBeforeTravel: 5,
+        mandatory: true,
+      },
+    ],
+    documents: [
+      {
+        documentType: 'import_permit',
+        description: 'Import permit from Australian Department of Agriculture',
+        mandatory: true,
+        issuingAuthority: 'Australian Department of Agriculture',
+      },
+      {
+        documentType: 'health_certificate',
+        description: 'Official veterinary health certificate',
+        mandatory: true,
+        issuingAuthority: 'Government-accredited veterinarian',
+      },
+    ],
+    additionalNotes: 'Australia has strict biosecurity laws. Quarantine period may apply.',
+  },
+  {
+    countryCode: 'JP',
+    countryName: 'Japan',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    officialReferenceUrl: 'https://www.maff.go.jp/aqs/english/animal/dog/index.html',
+    vaccinations: [
+      {
+        vaccineName: 'Rabies',
+        minWeeksBeforeTravel: 0,
+        validForMonths: 24,
+        mandatory: true,
+      },
+    ],
+    healthChecks: [
+      {
+        checkType: 'microchip',
+        description: 'ISO 11784/11785 compliant microchip',
+        mandatory: true,
+      },
+      {
+        checkType: 'rabies_titre_test',
+        description: 'Rabies antibody titre test (≥0.5 IU/mL)',
+        maxDaysBeforeTravel: 180,
+        mandatory: true,
+      },
+      {
+        checkType: 'waiting_period',
+        description: '180-day waiting period after titre test',
+        mandatory: true,
+      },
+    ],
+    documents: [
+      {
+        documentType: 'advance_notification',
+        description: 'Advance notification to Animal Quarantine Service (40 days before arrival)',
+        mandatory: true,
+        issuingAuthority: 'Japan Animal Quarantine Service',
+      },
+      {
+        documentType: 'health_certificate',
+        description: 'Official veterinary health certificate',
+        mandatory: true,
+        issuingAuthority: 'Government-accredited veterinarian',
+      },
+    ],
+    additionalNotes: 'Quarantine period of up to 180 days may apply if requirements are not met.',
+  },
+  {
+    countryCode: 'CA',
+    countryName: 'Canada',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    officialReferenceUrl: 'https://inspection.canada.ca/importing-food-plants-or-animals/pets',
+    vaccinations: [
+      {
+        vaccineName: 'Rabies',
+        mandatory: true,
+        notes: 'Required for dogs 3 months and older',
+      },
+    ],
+    healthChecks: [
+      {
+        checkType: 'general_health_exam',
+        description: 'General health examination',
+        maxDaysBeforeTravel: 30,
+        mandatory: false,
+      },
+    ],
+    documents: [
+      {
+        documentType: 'rabies_vaccination_certificate',
+        description: 'Rabies vaccination certificate signed by a licensed vet',
+        mandatory: true,
+        issuingAuthority: 'Licensed Veterinarian',
+      },
+    ],
+  },
+  {
+    countryCode: 'SG',
+    countryName: 'Singapore',
+    applicableSpecies: ['dog', 'cat'],
+    lastUpdated: '2026-01-15',
+    officialReferenceUrl: 'https://www.nparks.gov.sg/avs/pets/bringing-animals-into-singapore',
+    vaccinations: [
+      {
+        vaccineName: 'Rabies',
+        mandatory: true,
+        minWeeksBeforeTravel: 4,
+        validForMonths: 36,
+      },
+      {
+        vaccineName: 'Distemper',
+        mandatory: true,
+      },
+      {
+        vaccineName: 'Parvovirus',
+        mandatory: true,
+      },
+    ],
+    healthChecks: [
+      {
+        checkType: 'microchip',
+        description: 'ISO 11784/11785 compliant microchip',
+        mandatory: true,
+      },
+      {
+        checkType: 'rabies_titre_test',
+        description: 'Rabies antibody titre test',
+        mandatory: true,
+      },
+    ],
+    documents: [
+      {
+        documentType: 'import_licence',
+        description: 'Import licence from AVS (Animals & Veterinary Service)',
+        mandatory: true,
+        issuingAuthority: 'Singapore AVS',
+      },
+      {
+        documentType: 'health_certificate',
+        description: 'Official veterinary health certificate',
+        mandatory: true,
+        issuingAuthority: 'Government-accredited veterinarian',
+      },
+    ],
+    additionalNotes: 'Quarantine period applies. Apply for import licence at least 30 days before travel.',
+  },
+];
+
+/** Look up requirements for a given country code and species */
+export function getCountryRequirements(
+  countryCode: string,
+  species?: string,
+): CountryTravelRequirements | undefined {
+  const req = COUNTRY_REQUIREMENTS.find(
+    (r) => r.countryCode.toUpperCase() === countryCode.toUpperCase(),
+  );
+  if (!req) return undefined;
+  if (species && req.applicableSpecies.length > 0) {
+    const applies = req.applicableSpecies.includes(species.toLowerCase());
+    if (!applies) return undefined;
+  }
+  return req;
+}
+
+/** Return all supported countries as { code, name } pairs */
+export function getSupportedCountries(): { code: string; name: string }[] {
+  return COUNTRY_REQUIREMENTS.map((r) => ({ code: r.countryCode, name: r.countryName }));
+}

--- a/src/models/TravelCertificate.ts
+++ b/src/models/TravelCertificate.ts
@@ -1,0 +1,102 @@
+/**
+ * Travel Health Certificate domain models.
+ * Issue #123 — Pet Travel Health Certificate Generator
+ */
+
+// ─── Country Requirements ─────────────────────────────────────────────────────
+
+export interface VaccinationRequirement {
+  vaccineName: string;
+  /** Minimum weeks before travel the vaccine must have been administered */
+  minWeeksBeforeTravel?: number;
+  /** Maximum months the vaccine is valid for travel */
+  validForMonths?: number;
+  mandatory: boolean;
+  notes?: string;
+}
+
+export interface HealthCheckRequirement {
+  checkType: string;
+  description: string;
+  /** Days before travel the check must be performed */
+  maxDaysBeforeTravel?: number;
+  mandatory: boolean;
+}
+
+export interface DocumentRequirement {
+  documentType: string;
+  description: string;
+  mandatory: boolean;
+  issuingAuthority?: string;
+}
+
+export interface CountryTravelRequirements {
+  countryCode: string; // ISO 3166-1 alpha-2
+  countryName: string;
+  /** Species this requirement applies to; empty = all species */
+  applicableSpecies: string[];
+  vaccinations: VaccinationRequirement[];
+  healthChecks: HealthCheckRequirement[];
+  documents: DocumentRequirement[];
+  /** ISO 8601 date when these requirements were last verified */
+  lastUpdated: string;
+  officialReferenceUrl?: string;
+  additionalNotes?: string;
+}
+
+// ─── Certificate ──────────────────────────────────────────────────────────────
+
+export type CertificateStatus =
+  | 'draft'
+  | 'ready'
+  | 'incomplete'
+  | 'anchored'
+  | 'anchor_failed';
+
+export interface CertificateRequirementCheck {
+  requirementType: 'vaccination' | 'health_check' | 'document';
+  requirementName: string;
+  met: boolean;
+  details?: string;
+  /** ISO date the requirement was satisfied */
+  satisfiedAt?: string;
+  /** Actionable step if not met */
+  actionRequired?: string;
+}
+
+export interface TravelHealthCertificate {
+  id: string;
+  petId: string;
+  petName: string;
+  destinationCountryCode: string;
+  destinationCountryName: string;
+  /** Planned travel date (ISO date string) */
+  travelDate: string;
+  /** ISO timestamp when the certificate was generated */
+  generatedAt: string;
+  status: CertificateStatus;
+  requirementChecks: CertificateRequirementCheck[];
+  /** Overall compliance: percentage of mandatory requirements met */
+  complianceScore: number;
+  /** PDF download URL (populated after generation) */
+  pdfUrl?: string;
+  // Blockchain anchoring
+  blockchainTxHash?: string;
+  blockchainHash?: string;
+  isBlockchainAnchored: boolean;
+  blockchainAnchoredAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GenerateCertificateRequest {
+  petId: string;
+  destinationCountryCode: string;
+  travelDate: string;
+}
+
+export interface GenerateCertificateResponse {
+  certificate: TravelHealthCertificate;
+  missingRequirements: CertificateRequirementCheck[];
+  pdfUrl?: string;
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -27,6 +27,7 @@ import PetHealthDashboardScreen from '../screens/PetHealthDashboardScreen';
 import PetHealthMetricsScreen from '../screens/PetHealthMetricsScreen';
 import PetListScreen from '../screens/PetListScreen';
 import PetShareScreen from '../screens/PetShareScreen';
+import TravelCertificateScreen from '../screens/TravelCertificateScreen';
 import ProfileScreen from '../screens/ProfileScreen';
 import QRScannerScreen from '../screens/QRScannerScreen';
 import analyticsService from '../services/analyticsService';
@@ -114,6 +115,15 @@ function PetNavigator() {
       <PetStack.Screen name="PetShare" options={{ title: 'Share Pet Profile' }}>
         {({ route, navigation }) => (
           <PetShareScreen
+            petId={route.params.petId}
+            petName={route.params.petName}
+            onBack={() => navigation.goBack()}
+          />
+        )}
+      </PetStack.Screen>
+      <PetStack.Screen name="TravelCertificate" options={{ title: 'Travel Health Certificate' }}>
+        {({ route, navigation }) => (
+          <TravelCertificateScreen
             petId={route.params.petId}
             petName={route.params.petName}
             onBack={() => navigation.goBack()}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -36,6 +36,7 @@ export type PetStackParamList = {
   MedicalRecordSearch: { petId: string };
   MedicalRecordViewer: { petId: string; petName?: string };
   PetShare: { petId: string; petName: string };
+  TravelCertificate: { petId: string; petName?: string };
   DosageCalculator: { petId?: string; species?: string; weightKg?: number };
   NearbyVet: undefined;
   VetDirectory: undefined;

--- a/src/screens/TravelCertificateScreen.tsx
+++ b/src/screens/TravelCertificateScreen.tsx
@@ -1,0 +1,738 @@
+/**
+ * TravelCertificateScreen
+ * Issue #123 — Pet Travel Health Certificate Generator
+ *
+ * Allows users to:
+ * 1. Select a destination country
+ * 2. Set a travel date
+ * 3. Generate a travel health certificate
+ * 4. View compliance status and missing requirements with actionable steps
+ * 5. Anchor the certificate to the Stellar blockchain
+ * 6. Download/share the PDF certificate
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import {
+  generateTravelCertificate,
+  getPetTravelCertificates,
+  anchorCertificateToBlockchain,
+  getCertificatePdfUrl,
+  getMissingRequirements,
+  getComplianceSummary,
+  TravelCertificateError,
+} from '../services/travelCertificateService';
+import { getSupportedCountries } from '../data/countryTravelRequirements';
+import type {
+  TravelHealthCertificate,
+  CertificateRequirementCheck,
+} from '../models/TravelCertificate';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  petId: string;
+  petName?: string;
+  onBack: () => void;
+}
+
+type Screen = 'list' | 'generate' | 'detail';
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+const TravelCertificateScreen: React.FC<Props> = ({ petId, petName, onBack }) => {
+  const [screen, setScreen] = useState<Screen>('list');
+  const [certificates, setCertificates] = useState<TravelHealthCertificate[]>([]);
+  const [selectedCert, setSelectedCert] = useState<TravelHealthCertificate | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [anchoring, setAnchoring] = useState(false);
+
+  // Generate form state
+  const [countryPickerVisible, setCountryPickerVisible] = useState(false);
+  const [selectedCountry, setSelectedCountry] = useState<{ code: string; name: string } | null>(null);
+  const [travelDate, setTravelDate] = useState('');
+  const [countrySearch, setCountrySearch] = useState('');
+
+  const countries = getSupportedCountries();
+  const filteredCountries = countries.filter((c) =>
+    c.name.toLowerCase().includes(countrySearch.toLowerCase()),
+  );
+
+  // ── Data loading ────────────────────────────────────────────────────────────
+
+  const loadCertificates = useCallback(async () => {
+    setLoading(true);
+    try {
+      const certs = await getPetTravelCertificates(petId);
+      setCertificates(certs);
+    } catch {
+      Alert.alert('Error', 'Failed to load travel certificates.');
+    } finally {
+      setLoading(false);
+    }
+  }, [petId]);
+
+  useEffect(() => {
+    if (screen === 'list') void loadCertificates();
+  }, [screen, loadCertificates]);
+
+  // ── Generate ────────────────────────────────────────────────────────────────
+
+  const handleGenerate = async () => {
+    if (!selectedCountry) {
+      Alert.alert('Missing Info', 'Please select a destination country.');
+      return;
+    }
+    if (!travelDate.trim() || !/^\d{4}-\d{2}-\d{2}$/.test(travelDate.trim())) {
+      Alert.alert('Missing Info', 'Please enter a valid travel date (YYYY-MM-DD).');
+      return;
+    }
+    if (new Date(travelDate) <= new Date()) {
+      Alert.alert('Invalid Date', 'Travel date must be in the future.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await generateTravelCertificate({
+        petId,
+        destinationCountryCode: selectedCountry.code,
+        travelDate: travelDate.trim(),
+      });
+      setSelectedCert(result.certificate);
+      setScreen('detail');
+    } catch (error) {
+      const msg =
+        error instanceof TravelCertificateError
+          ? error.message
+          : 'Failed to generate certificate. Please try again.';
+      Alert.alert('Error', msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // ── Anchor ──────────────────────────────────────────────────────────────────
+
+  const handleAnchor = async () => {
+    if (!selectedCert) return;
+    Alert.alert(
+      'Anchor to Blockchain',
+      'This will permanently record this certificate on the Stellar blockchain. Continue?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Anchor',
+          onPress: async () => {
+            setAnchoring(true);
+            try {
+              const updated = await anchorCertificateToBlockchain(selectedCert.id);
+              setSelectedCert(updated);
+              Alert.alert('Success', 'Certificate anchored to Stellar blockchain.');
+            } catch {
+              Alert.alert('Error', 'Failed to anchor certificate. Please try again.');
+            } finally {
+              setAnchoring(false);
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  // ── Download PDF ────────────────────────────────────────────────────────────
+
+  const handleDownloadPdf = async () => {
+    if (!selectedCert) return;
+    try {
+      const url = await getCertificatePdfUrl(selectedCert.id);
+      Alert.alert('PDF Ready', `Certificate PDF available at:\n${url}`);
+    } catch {
+      Alert.alert('Error', 'Failed to get PDF. Please try again.');
+    }
+  };
+
+  // ── Render helpers ──────────────────────────────────────────────────────────
+
+  const renderCertCard = ({ item }: { item: TravelHealthCertificate }) => (
+    <TouchableOpacity
+      style={styles.card}
+      onPress={() => {
+        setSelectedCert(item);
+        setScreen('detail');
+      }}
+      accessibilityRole="button"
+      accessibilityLabel={`Certificate for ${item.destinationCountryName}`}
+    >
+      <View style={styles.cardRow}>
+        <Text style={styles.cardCountry}>{item.destinationCountryName}</Text>
+        <View style={[styles.statusBadge, statusBadgeStyle(item.status)]}>
+          <Text style={styles.statusBadgeText}>{item.status.toUpperCase()}</Text>
+        </View>
+      </View>
+      <Text style={styles.cardMeta}>
+        Travel: {new Date(item.travelDate).toLocaleDateString()}
+      </Text>
+      <Text style={styles.cardMeta}>
+        Compliance: {item.complianceScore}% · Generated:{' '}
+        {new Date(item.generatedAt).toLocaleDateString()}
+      </Text>
+      {item.isBlockchainAnchored && (
+        <Text style={styles.anchoredBadge}>🔗 Blockchain Anchored</Text>
+      )}
+    </TouchableOpacity>
+  );
+
+  const renderRequirementCheck = (check: CertificateRequirementCheck, idx: number) => (
+    <View key={idx} style={[styles.checkRow, check.met ? styles.checkMet : styles.checkMissing]}>
+      <View style={styles.checkHeader}>
+        <Text style={styles.checkIcon}>{check.met ? '✓' : '✗'}</Text>
+        <View style={styles.checkContent}>
+          <Text style={styles.checkName}>{check.requirementName}</Text>
+          <View style={[styles.typePill, typePillStyle(check.requirementType)]}>
+            <Text style={styles.typePillText}>
+              {check.requirementType.replace('_', ' ')}
+            </Text>
+          </View>
+        </View>
+      </View>
+      {check.details ? (
+        <Text style={styles.checkDetails}>{check.details}</Text>
+      ) : null}
+      {!check.met && check.actionRequired ? (
+        <View style={styles.actionBox}>
+          <Text style={styles.actionLabel}>Action required:</Text>
+          <Text style={styles.actionText}>{check.actionRequired}</Text>
+        </View>
+      ) : null}
+    </View>
+  );
+
+  // ── Screens ─────────────────────────────────────────────────────────────────
+
+  if (screen === 'detail' && selectedCert) {
+    const missing = getMissingRequirements(selectedCert);
+    const summary = getComplianceSummary(selectedCert);
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity
+            onPress={() => setScreen('list')}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+          >
+            <Text style={styles.backText}>‹ Back</Text>
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Travel Certificate</Text>
+          <View style={{ width: 50 }} />
+        </View>
+
+        <ScrollView contentContainerStyle={styles.detailBody}>
+          {/* Summary card */}
+          <View style={styles.summaryCard}>
+            <Text style={styles.summaryCountry}>{selectedCert.destinationCountryName}</Text>
+            <Text style={styles.summaryDate}>
+              Travel: {new Date(selectedCert.travelDate).toLocaleDateString()}
+            </Text>
+            <View style={styles.summaryRow}>
+              <View style={[styles.statusBadge, statusBadgeStyle(selectedCert.status)]}>
+                <Text style={styles.statusBadgeText}>{selectedCert.status.toUpperCase()}</Text>
+              </View>
+              <Text style={styles.summaryScore}>{selectedCert.complianceScore}%</Text>
+            </View>
+            <Text style={styles.summaryMeta}>{summary}</Text>
+          </View>
+
+          {/* Missing requirements alert */}
+          {missing.length > 0 && (
+            <View style={styles.alertBox}>
+              <Text style={styles.alertTitle}>
+                ⚠️ {missing.length} Missing Requirement{missing.length > 1 ? 's' : ''}
+              </Text>
+              {missing.map((c, i) => (
+                <Text key={i} style={styles.alertItem}>
+                  • {c.requirementName}: {c.actionRequired}
+                </Text>
+              ))}
+            </View>
+          )}
+
+          {/* All requirement checks */}
+          <Text style={styles.sectionTitle}>Requirement Checks</Text>
+          {selectedCert.requirementChecks.map(renderRequirementCheck)}
+
+          {/* Blockchain section */}
+          <Text style={styles.sectionTitle}>Blockchain</Text>
+          {selectedCert.isBlockchainAnchored ? (
+            <View style={styles.blockchainCard}>
+              <Text style={styles.blockchainTitle}>🔗 Anchored on Stellar</Text>
+              <Text style={styles.blockchainMeta}>
+                TX: {selectedCert.blockchainTxHash}
+              </Text>
+              <Text style={styles.blockchainMeta}>
+                Anchored: {selectedCert.blockchainAnchoredAt
+                  ? new Date(selectedCert.blockchainAnchoredAt).toLocaleString()
+                  : 'N/A'}
+              </Text>
+            </View>
+          ) : (
+            <TouchableOpacity
+              style={[styles.anchorBtn, anchoring && styles.btnDisabled]}
+              onPress={() => void handleAnchor()}
+              disabled={anchoring}
+              accessibilityRole="button"
+              accessibilityLabel="Anchor certificate to Stellar blockchain"
+            >
+              {anchoring ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <Text style={styles.anchorBtnText}>🔗 Anchor to Stellar Blockchain</Text>
+              )}
+            </TouchableOpacity>
+          )}
+
+          {/* PDF download */}
+          <TouchableOpacity
+            style={styles.pdfBtn}
+            onPress={() => void handleDownloadPdf()}
+            accessibilityRole="button"
+            accessibilityLabel="Download PDF certificate"
+          >
+            <Text style={styles.pdfBtnText}>📄 Download PDF Certificate</Text>
+          </TouchableOpacity>
+
+          <Text style={styles.disclaimer}>
+            Certificate ID: {selectedCert.id}{'\n'}
+            Generated: {new Date(selectedCert.generatedAt).toLocaleString()}{'\n'}
+            Always verify requirements with official government sources before travel.
+          </Text>
+        </ScrollView>
+      </View>
+    );
+  }
+
+  if (screen === 'generate') {
+    return (
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity
+            onPress={() => setScreen('list')}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+          >
+            <Text style={styles.backText}>‹ Back</Text>
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>New Certificate</Text>
+          <View style={{ width: 50 }} />
+        </View>
+
+        <ScrollView contentContainerStyle={styles.formBody}>
+          <Text style={styles.formLabel}>Destination Country</Text>
+          <TouchableOpacity
+            style={styles.countrySelector}
+            onPress={() => setCountryPickerVisible(true)}
+            accessibilityRole="button"
+            accessibilityLabel="Select destination country"
+          >
+            <Text style={selectedCountry ? styles.countrySelectorText : styles.countrySelectorPlaceholder}>
+              {selectedCountry ? `${selectedCountry.name} (${selectedCountry.code})` : 'Select a country…'}
+            </Text>
+            <Text style={styles.chevron}>›</Text>
+          </TouchableOpacity>
+
+          <Text style={styles.formLabel}>Travel Date</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="YYYY-MM-DD"
+            placeholderTextColor="#9CA3AF"
+            value={travelDate}
+            onChangeText={setTravelDate}
+            keyboardType="numeric"
+            accessibilityLabel="Travel date"
+          />
+
+          <TouchableOpacity
+            style={[styles.generateBtn, loading && styles.btnDisabled]}
+            onPress={() => void handleGenerate()}
+            disabled={loading}
+            accessibilityRole="button"
+            accessibilityLabel="Generate travel health certificate"
+          >
+            {loading ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.generateBtnText}>Generate Certificate</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+
+        {/* Country picker modal */}
+        <Modal
+          visible={countryPickerVisible}
+          animationType="slide"
+          transparent
+          onRequestClose={() => setCountryPickerVisible(false)}
+        >
+          <View style={styles.overlay}>
+            <View style={styles.pickerSheet}>
+              <View style={styles.pickerHeader}>
+                <Text style={styles.pickerTitle}>Select Country</Text>
+                <TouchableOpacity onPress={() => setCountryPickerVisible(false)}>
+                  <Text style={styles.pickerClose}>✕</Text>
+                </TouchableOpacity>
+              </View>
+              <TextInput
+                style={styles.pickerSearch}
+                placeholder="Search countries…"
+                placeholderTextColor="#9CA3AF"
+                value={countrySearch}
+                onChangeText={setCountrySearch}
+                accessibilityLabel="Search countries"
+              />
+              <FlatList
+                data={filteredCountries}
+                keyExtractor={(c) => c.code}
+                renderItem={({ item }) => (
+                  <TouchableOpacity
+                    style={[
+                      styles.countryItem,
+                      selectedCountry?.code === item.code && styles.countryItemActive,
+                    ]}
+                    onPress={() => {
+                      setSelectedCountry(item);
+                      setCountryPickerVisible(false);
+                      setCountrySearch('');
+                    }}
+                    accessibilityRole="button"
+                    accessibilityLabel={item.name}
+                  >
+                    <Text
+                      style={[
+                        styles.countryItemText,
+                        selectedCountry?.code === item.code && styles.countryItemTextActive,
+                      ]}
+                    >
+                      {item.name}
+                    </Text>
+                    <Text style={styles.countryCode}>{item.code}</Text>
+                  </TouchableOpacity>
+                )}
+              />
+            </View>
+          </View>
+        </Modal>
+      </View>
+    );
+  }
+
+  // ── List screen ─────────────────────────────────────────────────────────────
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onBack} accessibilityRole="button" accessibilityLabel="Back">
+          <Text style={styles.backText}>‹ Back</Text>
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>
+          {petName ? `${petName}'s Travel Certs` : 'Travel Certificates'}
+        </Text>
+        <TouchableOpacity
+          onPress={() => setScreen('generate')}
+          accessibilityRole="button"
+          accessibilityLabel="New certificate"
+        >
+          <Text style={styles.newBtn}>+ New</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading ? (
+        <ActivityIndicator style={styles.loader} size="large" color="#10B981" />
+      ) : (
+        <FlatList
+          data={certificates}
+          keyExtractor={(c) => c.id}
+          renderItem={renderCertCard}
+          contentContainerStyle={
+            certificates.length === 0 ? styles.emptyContainer : styles.list
+          }
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyIcon}>✈️</Text>
+              <Text style={styles.emptyTitle}>No travel certificates yet</Text>
+              <Text style={styles.emptySubtitle}>
+                Generate a certificate to check if {petName ?? 'your pet'} meets the requirements
+                for your destination country.
+              </Text>
+              <TouchableOpacity
+                style={styles.generateBtn}
+                onPress={() => setScreen('generate')}
+                accessibilityRole="button"
+              >
+                <Text style={styles.generateBtnText}>Generate Certificate</Text>
+              </TouchableOpacity>
+            </View>
+          }
+          onRefresh={() => void loadCertificates()}
+          refreshing={loading}
+        />
+      )}
+    </View>
+  );
+};
+
+// ─── Style helpers ────────────────────────────────────────────────────────────
+
+const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
+  ready: { bg: '#D1FAE5', text: '#065F46' },
+  incomplete: { bg: '#FEE2E2', text: '#991B1B' },
+  anchored: { bg: '#DBEAFE', text: '#1E40AF' },
+  anchor_failed: { bg: '#FEF3C7', text: '#92400E' },
+  draft: { bg: '#F3F4F6', text: '#374151' },
+};
+
+const statusBadgeStyle = (status: string) => {
+  const c = STATUS_COLORS[status] ?? STATUS_COLORS.draft;
+  return { backgroundColor: c.bg };
+};
+
+const TYPE_PILL_COLORS: Record<string, { bg: string; text: string }> = {
+  vaccination: { bg: '#D1FAE5', text: '#065F46' },
+  health_check: { bg: '#E0F2FE', text: '#0369A1' },
+  document: { bg: '#F3E8FF', text: '#6B21A8' },
+};
+
+const typePillStyle = (type: string) => {
+  const c = TYPE_PILL_COLORS[type] ?? { bg: '#F3F4F6', text: '#374151' };
+  return { backgroundColor: c.bg };
+};
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#F9FAFB' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '#1F2937',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  backText: { color: '#10B981', fontSize: 16, fontWeight: '600', minWidth: 50 },
+  headerTitle: { color: '#fff', fontSize: 17, fontWeight: '700', flex: 1, textAlign: 'center' },
+  newBtn: { color: '#10B981', fontSize: 15, fontWeight: '700', minWidth: 50, textAlign: 'right' },
+  loader: { marginTop: 40 },
+  list: { padding: 12 },
+  emptyContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 32 },
+  emptyState: { alignItems: 'center' },
+  emptyIcon: { fontSize: 48, marginBottom: 12 },
+  emptyTitle: { fontSize: 18, fontWeight: '700', color: '#111827', marginBottom: 8 },
+  emptySubtitle: { fontSize: 14, color: '#6B7280', textAlign: 'center', marginBottom: 24, lineHeight: 20 },
+
+  // Certificate card
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 14,
+    marginBottom: 10,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  cardRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 },
+  cardCountry: { fontSize: 16, fontWeight: '700', color: '#111827', flex: 1 },
+  cardMeta: { fontSize: 12, color: '#6B7280', marginTop: 2 },
+  anchoredBadge: { fontSize: 11, color: '#1E40AF', marginTop: 4, fontWeight: '600' },
+
+  // Status badge
+  statusBadge: { borderRadius: 6, paddingHorizontal: 8, paddingVertical: 3 },
+  statusBadgeText: { fontSize: 11, fontWeight: '700', color: '#374151' },
+
+  // Detail
+  detailBody: { padding: 16 },
+  summaryCard: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  summaryCountry: { fontSize: 20, fontWeight: '700', color: '#111827', marginBottom: 4 },
+  summaryDate: { fontSize: 14, color: '#6B7280', marginBottom: 10 },
+  summaryRow: { flexDirection: 'row', alignItems: 'center', gap: 12, marginBottom: 6 },
+  summaryScore: { fontSize: 28, fontWeight: '800', color: '#10B981' },
+  summaryMeta: { fontSize: 13, color: '#6B7280' },
+
+  alertBox: {
+    backgroundColor: '#FEF2F2',
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: '#FECACA',
+  },
+  alertTitle: { fontSize: 14, fontWeight: '700', color: '#991B1B', marginBottom: 8 },
+  alertItem: { fontSize: 13, color: '#7F1D1D', marginBottom: 4, lineHeight: 18 },
+
+  sectionTitle: { fontSize: 15, fontWeight: '700', color: '#374151', marginBottom: 10, marginTop: 8 },
+
+  // Requirement checks
+  checkRow: {
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 8,
+    borderWidth: 1,
+  },
+  checkMet: { backgroundColor: '#F0FDF4', borderColor: '#BBF7D0' },
+  checkMissing: { backgroundColor: '#FFF7F7', borderColor: '#FECACA' },
+  checkHeader: { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
+  checkIcon: { fontSize: 16, fontWeight: '700', marginTop: 1 },
+  checkContent: { flex: 1 },
+  checkName: { fontSize: 14, fontWeight: '600', color: '#111827', marginBottom: 4 },
+  checkDetails: { fontSize: 12, color: '#6B7280', marginTop: 4 },
+  typePill: { alignSelf: 'flex-start', borderRadius: 10, paddingHorizontal: 8, paddingVertical: 2 },
+  typePillText: { fontSize: 11, fontWeight: '600', color: '#374151', textTransform: 'capitalize' },
+  actionBox: {
+    marginTop: 8,
+    backgroundColor: '#FEF3C7',
+    borderRadius: 6,
+    padding: 8,
+  },
+  actionLabel: { fontSize: 11, fontWeight: '700', color: '#92400E', marginBottom: 2 },
+  actionText: { fontSize: 12, color: '#78350F', lineHeight: 16 },
+
+  // Blockchain
+  blockchainCard: {
+    backgroundColor: '#EFF6FF',
+    borderRadius: 10,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: '#BFDBFE',
+    marginBottom: 12,
+  },
+  blockchainTitle: { fontSize: 14, fontWeight: '700', color: '#1E40AF', marginBottom: 6 },
+  blockchainMeta: { fontSize: 12, color: '#1E3A8A', marginBottom: 2 },
+
+  anchorBtn: {
+    backgroundColor: '#4F46E5',
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  anchorBtnText: { color: '#fff', fontWeight: '700', fontSize: 15 },
+
+  pdfBtn: {
+    backgroundColor: '#10B981',
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  pdfBtnText: { color: '#fff', fontWeight: '700', fontSize: 15 },
+
+  btnDisabled: { opacity: 0.6 },
+
+  disclaimer: {
+    fontSize: 11,
+    color: '#9CA3AF',
+    textAlign: 'center',
+    lineHeight: 16,
+    marginBottom: 32,
+  },
+
+  // Generate form
+  formBody: { padding: 20 },
+  formLabel: { fontSize: 13, fontWeight: '600', color: '#374151', marginBottom: 8, marginTop: 16 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 15,
+    color: '#111827',
+    backgroundColor: '#fff',
+  },
+  countrySelector: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    backgroundColor: '#fff',
+  },
+  countrySelectorText: { fontSize: 15, color: '#111827' },
+  countrySelectorPlaceholder: { fontSize: 15, color: '#9CA3AF' },
+  chevron: { fontSize: 18, color: '#9CA3AF' },
+
+  generateBtn: {
+    backgroundColor: '#10B981',
+    borderRadius: 10,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 28,
+  },
+  generateBtnText: { color: '#fff', fontWeight: '700', fontSize: 16 },
+
+  // Country picker modal
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', justifyContent: 'flex-end' },
+  pickerSheet: {
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    padding: 20,
+    maxHeight: '75%',
+  },
+  pickerHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 14,
+  },
+  pickerTitle: { fontSize: 18, fontWeight: '700', color: '#111827' },
+  pickerClose: { fontSize: 20, color: '#6B7280' },
+  pickerSearch: {
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 14,
+    color: '#111827',
+    marginBottom: 10,
+  },
+  countryItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+  },
+  countryItemActive: { backgroundColor: '#F0FDF4' },
+  countryItemText: { fontSize: 15, color: '#111827' },
+  countryItemTextActive: { color: '#065F46', fontWeight: '600' },
+  countryCode: { fontSize: 13, color: '#9CA3AF', fontWeight: '600' },
+});
+
+export default TravelCertificateScreen;

--- a/src/services/travelCertificateService.ts
+++ b/src/services/travelCertificateService.ts
@@ -1,0 +1,114 @@
+/**
+ * Travel Health Certificate Service
+ * Issue #123 — Pet Travel Health Certificate Generator
+ *
+ * Handles:
+ * - Checking pet health records against destination country requirements
+ * - Generating travel health certificates via the backend
+ * - Anchoring certificates to the Stellar blockchain
+ */
+
+import apiClient from './apiClient';
+import type {
+  TravelHealthCertificate,
+  GenerateCertificateRequest,
+  GenerateCertificateResponse,
+  CertificateRequirementCheck,
+} from '../models/TravelCertificate';
+
+export class TravelCertificateError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = 'TravelCertificateError';
+  }
+}
+
+// ─── API calls ────────────────────────────────────────────────────────────────
+
+/** Generate a travel health certificate for a pet traveling to a destination country */
+export async function generateTravelCertificate(
+  req: GenerateCertificateRequest,
+): Promise<GenerateCertificateResponse> {
+  try {
+    const res = await apiClient.post<{ success: boolean; data: GenerateCertificateResponse }>(
+      '/travel-certificates/generate',
+      req,
+    );
+    return res.data.data;
+  } catch (error) {
+    throw new TravelCertificateError('Failed to generate travel certificate', 'GENERATE_FAILED');
+  }
+}
+
+/** Fetch all travel certificates for a pet */
+export async function getPetTravelCertificates(
+  petId: string,
+): Promise<TravelHealthCertificate[]> {
+  try {
+    const res = await apiClient.get<{ success: boolean; data: TravelHealthCertificate[] }>(
+      `/travel-certificates/pet/${petId}`,
+    );
+    return res.data.data;
+  } catch {
+    throw new TravelCertificateError('Failed to fetch travel certificates', 'FETCH_FAILED');
+  }
+}
+
+/** Fetch a single certificate by ID */
+export async function getTravelCertificate(
+  certificateId: string,
+): Promise<TravelHealthCertificate> {
+  try {
+    const res = await apiClient.get<{ success: boolean; data: TravelHealthCertificate }>(
+      `/travel-certificates/${certificateId}`,
+    );
+    return res.data.data;
+  } catch {
+    throw new TravelCertificateError('Failed to fetch travel certificate', 'FETCH_FAILED');
+  }
+}
+
+/** Anchor a certificate to the Stellar blockchain */
+export async function anchorCertificateToBlockchain(
+  certificateId: string,
+): Promise<TravelHealthCertificate> {
+  try {
+    const res = await apiClient.post<{ success: boolean; data: TravelHealthCertificate }>(
+      `/travel-certificates/${certificateId}/anchor`,
+    );
+    return res.data.data;
+  } catch {
+    throw new TravelCertificateError('Failed to anchor certificate to blockchain', 'ANCHOR_FAILED');
+  }
+}
+
+/** Download the PDF for a certificate — returns a signed URL */
+export async function getCertificatePdfUrl(certificateId: string): Promise<string> {
+  try {
+    const res = await apiClient.get<{ success: boolean; data: { pdfUrl: string } }>(
+      `/travel-certificates/${certificateId}/pdf`,
+    );
+    return res.data.data.pdfUrl;
+  } catch {
+    throw new TravelCertificateError('Failed to get certificate PDF', 'PDF_FAILED');
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Returns only the unmet mandatory requirements from a certificate */
+export function getMissingRequirements(
+  certificate: TravelHealthCertificate,
+): CertificateRequirementCheck[] {
+  return certificate.requirementChecks.filter((c) => !c.met);
+}
+
+/** Returns a human-readable compliance summary */
+export function getComplianceSummary(certificate: TravelHealthCertificate): string {
+  const total = certificate.requirementChecks.length;
+  const met = certificate.requirementChecks.filter((c) => c.met).length;
+  return `${met}/${total} requirements met (${certificate.complianceScore}%)`;
+}


### PR DESCRIPTION
Closes #123

- Add country travel requirements database (8 countries: GB, DE, FR, US, AU, JP, CA, SG)
- Add TravelCertificate model with compliance checking types
- Add backend TravelCertificateService: checks vaccinations, health checks, and documents against pet records; computes compliance score; generates HTML/PDF certificate
- Add backend REST routes: POST /generate, GET /countries, GET /pet/:petId, GET /:id, POST /:id/anchor, GET /:id/pdf
- Add Stellar blockchain anchoring for certificates via existing StellarAnchorService
- Add frontend travelCertificateService with API client wrappers
- Add TravelCertificateScreen: country picker, travel date input, compliance view with actionable missing requirements, blockchain anchor button, PDF download
- Register TravelCertificate screen in AppNavigator and navigation types
- Extend backend store with StoredTravelCertificate
closes #403 