### PR TITLE
feat: resolve issues #421, #422, #423, #424

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -1,0 +1,67 @@
+/** @type {Detox.DetoxConfig} */
+module.exports = {
+  testRunner: {
+    args: {
+      $0: 'jest',
+      config: 'e2e/jest.config.js',
+    },
+    jest: {
+      setupTimeout: 120000,
+    },
+  },
+  apps: {
+    'ios.debug': {
+      type: 'ios.app',
+      binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/PetChain.app',
+      build:
+        'xcodebuild -workspace ios/PetChain.xcworkspace -scheme PetChain -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build',
+    },
+    'ios.release': {
+      type: 'ios.app',
+      binaryPath: 'ios/build/Build/Products/Release-iphonesimulator/PetChain.app',
+      build:
+        'xcodebuild -workspace ios/PetChain.xcworkspace -scheme PetChain -configuration Release -sdk iphonesimulator -derivedDataPath ios/build',
+    },
+    'android.debug': {
+      type: 'android.apk',
+      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
+      build:
+        'cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..',
+      reversePorts: [8081],
+    },
+    'android.release': {
+      type: 'android.apk',
+      binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
+      build:
+        'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..',
+    },
+  },
+  devices: {
+    simulator: {
+      type: 'ios.simulator',
+      device: { type: 'iPhone 15' },
+    },
+    emulator: {
+      type: 'android.emulator',
+      device: { avdName: 'Pixel_6_API_33' },
+    },
+  },
+  configurations: {
+    'ios.sim.debug': {
+      device: 'simulator',
+      app: 'ios.debug',
+    },
+    'ios.sim.release': {
+      device: 'simulator',
+      app: 'ios.release',
+    },
+    'android.emu.debug': {
+      device: 'emulator',
+      app: 'android.debug',
+    },
+    'android.emu.release': {
+      device: 'emulator',
+      app: 'android.release',
+    },
+  },
+};

--- a/.github/workflows/e2e-detox.yml
+++ b/.github/workflows/e2e-detox.yml
@@ -1,0 +1,106 @@
+name: E2E Tests — Detox
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-detox-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-android:
+    name: Detox E2E — Android
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Build Android debug APK
+        run: npx detox build --configuration android.emu.debug
+
+      - name: Run Detox E2E tests (Android)
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          script: |
+            npm run seed:test
+            npx detox test --configuration android.emu.debug --headless --record-logs all
+
+      - name: Upload Detox artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: detox-artifacts-android
+          path: artifacts/
+          retention-days: 7
+
+  e2e-ios:
+    name: Detox E2E — iOS
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install CocoaPods
+        run: cd ios && pod install && cd ..
+
+      - name: Build iOS debug app
+        run: npx detox build --configuration ios.sim.debug
+
+      - name: Run Detox E2E tests (iOS)
+        run: |
+          npm run seed:test
+          npx detox test --configuration ios.sim.debug --record-logs all
+
+      - name: Upload Detox artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: detox-artifacts-ios
+          path: artifacts/
+          retention-days: 7

--- a/App.tsx
+++ b/App.tsx
@@ -22,6 +22,8 @@ import {
   watchNotificationActions,
 } from './src/services/notificationService';
 import updateService from './src/services/updateService';
+import { registerBackgroundMedicationTask } from './src/services/backgroundTaskService';
+import { checkAppVersion } from './src/services/versionCheckService';
 
 const isStorybookEnabled = process.env.STORYBOOK_ENABLED === 'true';
 
@@ -66,6 +68,18 @@ function App() {
   React.useEffect(() => {
     if (!appReady) return;
     void (async () => {
+      // 1. Check server-side minimum version (critical/recommended)
+      const versionResult = await checkAppVersion();
+      if (versionResult.type === 'critical') {
+        setUpdateStatus({ visible: true, variant: 'force', storeUrl: versionResult.storeUrl });
+        return; // no need to check OTA if a store update is required
+      }
+      if (versionResult.type === 'recommended') {
+        setUpdateStatus({ visible: true, variant: 'optional', storeUrl: versionResult.storeUrl });
+        return;
+      }
+
+      // 2. Fall back to OTA check via expo-updates
       const result = await updateService.checkForUpdate();
       if (result.type === 'force-update') {
         setUpdateStatus({ visible: true, variant: 'force', storeUrl: result.storeUrl });
@@ -86,6 +100,7 @@ function App() {
   useEffect(() => {
     void registerNotificationActions();
     const subscription = watchNotificationActions();
+    void registerBackgroundMedicationTask();
     return () => subscription.remove();
   }, []);
 

--- a/backend/server/app.ts
+++ b/backend/server/app.ts
@@ -42,6 +42,7 @@ import usersRouter from './routes/users';
 import vaccinationsRouter from './routes/vaccinations';
 import vetsRouter from './routes/vets';
 import vitalsRouter from './routes/vitals';
+import appRouter from './routes/app';
 import { attachAudit } from '../middleware/auditLog';
 import federationRouter from '../src/routes/federation';
 
@@ -130,6 +131,7 @@ export function createApp(): Express {
   api.use('/insurance', insuranceRouter);
   api.use('/search', searchRouter);
   api.use('/vitals', vitalsRouter);
+  api.use('/app', appRouter);
 
   app.use('/api', api);
 

--- a/backend/server/routes/app.ts
+++ b/backend/server/routes/app.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+
+const router = Router();
+
+/**
+ * GET /api/app/version-check
+ *
+ * Returns the minimum required app version and store URLs.
+ * The client compares this against its current version to decide
+ * whether to show a blocking (critical) or dismissible (recommended) update prompt.
+ */
+router.get('/version-check', (_req, res) => {
+  res.json({
+    minimumVersion: process.env.APP_MINIMUM_VERSION ?? '1.0.0',
+    recommendedVersion: process.env.APP_RECOMMENDED_VERSION ?? '1.0.0',
+    iosStoreUrl:
+      process.env.IOS_STORE_URL ?? 'https://apps.apple.com/app/petchain/id000000000',
+    androidStoreUrl:
+      process.env.ANDROID_STORE_URL ??
+      'https://play.google.com/store/apps/details?id=app.petchain.mobile',
+    message: process.env.APP_UPDATE_MESSAGE ?? 'A new version of PetChain is available.',
+  });
+});
+
+export default router;

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -109,3 +109,69 @@ For new features, provide:
 - Be respectful and constructive in discussions.
 
 Thank you for contributing to PetChain-MobileApp!
+
+## End-to-End (E2E) Testing with Detox
+
+PetChain uses [Detox](https://wix.github.io/Detox/) for end-to-end testing on iOS Simulator and Android Emulator.
+
+### Prerequisites
+
+- Xcode (iOS) or Android Studio (Android) installed
+- A running simulator/emulator
+- App built in debug or release mode (see below)
+
+### Setup
+
+```bash
+# Install Detox CLI globally
+npm install -g detox-cli
+
+# Install project dependencies (Detox is included as a devDependency)
+npm install
+```
+
+### Build the app for E2E
+
+```bash
+# iOS debug build
+detox build --configuration ios.sim.debug
+
+# Android debug build
+detox build --configuration android.emu.debug
+```
+
+### Run E2E tests
+
+```bash
+# iOS
+detox test --configuration ios.sim.debug
+
+# Android
+detox test --configuration android.emu.debug
+```
+
+### Run against a seeded test database
+
+```bash
+# Seed minimal test data first
+npm run seed:test
+
+# Then run E2E tests
+detox test --configuration ios.sim.debug
+```
+
+### Test suites
+
+| File | Covers |
+|------|--------|
+| `e2e/onboarding.test.ts` | User registration → login flow |
+| `e2e/addPet.test.ts` | Add a new pet |
+| `e2e/healthRecord.test.ts` | Log a health record + search |
+| `e2e/sos.test.ts` | Emergency SOS flow |
+
+### Configuration
+
+Detox is configured in `.detoxrc.js` at the project root. Supported configurations:
+
+- `ios.sim.debug` / `ios.sim.release`
+- `android.emu.debug` / `android.emu.release`

--- a/e2e/addPet.test.ts
+++ b/e2e/addPet.test.ts
@@ -1,0 +1,42 @@
+import { by, device, element, expect as detoxExpect, waitFor } from 'detox';
+
+describe('Add Pet', () => {
+  beforeAll(async () => {
+    await device.launchApp({
+      newInstance: true,
+      launchArgs: { detoxSeed: 'test', detoxSkipOnboarding: 'true' },
+    });
+    // Wait for pet list to be ready
+    await waitFor(element(by.id('pet-list-screen'))).toBeVisible().withTimeout(10000);
+  });
+
+  afterAll(async () => {
+    await device.terminateApp();
+  });
+
+  it('opens the add pet form', async () => {
+    await element(by.id('add-pet-button')).tap();
+    await detoxExpect(element(by.id('pet-form-screen'))).toBeVisible();
+  });
+
+  it('fills in pet details and saves', async () => {
+    await element(by.id('pet-name-input')).typeText('Buddy');
+    await element(by.id('pet-species-input')).typeText('Dog');
+    await element(by.id('pet-breed-input')).typeText('Labrador');
+    await element(by.id('pet-dob-input')).typeText('2020-01-15');
+    await element(by.id('pet-form-save-button')).tap();
+
+    await waitFor(element(by.id('pet-list-screen')))
+      .toBeVisible()
+      .withTimeout(8000);
+  });
+
+  it('shows the new pet in the list', async () => {
+    await detoxExpect(element(by.text('Buddy'))).toBeVisible();
+  });
+
+  it('navigates to pet detail screen', async () => {
+    await element(by.text('Buddy')).tap();
+    await detoxExpect(element(by.id('pet-detail-screen'))).toBeVisible();
+  });
+});

--- a/e2e/healthRecord.test.ts
+++ b/e2e/healthRecord.test.ts
@@ -1,0 +1,53 @@
+import { by, device, element, expect as detoxExpect, waitFor } from 'detox';
+
+describe('Log Health Record', () => {
+  beforeAll(async () => {
+    await device.launchApp({
+      newInstance: true,
+      launchArgs: { detoxSeed: 'test', detoxSkipOnboarding: 'true' },
+    });
+    await waitFor(element(by.id('pet-list-screen'))).toBeVisible().withTimeout(10000);
+    // Navigate to the seeded pet
+    await element(by.id('pet-list-item-0')).tap();
+    await waitFor(element(by.id('pet-detail-screen'))).toBeVisible().withTimeout(5000);
+  });
+
+  afterAll(async () => {
+    await device.terminateApp();
+  });
+
+  it('opens the health records tab', async () => {
+    await element(by.id('pet-detail-records-tab')).tap();
+    await detoxExpect(element(by.id('health-records-list'))).toBeVisible();
+  });
+
+  it('opens the add health record form', async () => {
+    await element(by.id('add-health-record-button')).tap();
+    await detoxExpect(element(by.id('health-record-form'))).toBeVisible();
+  });
+
+  it('fills in and saves a health record', async () => {
+    await element(by.id('record-type-selector')).tap();
+    await element(by.text('Diagnosis')).tap();
+    await element(by.id('record-notes-input')).typeText('Annual checkup — all clear');
+    await element(by.id('record-vet-input')).typeText('Dr. Smith');
+    await element(by.id('record-save-button')).tap();
+
+    await waitFor(element(by.id('health-records-list')))
+      .toBeVisible()
+      .withTimeout(8000);
+  });
+
+  it('shows the new record in the list', async () => {
+    await detoxExpect(element(by.text('Annual checkup — all clear'))).toBeVisible();
+  });
+
+  it('searches for the health record', async () => {
+    await element(by.id('search-records-button')).tap();
+    await waitFor(element(by.id('search-input'))).toBeVisible().withTimeout(5000);
+    await element(by.id('search-input')).typeText('Annual');
+    await waitFor(element(by.text('Annual checkup — all clear')))
+      .toBeVisible()
+      .withTimeout(5000);
+  });
+});

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -1,0 +1,12 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  rootDir: '..',
+  testMatch: ['<rootDir>/e2e/**/*.test.ts'],
+  testTimeout: 120000,
+  maxWorkers: 1,
+  globalSetup: 'detox/runners/jest/globalSetup',
+  globalTeardown: 'detox/runners/jest/globalTeardown',
+  reporters: ['detox/runners/jest/reporter'],
+  testEnvironment: 'detox/runners/jest/testEnvironment',
+  verbose: true,
+};

--- a/e2e/onboarding.test.ts
+++ b/e2e/onboarding.test.ts
@@ -1,0 +1,51 @@
+import { by, device, element, expect as detoxExpect, waitFor } from 'detox';
+
+describe('Onboarding & Authentication', () => {
+  beforeAll(async () => {
+    await device.launchApp({ newInstance: true, launchArgs: { detoxSeed: 'test' } });
+  });
+
+  afterAll(async () => {
+    await device.terminateApp();
+  });
+
+  it('shows the onboarding screen on first launch', async () => {
+    await detoxExpect(element(by.id('onboarding-screen'))).toBeVisible();
+  });
+
+  it('navigates through onboarding slides', async () => {
+    await element(by.id('onboarding-next-button')).tap();
+    await element(by.id('onboarding-next-button')).tap();
+    await element(by.id('onboarding-get-started-button')).tap();
+  });
+
+  it('shows the registration screen', async () => {
+    await detoxExpect(element(by.id('register-screen'))).toBeVisible();
+  });
+
+  it('registers a new user', async () => {
+    await element(by.id('register-name-input')).typeText('Test User');
+    await element(by.id('register-email-input')).typeText('testuser@petchain.test');
+    await element(by.id('register-password-input')).typeText('TestPass123!');
+    await element(by.id('register-submit-button')).tap();
+
+    await waitFor(element(by.id('pet-list-screen')))
+      .toBeVisible()
+      .withTimeout(10000);
+  });
+
+  it('logs out and logs back in', async () => {
+    await element(by.id('settings-tab')).tap();
+    await element(by.id('logout-button')).tap();
+
+    await detoxExpect(element(by.id('login-screen'))).toBeVisible();
+
+    await element(by.id('login-email-input')).typeText('testuser@petchain.test');
+    await element(by.id('login-password-input')).typeText('TestPass123!');
+    await element(by.id('login-submit-button')).tap();
+
+    await waitFor(element(by.id('pet-list-screen')))
+      .toBeVisible()
+      .withTimeout(10000);
+  });
+});

--- a/e2e/sos.test.ts
+++ b/e2e/sos.test.ts
@@ -1,0 +1,44 @@
+import { by, device, element, expect as detoxExpect, waitFor } from 'detox';
+
+describe('Emergency SOS Flow', () => {
+  beforeAll(async () => {
+    await device.launchApp({
+      newInstance: true,
+      launchArgs: { detoxSeed: 'test', detoxSkipOnboarding: 'true' },
+    });
+    await waitFor(element(by.id('pet-list-screen'))).toBeVisible().withTimeout(10000);
+  });
+
+  afterAll(async () => {
+    await device.terminateApp();
+  });
+
+  it('navigates to emergency contacts screen', async () => {
+    await element(by.id('emergency-tab')).tap();
+    await detoxExpect(element(by.id('emergency-contacts-screen'))).toBeVisible();
+  });
+
+  it('shows the SOS button', async () => {
+    await detoxExpect(element(by.id('sos-button'))).toBeVisible();
+  });
+
+  it('shows confirmation dialog before triggering SOS', async () => {
+    await element(by.id('sos-button')).tap();
+    await detoxExpect(element(by.id('sos-confirm-dialog'))).toBeVisible();
+  });
+
+  it('can cancel the SOS confirmation', async () => {
+    await element(by.id('sos-cancel-button')).tap();
+    await detoxExpect(element(by.id('sos-confirm-dialog'))).not.toBeVisible();
+    await detoxExpect(element(by.id('emergency-contacts-screen'))).toBeVisible();
+  });
+
+  it('can add an emergency contact', async () => {
+    await element(by.id('add-emergency-contact-button')).tap();
+    await detoxExpect(element(by.id('emergency-contact-form'))).toBeVisible();
+    await element(by.id('contact-name-input')).typeText('Jane Doe');
+    await element(by.id('contact-phone-input')).typeText('+15551234567');
+    await element(by.id('contact-save-button')).tap();
+    await waitFor(element(by.text('Jane Doe'))).toBeVisible().withTimeout(5000);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -86,7 +86,10 @@
       "^expo-sqlite$": "<rootDir>/src/__mocks__/expo-sqlite.ts",
       "^expo-notifications$": "<rootDir>/src/__mocks__/expo-notifications.ts",
       "^expo-secure-store$": "<rootDir>/src/__mocks__/expo-secure-store.ts",
-      "^@sentry/react-native$": "<rootDir>/src/__mocks__/@sentry/react-native.ts"
+      "^expo-background-fetch$": "<rootDir>/src/__mocks__/expo-background-fetch.ts",
+      "^expo-task-manager$": "<rootDir>/src/__mocks__/expo-task-manager.ts",
+      "^expo-application$": "<rootDir>/src/__mocks__/expo-application.ts",
+      "^@sentry/react-native$": "<rootDir>/src/__mocks__/@sentry/react-native.ts",
       "^pg$": "<rootDir>/src/__mocks__/pg.js",
       "^@elastic/elasticsearch$": "<rootDir>/src/__mocks__/@elastic/elasticsearch.js",
       "^socket\\.io$": "<rootDir>/src/__mocks__/socket.io.js",
@@ -149,10 +152,9 @@
     "react-native-webrtc": "^124.0.3",
     "helmet": "^8.0.0",
     "swagger-ui-express": "^5.0.1",
-    "tesseract.js": "^5.0.4"
-    "swagger-ui-express": "^5.0.1"
+    "tesseract.js": "^5.0.4",
     "winston": "3.17.0",
-    "winston-daily-rotate-file": "5.0.0"
+    "winston-daily-rotate-file": "5.0.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
@@ -201,7 +203,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "8.59.0",
     "vitest": "^4.1.5",
-    "@types/winston": "^2.4.4"
+    "@types/winston": "^2.4.4",
     "vitest": "^4.1.5"
   },
   "overrides": {

--- a/src/__mocks__/expo-application.ts
+++ b/src/__mocks__/expo-application.ts
@@ -1,0 +1,4 @@
+export const nativeApplicationVersion = '1.0.0';
+export const applicationVersion = '1.0.0';
+export const applicationName = 'PetChain';
+export const nativeBuildVersion = '1';

--- a/src/__mocks__/expo-background-fetch.ts
+++ b/src/__mocks__/expo-background-fetch.ts
@@ -1,0 +1,12 @@
+const BackgroundFetch = {
+  BackgroundFetchResult: {
+    NewData: 'newData',
+    NoData: 'noData',
+    Failed: 'failed',
+  },
+  registerTaskAsync: jest.fn().mockResolvedValue(undefined),
+  unregisterTaskAsync: jest.fn().mockResolvedValue(undefined),
+};
+
+export default BackgroundFetch;
+export const { BackgroundFetchResult, registerTaskAsync, unregisterTaskAsync } = BackgroundFetch;

--- a/src/__mocks__/expo-task-manager.ts
+++ b/src/__mocks__/expo-task-manager.ts
@@ -1,0 +1,8 @@
+const TaskManager = {
+  defineTask: jest.fn(),
+  isTaskRegisteredAsync: jest.fn().mockResolvedValue(false),
+  unregisterAllTasksAsync: jest.fn().mockResolvedValue(undefined),
+};
+
+export default TaskManager;
+export const { defineTask, isTaskRegisteredAsync, unregisterAllTasksAsync } = TaskManager;

--- a/src/components/SOSButton.tsx
+++ b/src/components/SOSButton.tsx
@@ -119,10 +119,11 @@ const SOSButton: React.FC<SOSButtonProps> = ({ onSOSSent, style }) => {
         style={[styles.button, styles.countdownButton, style]}
         onPress={cancelSOS}
         activeOpacity={0.9}
+        testID="sos-confirm-dialog"
       >
         <Animated.View style={{ transform: [{ scale: pulseAnim }] }}>
           <Text style={styles.countdownText}>{countdown}</Text>
-          <Text style={styles.cancelText}>TAP TO CANCEL</Text>
+          <Text style={styles.cancelText} testID="sos-cancel-button">TAP TO CANCEL</Text>
         </Animated.View>
       </TouchableOpacity>
     );
@@ -135,6 +136,7 @@ const SOSButton: React.FC<SOSButtonProps> = ({ onSOSSent, style }) => {
         onPressIn={handlePressIn}
         onPressOut={handlePressOut}
         activeOpacity={1}
+        testID="sos-button"
       >
         <View style={styles.content}>
           <Text style={styles.buttonText}>🚨 SOS EMERGENCY</Text>

--- a/src/migrations/scripts/v6_medical_records_fts.ts
+++ b/src/migrations/scripts/v6_medical_records_fts.ts
@@ -1,0 +1,70 @@
+import { executeSql } from '../../services/localDB';
+import type { Migration } from '../types';
+
+/**
+ * v6 — Add FTS5 virtual table for full-text search on medical records.
+ */
+const migration: Migration = {
+  version: 6,
+  description: 'Add FTS5 full-text search index for medical records',
+
+  async up() {
+    // FTS5 virtual table — mirrors searchable fields from medical_records
+    await executeSql(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS medical_records_fts
+      USING fts5(
+        id UNINDEXED,
+        pet_id UNINDEXED,
+        type,
+        notes,
+        veterinarian,
+        date UNINDEXED,
+        content='medical_records',
+        content_rowid='rowid'
+      )
+    `);
+
+    // Populate from existing records
+    await executeSql(`
+      INSERT INTO medical_records_fts(rowid, id, pet_id, type, notes, veterinarian, date)
+      SELECT rowid, id, pet_id, type, notes, veterinarian, date
+      FROM medical_records
+    `);
+
+    // Keep FTS index in sync via triggers
+    await executeSql(`
+      CREATE TRIGGER IF NOT EXISTS medical_records_fts_insert
+      AFTER INSERT ON medical_records BEGIN
+        INSERT INTO medical_records_fts(rowid, id, pet_id, type, notes, veterinarian, date)
+        VALUES (new.rowid, new.id, new.pet_id, new.type, new.notes, new.veterinarian, new.date);
+      END
+    `);
+
+    await executeSql(`
+      CREATE TRIGGER IF NOT EXISTS medical_records_fts_delete
+      AFTER DELETE ON medical_records BEGIN
+        INSERT INTO medical_records_fts(medical_records_fts, rowid, id, pet_id, type, notes, veterinarian, date)
+        VALUES ('delete', old.rowid, old.id, old.pet_id, old.type, old.notes, old.veterinarian, old.date);
+      END
+    `);
+
+    await executeSql(`
+      CREATE TRIGGER IF NOT EXISTS medical_records_fts_update
+      AFTER UPDATE ON medical_records BEGIN
+        INSERT INTO medical_records_fts(medical_records_fts, rowid, id, pet_id, type, notes, veterinarian, date)
+        VALUES ('delete', old.rowid, old.id, old.pet_id, old.type, old.notes, old.veterinarian, old.date);
+        INSERT INTO medical_records_fts(rowid, id, pet_id, type, notes, veterinarian, date)
+        VALUES (new.rowid, new.id, new.pet_id, new.type, new.notes, new.veterinarian, new.date);
+      END
+    `);
+  },
+
+  async down() {
+    await executeSql(`DROP TRIGGER IF EXISTS medical_records_fts_update`);
+    await executeSql(`DROP TRIGGER IF EXISTS medical_records_fts_delete`);
+    await executeSql(`DROP TRIGGER IF EXISTS medical_records_fts_insert`);
+    await executeSql(`DROP TABLE IF EXISTS medical_records_fts`);
+  },
+};
+
+export default migration;

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -58,6 +58,7 @@ const LoginScreen: React.FC<Props> = ({ onSuccess, onRegister, onForgotPassword 
     <KeyboardAvoidingView
       style={styles.container}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      testID="login-screen"
     >
       <View style={styles.inner}>
         <Text style={styles.logo}>🐾</Text>
@@ -74,6 +75,7 @@ const LoginScreen: React.FC<Props> = ({ onSuccess, onRegister, onForgotPassword 
           onChangeText={setEmail}
           returnKeyType="next"
           onSubmitEditing={() => passwordRef.current?.focus()}
+          testID="login-email-input"
         />
 
         <TextInput
@@ -86,6 +88,7 @@ const LoginScreen: React.FC<Props> = ({ onSuccess, onRegister, onForgotPassword 
           ref={passwordRef}
           returnKeyType="go"
           onSubmitEditing={() => void handleLogin()}
+          testID="login-password-input"
         />
 
         <TouchableOpacity onPress={onForgotPassword} style={styles.forgotLink}>
@@ -96,6 +99,7 @@ const LoginScreen: React.FC<Props> = ({ onSuccess, onRegister, onForgotPassword 
           style={[styles.btn, loading && styles.btnDisabled]}
           onPress={() => void handleLogin()}
           disabled={loading}
+          testID="login-submit-button"
         >
           {loading ? (
             <ActivityIndicator color="#fff" />

--- a/src/screens/MedicalRecordSearchScreen.tsx
+++ b/src/screens/MedicalRecordSearchScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -12,10 +12,46 @@ import {
 
 import { HeaderOfflineStatus, useOfflineStatus } from '../components/OfflineIndicator';
 import { searchMedicalRecords, type MedicalRecord } from '../services/medicalRecordService';
+import {
+  addRecentSearch,
+  getRecentSearches,
+  removeRecentSearch,
+} from '../services/searchSuggestionsService';
 
 interface Props {
   petId: string;
   onBack: () => void;
+}
+
+const DEBOUNCE_MS = 300;
+const MAX_RECENT = 10;
+
+/** Highlight matching query text within a string. */
+function HighlightedText({
+  text,
+  query,
+  style,
+}: {
+  text: string;
+  query: string;
+  style?: object;
+}) {
+  if (!query.trim() || !text) return <Text style={style}>{text}</Text>;
+
+  const parts = text.split(new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi'));
+  return (
+    <Text style={style}>
+      {parts.map((part, i) =>
+        part.toLowerCase() === query.toLowerCase() ? (
+          <Text key={i} style={styles.highlight}>
+            {part}
+          </Text>
+        ) : (
+          part
+        ),
+      )}
+    </Text>
+  );
 }
 
 const MedicalRecordSearchScreen: React.FC<Props> = ({ petId, onBack }) => {
@@ -23,20 +59,56 @@ const MedicalRecordSearchScreen: React.FC<Props> = ({ petId, onBack }) => {
   const [results, setResults] = useState<MedicalRecord[]>([]);
   const [loading, setLoading] = useState(false);
   const [searched, setSearched] = useState(false);
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const [showRecents, setShowRecents] = useState(false);
   const offlineStatus = useOfflineStatus();
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleSearch = async () => {
-    if (!query.trim()) return;
-    setLoading(true);
-    setSearched(true);
-    try {
-      const data = await searchMedicalRecords(petId, query);
-      setResults(data);
-    } catch {
-      Alert.alert('Error', 'Failed to search medical records.');
-    } finally {
-      setLoading(false);
-    }
+  useEffect(() => {
+    getRecentSearches().then((recents) => setRecentSearches(recents.slice(0, MAX_RECENT)));
+  }, []);
+
+  const runSearch = useCallback(
+    async (q: string) => {
+      if (!q.trim()) {
+        setResults([]);
+        setSearched(false);
+        return;
+      }
+      setLoading(true);
+      setSearched(true);
+      setShowRecents(false);
+      try {
+        const data = await searchMedicalRecords(petId, q);
+        setResults(data);
+        await addRecentSearch(q);
+        const updated = await getRecentSearches();
+        setRecentSearches(updated.slice(0, MAX_RECENT));
+      } catch {
+        Alert.alert('Error', 'Failed to search medical records.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [petId],
+  );
+
+  const handleChangeText = (text: string) => {
+    setQuery(text);
+    setShowRecents(text.length === 0);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => runSearch(text), DEBOUNCE_MS);
+  };
+
+  const handleSelectRecent = (q: string) => {
+    setQuery(q);
+    setShowRecents(false);
+    void runSearch(q);
+  };
+
+  const handleRemoveRecent = async (q: string) => {
+    const updated = await removeRecentSearch(q);
+    setRecentSearches(updated.slice(0, MAX_RECENT));
   };
 
   const renderItem = useCallback(
@@ -46,8 +118,16 @@ const MedicalRecordSearchScreen: React.FC<Props> = ({ petId, onBack }) => {
           <Text style={styles.badge}>{item.type}</Text>
           <Text style={styles.date}>{new Date(item.date).toLocaleDateString()}</Text>
         </View>
-        {item.notes ? <Text style={styles.notes}>{item.notes}</Text> : null}
-        {item.veterinarian ? <Text style={styles.meta}>Vet: {item.veterinarian}</Text> : null}
+        {item.notes ? (
+          <HighlightedText text={item.notes} query={query} style={styles.notes} />
+        ) : null}
+        {item.veterinarian ? (
+          <HighlightedText
+            text={`Vet: ${item.veterinarian}`}
+            query={query}
+            style={styles.meta}
+          />
+        ) : null}
         {item.documents?.length ? (
           <Text style={styles.meta}>
             {item.documents.length} attachment{item.documents.length === 1 ? '' : 's'}
@@ -56,7 +136,7 @@ const MedicalRecordSearchScreen: React.FC<Props> = ({ petId, onBack }) => {
         {!offlineStatus?.isOnline ? <Text style={styles.cachedChip}>Cached</Text> : null}
       </View>
     ),
-    [offlineStatus?.isOnline],
+    [offlineStatus?.isOnline, query],
   );
 
   return (
@@ -67,6 +147,7 @@ const MedicalRecordSearchScreen: React.FC<Props> = ({ petId, onBack }) => {
           style={styles.backBtn}
           accessibilityRole="button"
           accessibilityLabel="Back"
+          testID="back-button"
         >
           <Text style={styles.backText}>‹ Back</Text>
         </TouchableOpacity>
@@ -75,6 +156,7 @@ const MedicalRecordSearchScreen: React.FC<Props> = ({ petId, onBack }) => {
           <HeaderOfflineStatus />
         </View>
       </View>
+
       {!offlineStatus?.isOnline ? (
         <View style={styles.cachedBanner}>
           <Text style={styles.cachedBannerText}>Showing cached records while offline.</Text>
@@ -86,20 +168,52 @@ const MedicalRecordSearchScreen: React.FC<Props> = ({ petId, onBack }) => {
           style={styles.input}
           placeholder="Search by diagnosis, notes, vet…"
           value={query}
-          onChangeText={setQuery}
-          onSubmitEditing={handleSearch}
+          onChangeText={handleChangeText}
+          onFocus={() => setShowRecents(query.length === 0)}
+          onSubmitEditing={() => runSearch(query)}
           returnKeyType="search"
           accessibilityLabel="Search medical records"
+          testID="search-input"
         />
-        <TouchableOpacity
-          style={styles.searchBtn}
-          onPress={handleSearch}
-          accessibilityRole="button"
-          accessibilityLabel="Search"
-        >
-          <Text style={styles.searchBtnText}>Search</Text>
-        </TouchableOpacity>
+        {query.length > 0 && (
+          <TouchableOpacity
+            style={styles.clearBtn}
+            onPress={() => {
+              setQuery('');
+              setResults([]);
+              setSearched(false);
+              setShowRecents(true);
+            }}
+            accessibilityLabel="Clear search"
+            testID="clear-button"
+          >
+            <Text style={styles.clearText}>✕</Text>
+          </TouchableOpacity>
+        )}
       </View>
+
+      {showRecents && recentSearches.length > 0 && (
+        <View style={styles.recentsContainer}>
+          <Text style={styles.recentsTitle}>Recent Searches</Text>
+          {recentSearches.map((r) => (
+            <View key={r} style={styles.recentRow}>
+              <TouchableOpacity
+                style={styles.recentItem}
+                onPress={() => handleSelectRecent(r)}
+                testID={`recent-${r}`}
+              >
+                <Text style={styles.recentText}>{r}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={() => handleRemoveRecent(r)}
+                accessibilityLabel={`Remove ${r}`}
+              >
+                <Text style={styles.recentRemove}>✕</Text>
+              </TouchableOpacity>
+            </View>
+          ))}
+        </View>
+      )}
 
       {loading ? (
         <ActivityIndicator style={styles.loader} size="large" color="#4CAF50" />
@@ -156,6 +270,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     borderBottomWidth: 1,
     borderBottomColor: '#e0e0e0',
+    alignItems: 'center',
   },
   input: {
     flex: 1,
@@ -167,14 +282,20 @@ const styles = StyleSheet.create({
     fontSize: 14,
     backgroundColor: '#fafafa',
   },
-  searchBtn: {
-    backgroundColor: '#4CAF50',
+  clearBtn: { padding: 6 },
+  clearText: { fontSize: 14, color: '#999' },
+  recentsContainer: {
+    backgroundColor: '#fff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#e0e0e0',
     paddingHorizontal: 16,
     paddingVertical: 8,
-    borderRadius: 8,
-    justifyContent: 'center',
   },
-  searchBtnText: { color: '#fff', fontWeight: '600' },
+  recentsTitle: { fontSize: 12, fontWeight: '700', color: '#999', marginBottom: 6 },
+  recentRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  recentItem: { flex: 1, paddingVertical: 6 },
+  recentText: { fontSize: 14, color: '#333' },
+  recentRemove: { fontSize: 12, color: '#bbb', paddingLeft: 8 },
   loader: { marginTop: 40 },
   list: { padding: 12 },
   card: {
@@ -201,6 +322,7 @@ const styles = StyleSheet.create({
   date: { fontSize: 12, color: '#999' },
   notes: { fontSize: 14, color: '#333', marginBottom: 4 },
   meta: { fontSize: 12, color: '#888' },
+  highlight: { backgroundColor: '#fff176', fontWeight: '700', color: '#1a1a1a' },
   cachedChip: {
     alignSelf: 'flex-start',
     marginTop: 8,

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -124,6 +124,7 @@ const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ onComplete, onSkip 
           <TouchableOpacity
             style={[styles.nextButton, isLastSlide && styles.getStartedButton]}
             onPress={handleNext}
+            testID={isLastSlide ? 'onboarding-get-started-button' : 'onboarding-next-button'}
           >
             <Text style={[styles.nextButtonText, isLastSlide && styles.getStartedButtonText]}>
               {isLastSlide ? 'Get Started' : 'Next'}
@@ -150,7 +151,7 @@ const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ onComplete, onSkip 
 
   return (
     <ErrorBoundary>
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={styles.container} testID="onboarding-screen">
         <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
 
         <View style={styles.header}>

--- a/src/screens/PetFormScreen.tsx
+++ b/src/screens/PetFormScreen.tsx
@@ -176,8 +176,7 @@ const PetFormScreen: React.FC<Props> = ({ pet, ownerId = '', onBack, onSaved }) 
   };
 
   return (
-    <View style={styles.container}>
-      {/* Header */}
+    <View style={styles.container} testID="pet-form-screen">
       <View style={styles.header}>
         <TouchableOpacity
           onPress={onBack}
@@ -194,6 +193,7 @@ const PetFormScreen: React.FC<Props> = ({ pet, ownerId = '', onBack, onSaved }) 
           disabled={saving}
           accessibilityRole="button"
           accessibilityLabel={isEdit ? 'Save changes' : 'Save pet'}
+          testID="pet-form-save-button"
         >
           <Text style={styles.saveBtnText}>{saving ? 'Saving…' : 'Save'}</Text>
         </TouchableOpacity>
@@ -275,6 +275,7 @@ const PetFormScreen: React.FC<Props> = ({ pet, ownerId = '', onBack, onSaved }) 
                 placeholderTextColor="#bbb"
                 accessibilityLabel={label.replace('*', '').trim()}
                 returnKeyType="next"
+                testID={`pet-${key}-input`}
               />
             </View>
           ))}

--- a/src/screens/PetListScreen.tsx
+++ b/src/screens/PetListScreen.tsx
@@ -55,13 +55,14 @@ const PetListScreen: React.FC<Props> = ({ onSelectPet, onAddPet }) => {
   );
 
   const renderItem = useCallback(
-    ({ item }: { item: Pet }) => (
+    ({ item, index }: { item: Pet; index: number }) => (
       <TouchableOpacity
         style={styles.card}
         onPress={() => onSelectPet(item)}
         accessibilityRole="button"
         accessibilityLabel={`${item.name}, ${item.species}`}
         accessibilityHint="Opens pet details"
+        testID={`pet-list-item-${index}`}
       >
         {item.photoUrl || item.thumbnailUrl ? (
           <OptimizedImage
@@ -94,7 +95,7 @@ const PetListScreen: React.FC<Props> = ({ onSelectPet, onAddPet }) => {
   );
 
   return (
-    <View style={styles.container}>
+    <View style={styles.container} testID="pet-list-screen">
       <View style={styles.header}>
         <View style={styles.titleRow}>
           <Text style={styles.title}>My Pets</Text>
@@ -106,6 +107,7 @@ const PetListScreen: React.FC<Props> = ({ onSelectPet, onAddPet }) => {
           accessibilityRole="button"
           accessibilityLabel="Add pet"
           accessibilityHint="Adds a new pet"
+          testID="add-pet-button"
         >
           <Text style={styles.addBtnText}>+ Add</Text>
         </TouchableOpacity>

--- a/src/screens/RegisterScreen.tsx
+++ b/src/screens/RegisterScreen.tsx
@@ -77,6 +77,7 @@ const RegisterScreen: React.FC<Props> = ({ onSuccess, onLogin }) => {
     <KeyboardAvoidingView
       style={styles.container}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      testID="register-screen"
     >
       <ScrollView contentContainerStyle={styles.inner} keyboardShouldPersistTaps="handled">
         <Text style={styles.logo}>🐾</Text>
@@ -89,6 +90,7 @@ const RegisterScreen: React.FC<Props> = ({ onSuccess, onLogin }) => {
           placeholderTextColor="#aaa"
           value={name}
           onChangeText={setName}
+          testID="register-name-input"
         />
 
         <TextInput
@@ -99,6 +101,7 @@ const RegisterScreen: React.FC<Props> = ({ onSuccess, onLogin }) => {
           keyboardType="email-address"
           value={email}
           onChangeText={setEmail}
+          testID="register-email-input"
         />
 
         <TextInput
@@ -108,6 +111,7 @@ const RegisterScreen: React.FC<Props> = ({ onSuccess, onLogin }) => {
           secureTextEntry
           value={password}
           onChangeText={setPassword}
+          testID="register-password-input"
         />
 
         <TextInput
@@ -124,6 +128,7 @@ const RegisterScreen: React.FC<Props> = ({ onSuccess, onLogin }) => {
           style={[styles.btn, loading && styles.btnDisabled]}
           onPress={() => void handleRegister()}
           disabled={loading}
+          testID="register-submit-button"
         >
           {loading ? (
             <ActivityIndicator color="#fff" />

--- a/src/services/__tests__/backgroundTaskService.test.ts
+++ b/src/services/__tests__/backgroundTaskService.test.ts
@@ -1,0 +1,166 @@
+import * as BackgroundFetch from 'expo-background-fetch';
+import * as Notifications from 'expo-notifications';
+import * as TaskManager from 'expo-task-manager';
+
+import * as medicationService from '../../services/medicationService';
+import {
+  BACKGROUND_MEDICATION_TASK,
+  cancelMedicationNotifications,
+  registerBackgroundMedicationTask,
+  rescheduleUpcomingMedications,
+  scheduleMedicationNotification,
+  unregisterBackgroundMedicationTask,
+} from '../../services/backgroundTaskService';
+
+jest.mock('expo-background-fetch', () => ({
+  BackgroundFetchResult: { NewData: 'newData', NoData: 'noData', Failed: 'failed' },
+  registerTaskAsync: jest.fn(),
+  unregisterTaskAsync: jest.fn(),
+}));
+
+jest.mock('expo-task-manager', () => ({
+  defineTask: jest.fn(),
+  isTaskRegisteredAsync: jest.fn(),
+}));
+
+jest.mock('expo-notifications', () => ({
+  scheduleNotificationAsync: jest.fn().mockResolvedValue('notif-id-1'),
+  getAllScheduledNotificationsAsync: jest.fn().mockResolvedValue([]),
+  cancelScheduledNotificationAsync: jest.fn().mockResolvedValue(undefined),
+  SchedulableTriggerInputTypes: { DATE: 'date' },
+}));
+
+jest.mock('../../services/medicationService', () => ({
+  getMedications: jest.fn(),
+  getScheduleForRange: jest.fn(),
+}));
+
+jest.mock('../../utils/errorLogger', () => ({ logError: jest.fn() }));
+
+const mockMedication = {
+  id: 'med-1',
+  name: 'Amoxicillin',
+  dosage: '250mg',
+  frequency: 8,
+  startDate: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+  status: 'active',
+};
+
+describe('backgroundTaskService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('registerBackgroundMedicationTask', () => {
+    it('registers the task when not already registered', async () => {
+      (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(false);
+      await registerBackgroundMedicationTask();
+      expect(BackgroundFetch.registerTaskAsync).toHaveBeenCalledWith(
+        BACKGROUND_MEDICATION_TASK,
+        expect.objectContaining({ stopOnTerminate: false, startOnBoot: true }),
+      );
+    });
+
+    it('skips registration when task is already registered', async () => {
+      (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(true);
+      await registerBackgroundMedicationTask();
+      expect(BackgroundFetch.registerTaskAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unregisterBackgroundMedicationTask', () => {
+    it('unregisters when task is registered', async () => {
+      (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(true);
+      await unregisterBackgroundMedicationTask();
+      expect(BackgroundFetch.unregisterTaskAsync).toHaveBeenCalledWith(BACKGROUND_MEDICATION_TASK);
+    });
+
+    it('does nothing when task is not registered', async () => {
+      (TaskManager.isTaskRegisteredAsync as jest.Mock).mockResolvedValue(false);
+      await unregisterBackgroundMedicationTask();
+      expect(BackgroundFetch.unregisterTaskAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rescheduleUpcomingMedications', () => {
+    it('returns 0 when there are no medications', async () => {
+      (medicationService.getMedications as jest.Mock).mockResolvedValue([]);
+      const count = await rescheduleUpcomingMedications();
+      expect(count).toBe(0);
+    });
+
+    it('schedules notifications for upcoming doses', async () => {
+      const futureTime = new Date(Date.now() + 2 * 60 * 60 * 1000); // 2 hours from now
+      (medicationService.getMedications as jest.Mock).mockResolvedValue([mockMedication]);
+      (medicationService.getScheduleForRange as jest.Mock).mockReturnValue([futureTime]);
+
+      const count = await rescheduleUpcomingMedications();
+      expect(count).toBe(1);
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({
+            data: expect.objectContaining({ type: 'medication_reminder', medicationId: 'med-1' }),
+          }),
+        }),
+      );
+    });
+
+    it('skips past dose times', async () => {
+      const pastTime = new Date(Date.now() - 60 * 1000); // 1 minute ago
+      (medicationService.getMedications as jest.Mock).mockResolvedValue([mockMedication]);
+      (medicationService.getScheduleForRange as jest.Mock).mockReturnValue([pastTime]);
+
+      const count = await rescheduleUpcomingMedications();
+      expect(count).toBe(0);
+      expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+    });
+
+    it('cancels existing medication notifications before rescheduling', async () => {
+      const existingNotif = {
+        identifier: 'old-notif',
+        content: { data: { type: 'medication_reminder' } },
+      };
+      (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([
+        existingNotif,
+      ]);
+      (medicationService.getMedications as jest.Mock).mockResolvedValue([]);
+
+      await rescheduleUpcomingMedications();
+      expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('old-notif');
+    });
+  });
+
+  describe('cancelMedicationNotifications', () => {
+    it('cancels only medication_reminder notifications', async () => {
+      const notifications = [
+        { identifier: 'med-notif', content: { data: { type: 'medication_reminder' } } },
+        { identifier: 'appt-notif', content: { data: { type: 'appointment' } } },
+      ];
+      (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue(
+        notifications,
+      );
+
+      await cancelMedicationNotifications();
+      expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('med-notif');
+      expect(Notifications.cancelScheduledNotificationAsync).not.toHaveBeenCalledWith('appt-notif');
+    });
+  });
+
+  describe('scheduleMedicationNotification', () => {
+    it('schedules a notification with correct content', async () => {
+      const doseTime = new Date(Date.now() + 60 * 60 * 1000);
+      await scheduleMedicationNotification(mockMedication as any, doseTime);
+
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        content: {
+          title: '💊 Medication Reminder',
+          body: `Time to give ${mockMedication.name} (${mockMedication.dosage})`,
+          data: {
+            type: 'medication_reminder',
+            medicationId: mockMedication.id,
+            scheduledFor: doseTime.toISOString(),
+          },
+        },
+        trigger: { type: 'date', date: doseTime },
+      });
+    });
+  });
+});

--- a/src/services/__tests__/versionCheckService.test.ts
+++ b/src/services/__tests__/versionCheckService.test.ts
@@ -1,0 +1,120 @@
+import * as Application from 'expo-application';
+
+import apiClient from '../../services/apiClient';
+import {
+  checkAppVersion,
+  clearVersionCheckCache,
+} from '../../services/versionCheckService';
+
+jest.mock('../../services/apiClient', () => ({
+  get: jest.fn(),
+}));
+
+jest.mock('expo-application', () => ({
+  nativeApplicationVersion: '1.2.0',
+  applicationVersion: '1.2.0',
+}));
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}));
+
+jest.mock('../../utils/errorLogger', () => ({ logError: jest.fn() }));
+
+const mockAsyncStorage = {
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+  removeItem: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
+
+const mockResponse = {
+  minimumVersion: '1.0.0',
+  recommendedVersion: '1.0.0',
+  iosStoreUrl: 'https://apps.apple.com/app/petchain/id000000000',
+  androidStoreUrl: 'https://play.google.com/store/apps/details?id=app.petchain.mobile',
+  message: 'Update available',
+};
+
+describe('versionCheckService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAsyncStorage.getItem.mockResolvedValue(null);
+  });
+
+  describe('checkAppVersion', () => {
+    it('returns up-to-date when current version meets minimum and recommended', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValue({ data: mockResponse });
+      const result = await checkAppVersion();
+      expect(result.type).toBe('up-to-date');
+    });
+
+    it('returns critical when current version is below minimum', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValue({
+        data: { ...mockResponse, minimumVersion: '2.0.0', recommendedVersion: '2.0.0' },
+      });
+      const result = await checkAppVersion();
+      expect(result.type).toBe('critical');
+      if (result.type === 'critical') {
+        expect(result.storeUrl).toBe(mockResponse.iosStoreUrl);
+      }
+    });
+
+    it('returns recommended when current version is below recommended but above minimum', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValue({
+        data: { ...mockResponse, minimumVersion: '1.0.0', recommendedVersion: '1.5.0' },
+      });
+      const result = await checkAppVersion();
+      expect(result.type).toBe('recommended');
+    });
+
+    it('returns cached result within TTL without calling API', async () => {
+      const cachedResult = { type: 'up-to-date' };
+      mockAsyncStorage.getItem.mockResolvedValue(
+        JSON.stringify({ result: cachedResult, cachedAt: Date.now() }),
+      );
+      const result = await checkAppVersion();
+      expect(result.type).toBe('up-to-date');
+      expect(apiClient.get).not.toHaveBeenCalled();
+    });
+
+    it('fetches fresh result when cache is expired', async () => {
+      const expiredCache = {
+        result: { type: 'up-to-date' },
+        cachedAt: Date.now() - 2 * 60 * 60 * 1000, // 2 hours ago
+      };
+      mockAsyncStorage.getItem.mockResolvedValue(JSON.stringify(expiredCache));
+      (apiClient.get as jest.Mock).mockResolvedValue({ data: mockResponse });
+
+      const result = await checkAppVersion();
+      expect(apiClient.get).toHaveBeenCalledWith('/app/version-check');
+      expect(result.type).toBe('up-to-date');
+    });
+
+    it('returns error when API call fails', async () => {
+      (apiClient.get as jest.Mock).mockRejectedValue(new Error('Network error'));
+      const result = await checkAppVersion();
+      expect(result.type).toBe('error');
+      if (result.type === 'error') {
+        expect(result.message).toBe('Network error');
+      }
+    });
+
+    it('caches the result after a successful API call', async () => {
+      (apiClient.get as jest.Mock).mockResolvedValue({ data: mockResponse });
+      await checkAppVersion();
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+        '@version_check_cache',
+        expect.stringContaining('"type":"up-to-date"'),
+      );
+    });
+  });
+
+  describe('clearVersionCheckCache', () => {
+    it('removes the cache key', async () => {
+      await clearVersionCheckCache();
+      expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('@version_check_cache');
+    });
+  });
+});

--- a/src/services/backgroundTaskService.ts
+++ b/src/services/backgroundTaskService.ts
@@ -1,0 +1,139 @@
+/**
+ * Background App Refresh for Medication Reminders
+ *
+ * Uses expo-background-fetch + expo-task-manager to re-schedule any missed
+ * medication notifications after the app has been backgrounded or killed.
+ */
+
+import * as BackgroundFetch from 'expo-background-fetch';
+import * as Notifications from 'expo-notifications';
+import * as TaskManager from 'expo-task-manager';
+
+import { logError } from '../utils/errorLogger';
+import { getMedications, getScheduleForRange, type Medication } from './medicationService';
+
+export const BACKGROUND_MEDICATION_TASK = 'BACKGROUND_MEDICATION_REMINDER_TASK';
+
+/** How far ahead (in hours) to pre-schedule notifications on each background wake. */
+const SCHEDULE_HORIZON_HOURS = 24;
+
+/** Minimum interval between background fetches (seconds). iOS enforces its own minimum (~15 min). */
+const FETCH_INTERVAL_SECONDS = 15 * 60;
+
+// ─── Task Definition ─────────────────────────────────────────────────────────
+
+TaskManager.defineTask(BACKGROUND_MEDICATION_TASK, async () => {
+  try {
+    const rescheduled = await rescheduleUpcomingMedications();
+    console.log(`[BackgroundTask] Rescheduled ${rescheduled} medication notifications`);
+    return rescheduled > 0
+      ? BackgroundFetch.BackgroundFetchResult.NewData
+      : BackgroundFetch.BackgroundFetchResult.NoData;
+  } catch (err) {
+    logError(err as Error, { context: BACKGROUND_MEDICATION_TASK });
+    return BackgroundFetch.BackgroundFetchResult.Failed;
+  }
+});
+
+// ─── Registration ─────────────────────────────────────────────────────────────
+
+/**
+ * Register the background fetch task. Call once on app startup (e.g. in App.tsx).
+ * Safe to call multiple times — skips registration if already registered.
+ */
+export async function registerBackgroundMedicationTask(): Promise<void> {
+  try {
+    const isRegistered = await TaskManager.isTaskRegisteredAsync(BACKGROUND_MEDICATION_TASK);
+    if (isRegistered) return;
+
+    await BackgroundFetch.registerTaskAsync(BACKGROUND_MEDICATION_TASK, {
+      minimumInterval: FETCH_INTERVAL_SECONDS,
+      stopOnTerminate: false, // continue after app is killed (Android)
+      startOnBoot: true, // restart on device reboot (Android)
+    });
+    console.log('[BackgroundTask] Registered medication reminder task');
+  } catch (err) {
+    // Background fetch may be unavailable in Expo Go or certain simulators
+    logError(err as Error, { context: 'registerBackgroundMedicationTask' });
+  }
+}
+
+/**
+ * Unregister the background fetch task (e.g. when user disables reminders).
+ */
+export async function unregisterBackgroundMedicationTask(): Promise<void> {
+  try {
+    const isRegistered = await TaskManager.isTaskRegisteredAsync(BACKGROUND_MEDICATION_TASK);
+    if (isRegistered) {
+      await BackgroundFetch.unregisterTaskAsync(BACKGROUND_MEDICATION_TASK);
+    }
+  } catch (err) {
+    logError(err as Error, { context: 'unregisterBackgroundMedicationTask' });
+  }
+}
+
+// ─── Core Logic ───────────────────────────────────────────────────────────────
+
+/**
+ * Cancel all pending medication notifications and re-schedule them for the
+ * next SCHEDULE_HORIZON_HOURS window. Returns the number of notifications scheduled.
+ */
+export async function rescheduleUpcomingMedications(): Promise<number> {
+  const medications = await getMedications();
+  if (!medications.length) return 0;
+
+  // Cancel existing scheduled medication notifications to avoid duplicates
+  await cancelMedicationNotifications();
+
+  const now = new Date();
+  const horizon = new Date(now.getTime() + SCHEDULE_HORIZON_HOURS * 60 * 60 * 1000);
+
+  let count = 0;
+  for (const med of medications) {
+    const doses = getScheduleForRange(med, now, horizon);
+    for (const doseTime of doses) {
+      if (doseTime <= now) continue; // skip already-past doses
+      await scheduleMedicationNotification(med, doseTime);
+      count++;
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Cancel all currently scheduled medication reminder notifications.
+ */
+export async function cancelMedicationNotifications(): Promise<void> {
+  const scheduled = await Notifications.getAllScheduledNotificationsAsync();
+  const medicationNotifications = scheduled.filter(
+    (n) => (n.content.data as Record<string, unknown>)?.type === 'medication_reminder',
+  );
+  await Promise.all(
+    medicationNotifications.map((n) => Notifications.cancelScheduledNotificationAsync(n.identifier)),
+  );
+}
+
+/**
+ * Schedule a single medication dose notification.
+ */
+export async function scheduleMedicationNotification(
+  med: Medication,
+  doseTime: Date,
+): Promise<string> {
+  return Notifications.scheduleNotificationAsync({
+    content: {
+      title: '💊 Medication Reminder',
+      body: `Time to give ${med.name} (${med.dosage})`,
+      data: {
+        type: 'medication_reminder',
+        medicationId: med.id,
+        scheduledFor: doseTime.toISOString(),
+      },
+    },
+    trigger: {
+      type: Notifications.SchedulableTriggerInputTypes.DATE,
+      date: doseTime,
+    },
+  });
+}

--- a/src/services/searchSuggestionsService.ts
+++ b/src/services/searchSuggestionsService.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const RECENT_KEY = '@search_recent';
-const MAX_RECENT = 8;
+const MAX_RECENT = 10;
 
 export interface QuickAction {
   id: string;

--- a/src/services/versionCheckService.ts
+++ b/src/services/versionCheckService.ts
@@ -1,0 +1,115 @@
+/**
+ * Version Check Service
+ *
+ * Fetches the minimum/recommended app version from the backend and compares
+ * it against the currently installed version to determine if an update is needed.
+ * Results are cached for 1 hour to avoid repeated API calls on every launch.
+ */
+
+import * as Application from 'expo-application';
+import { Platform } from 'react-native';
+
+import apiClient from './apiClient';
+import { logError } from '../utils/errorLogger';
+
+export type VersionCheckResult =
+  | { type: 'up-to-date' }
+  | { type: 'critical'; storeUrl: string; message: string }
+  | { type: 'recommended'; storeUrl: string; message: string }
+  | { type: 'error'; message: string };
+
+interface VersionCheckResponse {
+  minimumVersion: string;
+  recommendedVersion: string;
+  iosStoreUrl: string;
+  androidStoreUrl: string;
+  message: string;
+}
+
+const CACHE_KEY = '@version_check_cache';
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+interface CachedResult {
+  result: VersionCheckResult;
+  cachedAt: number;
+}
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] ?? 0;
+    const nb = pb[i] ?? 0;
+    if (na < nb) return -1;
+    if (na > nb) return 1;
+  }
+  return 0;
+}
+
+async function readCache(): Promise<VersionCheckResult | null> {
+  try {
+    const AsyncStorage = (await import('@react-native-async-storage/async-storage')).default;
+    const raw = await AsyncStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const cached: CachedResult = JSON.parse(raw);
+    if (Date.now() - cached.cachedAt < CACHE_TTL_MS) return cached.result;
+    await AsyncStorage.removeItem(CACHE_KEY);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(result: VersionCheckResult): Promise<void> {
+  try {
+    const AsyncStorage = (await import('@react-native-async-storage/async-storage')).default;
+    const cached: CachedResult = { result, cachedAt: Date.now() };
+    await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(cached));
+  } catch {
+    // non-critical
+  }
+}
+
+/**
+ * Check whether the current app version meets the server's minimum/recommended version.
+ * Returns a cached result if available and fresh (< 1 hour old).
+ */
+export async function checkAppVersion(): Promise<VersionCheckResult> {
+  const cached = await readCache();
+  if (cached) return cached;
+
+  try {
+    const { data } = await apiClient.get<VersionCheckResponse>('/app/version-check');
+
+    const currentVersion =
+      Application.nativeApplicationVersion ?? Application.applicationVersion ?? '1.0.0';
+    const storeUrl =
+      Platform.OS === 'ios' ? data.iosStoreUrl : data.androidStoreUrl;
+
+    let result: VersionCheckResult;
+
+    if (compareVersions(currentVersion, data.minimumVersion) < 0) {
+      result = { type: 'critical', storeUrl, message: data.message };
+    } else if (compareVersions(currentVersion, data.recommendedVersion) < 0) {
+      result = { type: 'recommended', storeUrl, message: data.message };
+    } else {
+      result = { type: 'up-to-date' };
+    }
+
+    await writeCache(result);
+    return result;
+  } catch (err) {
+    logError(err as Error, { context: 'checkAppVersion' });
+    return { type: 'error', message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/** Clear the cached version check result (e.g. to force a fresh check). */
+export async function clearVersionCheckCache(): Promise<void> {
+  try {
+    const AsyncStorage = (await import('@react-native-async-storage/async-storage')).default;
+    await AsyncStorage.removeItem(CACHE_KEY);
+  } catch {
+    // non-critical
+  }
+}


### PR DESCRIPTION
## Summary

This PR resolves all four open issues assigned to @BashMan11 in a single commit.

---

### Closes #421 — Background App Refresh for Medication Reminders

- **`src/services/backgroundTaskService.ts`** — new service using `expo-background-fetch` + `expo-task-manager`
  - Registers `BACKGROUND_MEDICATION_TASK` (persists across app kill/reboot on Android)
  - `rescheduleUpcomingMedications()` cancels stale notifications and re-schedules the next 24 h window on every background wake
  - Skips past dose times; logs execution for debugging
- **`App.tsx`** — calls `registerBackgroundMedicationTask()` on launch
- **`src/services/__tests__/backgroundTaskService.test.ts`** — unit tests covering registration, rescheduling, missed-dose recovery, and notification cancellation
- Added mocks for `expo-background-fetch` and `expo-task-manager`

---

### Closes #422 — Health Record Search with Full-Text Filtering

- **`src/migrations/scripts/v6_medical_records_fts.ts`** — SQLite FTS5 virtual table on `medical_records` with insert/update/delete triggers
- **`src/screens/MedicalRecordSearchScreen.tsx`** — rewritten with:
  - 300 ms debounce on text input
  - Highlighted matching terms in results
  - Recent searches panel (last 10) with per-item removal
  - Clear button
- **`src/services/searchSuggestionsService.ts`** — bumped `MAX_RECENT` from 8 → 10

---

### Closes #423 — App Update Prompt for Critical Versions

- **`backend/server/routes/app.ts`** — new `GET /api/app/version-check` endpoint returning `minimumVersion`, `recommendedVersion`, store URLs, and message (env-configurable)
- **`src/services/versionCheckService.ts`** — compares `expo-application` version against server response; returns `critical` / `recommended` / `up-to-date`; caches result for 1 hour
- **`App.tsx`** — integrates `checkAppVersion()`: critical → non-dismissible force modal, recommended → dismissible banner; falls back to existing OTA check
- **`src/services/__tests__/versionCheckService.test.ts`** — tests for all version comparison scenarios, caching, and error handling

---

### Closes #424 — End-to-End Tests with Detox

- **`.detoxrc.js`** — Detox config for iOS Simulator (`ios.sim.debug/release`) and Android Emulator (`android.emu.debug/release`)
- **`e2e/jest.config.js`** — Jest runner config for Detox
- **E2E test suites:**
  - `e2e/onboarding.test.ts` — user registration → login
  - `e2e/addPet.test.ts` — add a new pet
  - `e2e/healthRecord.test.ts` — log health record + search
  - `e2e/sos.test.ts` — emergency SOS flow
- **`testID` props** added to: `OnboardingScreen`, `LoginScreen`, `RegisterScreen`, `PetListScreen`, `PetFormScreen`, `SOSButton`
- **`.github/workflows/e2e-detox.yml`** — CI pipeline running Detox on both iOS (macOS runner) and Android (ubuntu + emulator)
- **`docs/CONTRIBUTING.md`** — E2E setup, build, and run instructions

---

## Testing

- Unit tests: `npm test` (backgroundTaskService + versionCheckService suites)
- E2E locally: `detox build --configuration ios.sim.debug && detox test --configuration ios.sim.debug`
- E2E with seeded data: `npm run seed:test && detox test --configuration ios.sim.debug`