### PR TITLE
feat: add secure API key management with rotation and admin UI

### DIFF
--- a/backend/middleware/__tests__/apiKeyAuth.test.ts
+++ b/backend/middleware/__tests__/apiKeyAuth.test.ts
@@ -1,0 +1,60 @@
+import express from 'express';
+import request from 'supertest';
+
+import apiKeyService from '../../services/apiKeyService';
+import { authenticateApiKey } from '../apiKeyAuth';
+
+describe('authenticateApiKey middleware', () => {
+  let app: express.Express;
+  let secret: string;
+
+  beforeAll(() => {
+    jest.useRealTimers();
+  });
+
+  beforeEach(async () => {
+    apiKeyService.resetApiKeyStore();
+    const created = await apiKeyService.createApiKey(
+      { name: 'Middleware test', scopes: ['pets:read', 'search:read'] },
+      'admin-1',
+    );
+    secret = created.secret;
+
+    app = express();
+    app.get('/protected', authenticateApiKey('pets:read'), (_req, res) => {
+      res.json({ ok: true });
+    });
+    app.get('/strict', authenticateApiKey('pets:write'), (_req, res) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('rejects requests without API key', async () => {
+    const res = await request(app).get('/protected');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('API_KEY_REQUIRED');
+  });
+
+  it('accepts X-Api-Key header with valid scope', async () => {
+    const res = await request(app).get('/protected').set('X-Api-Key', secret);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('accepts Authorization: ApiKey scheme', async () => {
+    const res = await request(app).get('/protected').set('Authorization', `ApiKey ${secret}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 403 when scope is insufficient', async () => {
+    const res = await request(app).get('/strict').set('X-Api-Key', secret);
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('INSUFFICIENT_SCOPE');
+  });
+
+  it('records usage after request completes', async () => {
+    await request(app).get('/protected').set('X-Api-Key', secret);
+    const usage = apiKeyService.getUsageSummary();
+    expect(usage.some((u) => u.endpoint === '/protected')).toBe(true);
+  });
+});

--- a/backend/middleware/apiKeyAuth.ts
+++ b/backend/middleware/apiKeyAuth.ts
@@ -1,0 +1,83 @@
+/**
+ * Authenticate third-party requests via X-Api-Key header with scoped permissions,
+ * per-endpoint usage tracking, and rate limiting.
+ */
+
+import { type NextFunction, type Response } from 'express';
+
+import type { AuthenticatedRequest } from './auth';
+import type { ApiKey, ApiKeyScope } from '../models/ApiKey';
+import { sendError } from '../server/response';
+import apiKeyService from '../services/apiKeyService';
+
+export interface ApiKeyAuthenticatedRequest extends AuthenticatedRequest {
+  apiKey?: ApiKey;
+}
+
+function extractApiKey(req: AuthenticatedRequest): string | null {
+  const header = req.headers['x-api-key'];
+  if (typeof header === 'string' && header.trim()) {
+    return header.trim();
+  }
+
+  const auth = req.headers.authorization;
+  if (auth?.startsWith('ApiKey ')) {
+    return auth.slice('ApiKey '.length).trim();
+  }
+
+  return null;
+}
+
+/**
+ * Require a valid API key. Optionally enforce one or more scopes.
+ */
+export function authenticateApiKey(...requiredScopes: ApiKeyScope[]) {
+  return async (req: ApiKeyAuthenticatedRequest, res: Response, next: NextFunction) => {
+    const secret = extractApiKey(req);
+    if (!secret) {
+      return sendError(
+        res,
+        401,
+        'API_KEY_REQUIRED',
+        'Provide a valid API key via X-Api-Key or Authorization: ApiKey <key>.',
+      );
+    }
+
+    try {
+      const key = await apiKeyService.validateApiKey(secret);
+      if (!key) {
+        return sendError(res, 401, 'INVALID_API_KEY', 'Invalid or expired API key.');
+      }
+
+      const endpoint = req.baseUrl + req.path;
+      if (!apiKeyService.checkRateLimit(key.id, endpoint)) {
+        apiKeyService.recordUsage(key.id, endpoint, req.method, 429);
+        return sendError(
+          res,
+          429,
+          'RATE_LIMIT_EXCEEDED',
+          'API key rate limit exceeded for this endpoint. Try again later.',
+        );
+      }
+
+      if (requiredScopes.length > 0 && !apiKeyService.hasScope(key, requiredScopes)) {
+        apiKeyService.recordUsage(key.id, endpoint, req.method, 403);
+        return sendError(
+          res,
+          403,
+          'INSUFFICIENT_SCOPE',
+          `API key missing required scope(s): ${requiredScopes.join(', ')}`,
+        );
+      }
+
+      req.apiKey = key;
+      res.on('finish', () => {
+        apiKeyService.recordUsage(key.id, endpoint, req.method, res.statusCode);
+      });
+
+      next();
+    } catch {
+      return sendError(res, 500, 'INTERNAL_ERROR', 'API key authentication failed.');
+    }
+  };
+}

--- a/backend/middleware/sanitize.ts
+++ b/backend/middleware/sanitize.ts
@@ -19,12 +19,8 @@ export function sanitizeInputs(req: Request, res: Response, next: NextFunction):
         Object.keys(req.query).forEach((k) => delete (req.query as any)[k]);
         Object.assign(req.query as any, sanitized);
       } catch {
-        // eslint-disable-next-line no-param-reassign
         req.query = sanitized;
       }
-      const sanitized = sanitizeObject(req.query) as Record<string, unknown>;
-      Object.keys(req.query).forEach((k) => delete (req.query as Record<string, unknown>)[k]);
-      Object.assign(req.query, sanitized);
     }
     if (req.params && typeof req.params === 'object') {
       const sanitized = sanitizeObject(req.params) as typeof req.params;
@@ -32,11 +28,8 @@ export function sanitizeInputs(req: Request, res: Response, next: NextFunction):
         Object.keys(req.params).forEach((k) => delete (req.params as any)[k]);
         Object.assign(req.params as any, sanitized);
       } catch {
-        // eslint-disable-next-line no-param-reassign
         req.params = sanitized;
       }
-      const sanitized = sanitizeObject(req.params) as Record<string, string>;
-      Object.assign(req.params, sanitized);
     }
     next();
   } catch (err) {

--- a/backend/migrations/010_api_keys.sql
+++ b/backend/migrations/010_api_keys.sql
@@ -1,0 +1,40 @@
+-- API keys for third-party integrations (hashes only; plaintext never stored)
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  id                      UUID PRIMARY KEY,
+  name                    TEXT NOT NULL,
+  key_prefix              TEXT NOT NULL,
+  key_hash                TEXT NOT NULL,
+  scopes                  TEXT[] NOT NULL DEFAULT '{}',
+  status                  TEXT NOT NULL DEFAULT 'active'
+                            CHECK (status IN ('active', 'rotating', 'revoked')),
+  created_by              TEXT NOT NULL,
+  expires_at              TIMESTAMPTZ,
+  rotated_from_id         UUID REFERENCES api_keys(id) ON DELETE SET NULL,
+  rotation_overlap_ends_at TIMESTAMPTZ,
+  last_used_at            TIMESTAMPTZ,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  revoked_at              TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_key_prefix ON api_keys(key_prefix);
+CREATE INDEX IF NOT EXISTS idx_api_keys_status ON api_keys(status);
+CREATE INDEX IF NOT EXISTS idx_api_keys_created_by ON api_keys(created_by);
+
+COMMENT ON TABLE api_keys IS 'Third-party API keys; key_hash is bcrypt of the full secret';
+COMMENT ON COLUMN api_keys.key_prefix IS 'Lookup prefix (first segment of issued key)';
+
+-- Per-endpoint usage analytics
+CREATE TABLE IF NOT EXISTS api_key_usage (
+  id           UUID PRIMARY KEY,
+  api_key_id   UUID NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+  endpoint     TEXT NOT NULL,
+  method       TEXT NOT NULL,
+  status_code  INTEGER NOT NULL DEFAULT 200,
+  called_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_key_usage_key_id ON api_key_usage(api_key_id);
+CREATE INDEX IF NOT EXISTS idx_api_key_usage_endpoint ON api_key_usage(endpoint);
+CREATE INDEX IF NOT EXISTS idx_api_key_usage_called_at ON api_key_usage(called_at DESC);

--- a/backend/migrations/rollback/010_api_keys_rollback.sql
+++ b/backend/migrations/rollback/010_api_keys_rollback.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS api_key_usage;
+DROP TABLE IF EXISTS api_keys;

--- a/backend/models/ApiKey.ts
+++ b/backend/models/ApiKey.ts
@@ -1,0 +1,87 @@
+/**
+ * API key domain types for third-party integrations.
+ */
+
+/** Permission scopes assignable to an API key. */
+export const API_KEY_SCOPES = [
+  'pets:read',
+  'pets:write',
+  'medical-records:read',
+  'medical-records:write',
+  'appointments:read',
+  'appointments:write',
+  'analytics:read',
+  'webhooks:write',
+  'search:read',
+] as const;
+
+export type ApiKeyScope = (typeof API_KEY_SCOPES)[number];
+
+export type ApiKeyStatus = 'active' | 'rotating' | 'revoked';
+
+export interface ApiKey {
+  id: string;
+  name: string;
+  /** Public prefix for lookup (e.g. pk_live_Ab12Cd34). */
+  keyPrefix: string;
+  /** bcrypt hash of the full secret — never exposed via API. */
+  keyHash: string;
+  scopes: ApiKeyScope[];
+  status: ApiKeyStatus;
+  createdBy: string;
+  expiresAt?: string;
+  /** Previous key id when this key was created via rotation. */
+  rotatedFromId?: string;
+  /** During rotation, old key remains valid until this timestamp. */
+  rotationOverlapEndsAt?: string;
+  lastUsedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  revokedAt?: string;
+}
+
+/** Safe view returned from list/detail endpoints (no hash). */
+export interface ApiKeyPublic {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  scopes: ApiKeyScope[];
+  status: ApiKeyStatus;
+  createdBy: string;
+  expiresAt?: string;
+  rotatedFromId?: string;
+  rotationOverlapEndsAt?: string;
+  lastUsedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  revokedAt?: string;
+}
+
+export interface ApiKeyUsageRecord {
+  id: string;
+  apiKeyId: string;
+  endpoint: string;
+  method: string;
+  statusCode: number;
+  timestamp: string;
+}
+
+export interface ApiKeyUsageSummary {
+  apiKeyId: string;
+  endpoint: string;
+  method: string;
+  count: number;
+  lastCalledAt: string;
+}
+
+export interface CreateApiKeyInput {
+  name: string;
+  scopes: ApiKeyScope[];
+  expiresAt?: string;
+}
+
+export interface ApiKeyCreateResult {
+  key: ApiKeyPublic;
+  /** Plaintext secret — shown only once at creation or rotation. */
+  secret: string;
+}

--- a/backend/public/admin/api-keys.html
+++ b/backend/public/admin/api-keys.html
@@ -1,0 +1,423 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PetChain — API Key Management</title>
+    <style>
+      :root {
+        --bg: #0f1419;
+        --surface: #1a2332;
+        --border: #2d3a4f;
+        --text: #e7ecf3;
+        --muted: #8b9cb3;
+        --accent: #3b82f6;
+        --danger: #ef4444;
+        --success: #22c55e;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        margin: 0;
+        padding: 2rem;
+        line-height: 1.5;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin: 0 0 0.25rem;
+      }
+      .subtitle {
+        color: var(--muted);
+        margin-bottom: 2rem;
+      }
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1.25rem;
+        margin-bottom: 1.5rem;
+      }
+      label {
+        display: block;
+        font-size: 0.85rem;
+        color: var(--muted);
+        margin-bottom: 0.35rem;
+      }
+      input,
+      select,
+      button {
+        font: inherit;
+      }
+      input[type='text'],
+      input[type='password'] {
+        width: 100%;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        background: var(--bg);
+        color: var(--text);
+        margin-bottom: 0.75rem;
+      }
+      .scopes {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+      }
+      .scopes label {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: var(--text);
+        cursor: pointer;
+      }
+      button {
+        padding: 0.5rem 1rem;
+        border-radius: 6px;
+        border: none;
+        cursor: pointer;
+        font-weight: 500;
+      }
+      .btn-primary {
+        background: var(--accent);
+        color: #fff;
+      }
+      .btn-danger {
+        background: transparent;
+        color: var(--danger);
+        border: 1px solid var(--danger);
+      }
+      .btn-secondary {
+        background: transparent;
+        color: var(--text);
+        border: 1px solid var(--border);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.9rem;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 0.6rem 0.5rem;
+        border-bottom: 1px solid var(--border);
+      }
+      th {
+        color: var(--muted);
+        font-weight: 500;
+      }
+      .badge {
+        display: inline-block;
+        padding: 0.15rem 0.5rem;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+      .badge-active {
+        background: #14532d;
+        color: var(--success);
+      }
+      .badge-rotating {
+        background: #422006;
+        color: #fbbf24;
+      }
+      .badge-revoked {
+        background: #450a0a;
+        color: var(--danger);
+      }
+      .secret-banner {
+        background: #14532d;
+        border: 1px solid var(--success);
+        padding: 1rem;
+        border-radius: 6px;
+        margin-bottom: 1rem;
+        word-break: break-all;
+      }
+      .error {
+        color: var(--danger);
+        margin-top: 0.5rem;
+      }
+      .actions {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+      #usage-panel h3 {
+        margin-top: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>API Key Management</h1>
+    <p class="subtitle">Admin dashboard — create, rotate, and revoke third-party integration keys.</p>
+
+    <div class="card" id="auth-card">
+      <h2 style="margin-top: 0; font-size: 1.1rem">Authentication</h2>
+      <label for="jwt">Admin JWT (Bearer token)</label>
+      <input type="password" id="jwt" placeholder="Paste admin JWT from login or mock token" />
+      <label for="api-base">API base URL</label>
+      <input type="text" id="api-base" value="/api" />
+      <button type="button" class="btn-primary" id="save-auth">Save &amp; load keys</button>
+      <p class="error" id="auth-error" hidden></p>
+    </div>
+
+    <div id="secret-banner" class="secret-banner" hidden>
+      <strong>Copy this secret now — it will not be shown again:</strong>
+      <pre id="secret-value" style="margin: 0.5rem 0 0"></pre>
+      <button type="button" class="btn-secondary" id="dismiss-secret">Dismiss</button>
+    </div>
+
+    <div class="card" id="create-card" hidden>
+      <h2 style="margin-top: 0; font-size: 1.1rem">Create API key</h2>
+      <label for="key-name">Name</label>
+      <input type="text" id="key-name" placeholder="e.g. Partner CRM integration" />
+      <label>Scopes</label>
+      <div class="scopes" id="scopes-container"></div>
+      <button type="button" class="btn-primary" id="create-key">Create key</button>
+      <p class="error" id="create-error" hidden></p>
+    </div>
+
+    <div class="card" id="keys-card" hidden>
+      <h2 style="margin-top: 0; font-size: 1.1rem">API keys</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Prefix</th>
+            <th>Scopes</th>
+            <th>Status</th>
+            <th>Last used</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody id="keys-tbody"></tbody>
+      </table>
+    </div>
+
+    <div class="card" id="usage-panel" hidden>
+      <h3>Usage analytics</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Key ID</th>
+            <th>Method</th>
+            <th>Endpoint</th>
+            <th>Count</th>
+            <th>Last called</th>
+          </tr>
+        </thead>
+        <tbody id="usage-tbody"></tbody>
+      </table>
+    </div>
+
+    <script>
+      const STORAGE_JWT = 'petchain_admin_jwt';
+      const STORAGE_BASE = 'petchain_api_base';
+
+      const jwtInput = document.getElementById('jwt');
+      const apiBaseInput = document.getElementById('api-base');
+      const authError = document.getElementById('auth-error');
+      const secretBanner = document.getElementById('secret-banner');
+      const secretValue = document.getElementById('secret-value');
+      const scopesContainer = document.getElementById('scopes-container');
+      const keysTbody = document.getElementById('keys-tbody');
+      const usageTbody = document.getElementById('usage-tbody');
+
+      function getJwt() {
+        return localStorage.getItem(STORAGE_JWT) || jwtInput.value.trim();
+      }
+
+      function getBase() {
+        return localStorage.getItem(STORAGE_BASE) || apiBaseInput.value.trim() || '/api';
+      }
+
+      async function api(path, options = {}) {
+        const res = await fetch(`${getBase()}${path}`, {
+          ...options,
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${getJwt()}`,
+            ...(options.headers || {}),
+          },
+        });
+        const body = await res.json();
+        if (!res.ok) {
+          throw new Error(body.error?.message || res.statusText);
+        }
+        return body.data;
+      }
+
+      function showSecret(secret) {
+        secretValue.textContent = secret;
+        secretBanner.hidden = false;
+      }
+
+      function statusBadge(status) {
+        const cls =
+          status === 'active'
+            ? 'badge-active'
+            : status === 'rotating'
+              ? 'badge-rotating'
+              : 'badge-revoked';
+        return `<span class="badge ${cls}">${status}</span>`;
+      }
+
+      async function loadScopes() {
+        const data = await api('/api-keys/scopes');
+        scopesContainer.innerHTML = data.scopes
+          .map(
+            (s) =>
+              `<label><input type="checkbox" name="scope" value="${s}" /> ${s}</label>`,
+          )
+          .join('');
+      }
+
+      async function loadKeys() {
+        const keys = await api('/api-keys');
+        keysTbody.innerHTML = keys
+          .map(
+            (k) => `
+          <tr>
+            <td>${escapeHtml(k.name)}</td>
+            <td><code>${escapeHtml(k.keyPrefix)}…</code></td>
+            <td>${k.scopes.map(escapeHtml).join(', ')}</td>
+            <td>${statusBadge(k.status)}</td>
+            <td>${k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleString() : '—'}</td>
+            <td class="actions">
+              ${
+                k.status !== 'revoked'
+                  ? `<button type="button" class="btn-secondary" data-rotate="${k.id}">Rotate</button>`
+                  : ''
+              }
+              ${
+                k.status !== 'revoked'
+                  ? `<button type="button" class="btn-danger" data-revoke="${k.id}">Revoke</button>`
+                  : ''
+              }
+            </td>
+          </tr>`,
+          )
+          .join('');
+
+        keysTbody.querySelectorAll('[data-rotate]').forEach((btn) => {
+          btn.addEventListener('click', () => rotateKey(btn.dataset.rotate));
+        });
+        keysTbody.querySelectorAll('[data-revoke]').forEach((btn) => {
+          btn.addEventListener('click', () => revokeKey(btn.dataset.revoke));
+        });
+      }
+
+      async function loadUsage() {
+        const usage = await api('/api-keys/usage');
+        usageTbody.innerHTML = usage
+          .map(
+            (u) => `
+          <tr>
+            <td><code>${escapeHtml(u.apiKeyId.slice(0, 8))}…</code></td>
+            <td>${escapeHtml(u.method)}</td>
+            <td>${escapeHtml(u.endpoint)}</td>
+            <td>${u.count}</td>
+            <td>${new Date(u.lastCalledAt).toLocaleString()}</td>
+          </tr>`,
+          )
+          .join('');
+        document.getElementById('usage-panel').hidden = usage.length === 0;
+      }
+
+      function escapeHtml(str) {
+        return String(str)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;');
+      }
+
+      async function rotateKey(id) {
+        if (!confirm('Rotate this key? The old key stays valid during the overlap period.')) return;
+        try {
+          const result = await api(`/api-keys/${id}/rotate`, { method: 'POST', body: '{}' });
+          showSecret(result.secret);
+          await refresh();
+        } catch (e) {
+          alert(e.message);
+        }
+      }
+
+      async function revokeKey(id) {
+        if (!confirm('Revoke this key immediately?')) return;
+        try {
+          await api(`/api-keys/${id}`, { method: 'DELETE' });
+          await refresh();
+        } catch (e) {
+          alert(e.message);
+        }
+      }
+
+      async function refresh() {
+        await loadKeys();
+        await loadUsage();
+      }
+
+      document.getElementById('save-auth').addEventListener('click', async () => {
+        authError.hidden = true;
+        const jwt = jwtInput.value.trim();
+        if (!jwt) {
+          authError.textContent = 'JWT is required';
+          authError.hidden = false;
+          return;
+        }
+        localStorage.setItem(STORAGE_JWT, jwt);
+        localStorage.setItem(STORAGE_BASE, apiBaseInput.value.trim() || '/api');
+        try {
+          await loadScopes();
+          document.getElementById('create-card').hidden = false;
+          document.getElementById('keys-card').hidden = false;
+          await refresh();
+        } catch (e) {
+          authError.textContent = e.message;
+          authError.hidden = false;
+        }
+      });
+
+      document.getElementById('create-key').addEventListener('click', async () => {
+        const createError = document.getElementById('create-error');
+        createError.hidden = true;
+        const name = document.getElementById('key-name').value.trim();
+        const scopes = [...document.querySelectorAll('input[name="scope"]:checked')].map(
+          (el) => el.value,
+        );
+        if (!name || scopes.length === 0) {
+          createError.textContent = 'Name and at least one scope are required';
+          createError.hidden = false;
+          return;
+        }
+        try {
+          const result = await api('/api-keys', {
+            method: 'POST',
+            body: JSON.stringify({ name, scopes }),
+          });
+          showSecret(result.secret);
+          document.getElementById('key-name').value = '';
+          await refresh();
+        } catch (e) {
+          createError.textContent = e.message;
+          createError.hidden = false;
+        }
+      });
+
+      document.getElementById('dismiss-secret').addEventListener('click', () => {
+        secretBanner.hidden = true;
+      });
+
+      const savedJwt = localStorage.getItem(STORAGE_JWT);
+      const savedBase = localStorage.getItem(STORAGE_BASE);
+      if (savedJwt) jwtInput.value = savedJwt;
+      if (savedBase) apiBaseInput.value = savedBase;
+    </script>
+  </body>
+</html>

--- a/backend/server/app.ts
+++ b/backend/server/app.ts
@@ -5,25 +5,24 @@ import express, { type Express, type NextFunction, type Request, type Response }
 
 import { errBody } from './response';
 import { getRedisClient } from '../config/redis';
+import performanceLogger from '../middleware/performanceLogger';
 import { createRedisSessionMiddleware } from '../middleware/redisSession';
+import { requestLogger } from '../middleware/requestLogger';
 import { sanitizeInputs } from '../middleware/sanitize';
 import { applySecurityHeaders } from '../middleware/securityHeaders';
-import authRouter from './routes/auth';
-import { requestLogger } from '../middleware/requestLogger';
-import logger from '../utils/logger';
 import { getCacheMetrics, warmCache } from '../services/cacheService';
-import anchorRouter from '../src/routes/anchor';
+import logger from '../utils/logger';
 import analyticsRouter from './routes/analytics';
-import performanceLogger from '../middleware/performanceLogger';
 import appointmentsRouter from './routes/appointments';
 import auditLogsRouter from './routes/auditLogs';
 import auditTrailRouter from './routes/auditTrail';
+import authRouter from './routes/auth';
 import backupsRouter from './routes/backups';
 import breedsRouter from './routes/breeds';
 import communityRouter from './routes/community';
-import forumRouter from './routes/forum';
 import docsRouter from './routes/docs';
 import emergencyRouter from './routes/emergency';
+import forumRouter from './routes/forum';
 import importRouter from './routes/import';
 import insuranceRouter from './routes/insurance';
 import medicalRecordsRouter from './routes/medicalRecords';
@@ -32,18 +31,21 @@ import paymentsRouter from './routes/payments';
 import petsRouter from './routes/pets';
 import photosRouter from './routes/photos';
 import privacyRouter from './routes/privacy';
+import reconciliationRouter from './routes/reconciliation';
 import reportsRouter from './routes/reports';
 import searchRouter from './routes/search';
 import syncRouter from './routes/sync';
-import travelCertificatesRouter from './routes/travelCertificates';
 import telemedicineRouter from './routes/telemedicine';
-import reconciliationRouter from './routes/reconciliation';
+import travelCertificatesRouter from './routes/travelCertificates';
 import usersRouter from './routes/users';
 import vaccinationsRouter from './routes/vaccinations';
 import vetsRouter from './routes/vets';
 import vitalsRouter from './routes/vitals';
 import { attachAudit } from '../middleware/auditLog';
+import anchorRouter from '../src/routes/anchor';
+import apiKeysRouter from '../src/routes/apiKeys';
 import federationRouter from '../src/routes/federation';
+import integrationsRouter from '../src/routes/integrations';
 
 // Readiness probe state — set to false while the process is draining
 let isReady = true;
@@ -72,6 +74,8 @@ export function createApp(): Express {
     '/.well-known',
     express.static(path.join(__dirname, '../.well-known'), { dotfiles: 'allow' }),
   );
+
+  app.use('/admin', express.static(path.join(__dirname, '../public/admin')));
 
   const api = express.Router();
 
@@ -130,6 +134,8 @@ export function createApp(): Express {
   api.use('/insurance', insuranceRouter);
   api.use('/search', searchRouter);
   api.use('/vitals', vitalsRouter);
+  api.use('/api-keys', apiKeysRouter);
+  api.use('/integrations', integrationsRouter);
 
   app.use('/api', api);
 

--- a/backend/server/index.ts
+++ b/backend/server/index.ts
@@ -1,6 +1,7 @@
 import http from 'http';
 
 import { createApp } from './app';
+import apiKeyService from '../services/apiKeyService';
 import logger from '../utils/logger';
 
 const PORT = Number(process.env.PORT) || 3000;
@@ -46,6 +47,10 @@ server.listen(PORT, () => {
   logger.info(`PetChain REST API listening on http://localhost:${PORT}/api`);
   logger.info(`Health:  http://localhost:${PORT}/api/health`);
   logger.info(`Ready:   http://localhost:${PORT}/api/ready`);
+  logger.info(`Admin:   http://localhost:${PORT}/admin/api-keys.html`);
+
+  // Revoke rotated keys automatically once their overlap window ends
+  setInterval(() => apiKeyService.processRotationExpiry(), 60_000).unref();
 
   if (process.send) process.send('ready');
 });

--- a/backend/server/store.ts
+++ b/backend/server/store.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 
+import type { ApiKey, ApiKeyUsageRecord } from '../models/ApiKey';
 import { AppointmentStatus, AppointmentType } from '../models/Appointment';
 import { UserRole } from '../models/UserRole';
 
@@ -256,6 +257,9 @@ export interface StoredTravelCertificate {
 
 const travelCertificates = new Map<string, StoredTravelCertificate>();
 
+const apiKeys = new Map<string, ApiKey>();
+const apiKeyUsage: ApiKeyUsageRecord[] = [];
+
 export function newId(): string {
   return randomUUID();
 }
@@ -266,5 +270,7 @@ export const store = {
   petQrIdentities,
   emergencySessions,
   travelCertificates,
+  apiKeys,
+  apiKeyUsage,
   newId,
 };

--- a/backend/services/__tests__/apiKeyService.test.ts
+++ b/backend/services/__tests__/apiKeyService.test.ts
@@ -1,0 +1,142 @@
+import type { ApiKeyScope } from '../../models/ApiKey';
+import { store } from '../../server/store';
+import apiKeyService, {
+  DEFAULT_ROTATION_OVERLAP_MS,
+  generateKeyMaterial,
+  hashKey,
+  verifyKey,
+} from '../apiKeyService';
+
+describe('apiKeyService', () => {
+  beforeAll(() => {
+    jest.useRealTimers();
+  });
+
+  beforeEach(() => {
+    apiKeyService.resetApiKeyStore();
+  });
+
+  describe('key generation', () => {
+    it('generates cryptographically formatted keys with pk_live prefix', () => {
+      const { secret, prefix } = generateKeyMaterial();
+      expect(secret).toMatch(/^pk_live_[A-Za-z0-9_-]+$/);
+      expect(prefix).toBe(secret.slice(0, 16));
+    });
+
+    it('stores bcrypt hash, never plaintext', async () => {
+      const { secret } = generateKeyMaterial();
+      const hash = await hashKey(secret);
+      expect(hash).not.toBe(secret);
+      expect(hash.startsWith('$2')).toBe(true);
+      expect(await verifyKey(secret, hash)).toBe(true);
+      expect(await verifyKey('wrong-key', hash)).toBe(false);
+    });
+  });
+
+  describe('create and validate', () => {
+    it('creates a key with scopes and validates it', async () => {
+      const scopes: ApiKeyScope[] = ['pets:read', 'search:read'];
+      const { secret, key } = await apiKeyService.createApiKey(
+        { name: 'Test Partner', scopes },
+        'admin-1',
+      );
+
+      expect(key.name).toBe('Test Partner');
+      expect(key.scopes).toEqual(scopes);
+      expect(key.keyPrefix).toBe(secret.slice(0, 16));
+      expect(secret).toMatch(/^pk_live_/);
+
+      const validated = await apiKeyService.validateApiKey(secret);
+      expect(validated?.id).toBe(key.id);
+    });
+
+    it('rejects invalid scopes on create', async () => {
+      await expect(
+        apiKeyService.createApiKey(
+          { name: 'Bad', scopes: ['invalid:scope'] as ApiKeyScope[] },
+          'admin-1',
+        ),
+      ).rejects.toThrow('INVALID_SCOPES');
+    });
+
+    it('rejects unknown or revoked keys', async () => {
+      expect(await apiKeyService.validateApiKey('pk_live_notavalidkeyxx')).toBeNull();
+
+      const { secret, key } = await apiKeyService.createApiKey(
+        { name: 'Revoke me', scopes: ['pets:read'] },
+        'admin-1',
+      );
+      apiKeyService.revokeApiKey(key.id);
+      expect(await apiKeyService.validateApiKey(secret)).toBeNull();
+    });
+  });
+
+  describe('rotation', () => {
+    it('rotates with overlap — old key works until overlap ends', async () => {
+      const created = await apiKeyService.createApiKey(
+        { name: 'Rotate test', scopes: ['pets:read'] },
+        'admin-1',
+      );
+
+      const rotated = await apiKeyService.rotateApiKey(created.key.id, 60_000);
+      expect(rotated.secret).not.toBe(created.secret);
+      expect(rotated.key.rotatedFromId).toBe(created.key.id);
+
+      expect(await apiKeyService.validateApiKey(created.secret)).not.toBeNull();
+      expect(await apiKeyService.validateApiKey(rotated.secret)).not.toBeNull();
+
+      const oldRecord = [...store.apiKeys.values()].find((k) => k.id === created.key.id)!;
+      oldRecord.rotationOverlapEndsAt = new Date(Date.now() - 1000).toISOString();
+      apiKeyService.processRotationExpiry();
+
+      expect(await apiKeyService.validateApiKey(created.secret)).toBeNull();
+      expect(await apiKeyService.validateApiKey(rotated.secret)).not.toBeNull();
+    });
+
+    it('uses default overlap period constant', () => {
+      expect(DEFAULT_ROTATION_OVERLAP_MS).toBe(7 * 24 * 60 * 60 * 1000);
+    });
+  });
+
+  describe('usage and rate limiting', () => {
+    it('records usage per endpoint', async () => {
+      const { key } = await apiKeyService.createApiKey(
+        { name: 'Usage', scopes: ['pets:read'] },
+        'admin-1',
+      );
+      apiKeyService.recordUsage(key.id, '/api/integrations/pets', 'GET', 200);
+      apiKeyService.recordUsage(key.id, '/api/integrations/pets', 'GET', 200);
+
+      const summary = apiKeyService.getUsageSummary(key.id);
+      expect(summary).toHaveLength(1);
+      expect(summary[0].count).toBe(2);
+      expect(summary[0].endpoint).toBe('/api/integrations/pets');
+    });
+
+    it('enforces per-endpoint rate limits', async () => {
+      const { key } = await apiKeyService.createApiKey(
+        { name: 'Rate', scopes: ['pets:read'] },
+        'admin-1',
+      );
+      const endpoint = '/api/integrations/pets';
+      let allowed = 0;
+      for (let i = 0; i < 105; i++) {
+        if (apiKeyService.checkRateLimit(key.id, endpoint)) allowed += 1;
+      }
+      expect(allowed).toBe(100);
+    });
+  });
+
+  describe('scopes', () => {
+    it('checks required scopes', async () => {
+      const { key: pub } = await apiKeyService.createApiKey(
+        { name: 'Scoped', scopes: ['pets:read'] },
+        'admin-1',
+      );
+      const full = [...store.apiKeys.values()].find((k) => k.id === pub.id)!;
+      expect(apiKeyService.hasScope(full, 'pets:read')).toBe(true);
+      expect(apiKeyService.hasScope(full, 'pets:write')).toBe(false);
+      expect(apiKeyService.hasScope(full, ['pets:read', 'search:read'])).toBe(false);
+    });
+  });
+});

--- a/backend/services/apiKeyService.ts
+++ b/backend/services/apiKeyService.ts
@@ -1,0 +1,314 @@
+/**
+ * API key lifecycle: generation, bcrypt storage, rotation overlap, usage analytics.
+ */
+
+import { createHash, randomBytes } from 'crypto';
+
+import bcrypt from 'bcryptjs';
+
+import type {
+  ApiKey,
+  ApiKeyCreateResult,
+  ApiKeyPublic,
+  ApiKeyScope,
+  ApiKeyUsageRecord,
+  ApiKeyUsageSummary,
+  CreateApiKeyInput,
+} from '../models/ApiKey';
+import { API_KEY_SCOPES } from '../models/ApiKey';
+import { store, newId } from '../server/store';
+
+const BCRYPT_ROUNDS = process.env.NODE_ENV === 'test' ? 4 : 10;
+const KEY_RANDOM_BYTES = 32;
+const PREFIX_SEGMENT = 'pk_live';
+/** Default overlap window while old and new keys both work during rotation. */
+export const DEFAULT_ROTATION_OVERLAP_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Per-key per-endpoint rate limit: max requests per window. */
+const RATE_LIMIT_MAX = 100;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+
+interface RateLimitBucket {
+  count: number;
+  windowStart: number;
+}
+
+const rateLimitBuckets = new Map<string, RateLimitBucket>();
+
+function toPublic(key: ApiKey): ApiKeyPublic {
+  const { keyHash: _hash, ...rest } = key;
+  return rest;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/** Cryptographically secure API key material. */
+export function generateKeyMaterial(): { secret: string; prefix: string } {
+  const randomPart = randomBytes(KEY_RANDOM_BYTES).toString('base64url');
+  const secret = `${PREFIX_SEGMENT}_${randomPart}`;
+  const prefix = secret.slice(0, PREFIX_SEGMENT.length + 9);
+  return { secret, prefix };
+}
+
+export async function hashKey(secret: string): Promise<string> {
+  return bcrypt.hashSync(secret, BCRYPT_ROUNDS);
+}
+
+export async function verifyKey(secret: string, hash: string): Promise<boolean> {
+  return bcrypt.compareSync(secret, hash);
+}
+
+function isScopeValid(scopes: string[]): scopes is ApiKeyScope[] {
+  return (
+    scopes.length > 0 && scopes.every((s) => (API_KEY_SCOPES as readonly string[]).includes(s))
+  );
+}
+
+function isKeyUsable(key: ApiKey, at = Date.now()): boolean {
+  if (key.status === 'revoked') return false;
+  if (key.expiresAt && new Date(key.expiresAt).getTime() <= at) return false;
+  if (key.status === 'rotating' && key.rotationOverlapEndsAt) {
+    return new Date(key.rotationOverlapEndsAt).getTime() > at;
+  }
+  return key.status === 'active' || key.status === 'rotating';
+}
+
+/** Expire rotating keys whose overlap window has ended. */
+export function processRotationExpiry(): void {
+  const now = Date.now();
+  for (const key of store.apiKeys.values()) {
+    if (
+      key.status === 'rotating' &&
+      key.rotationOverlapEndsAt &&
+      new Date(key.rotationOverlapEndsAt).getTime() <= now
+    ) {
+      key.status = 'revoked';
+      key.revokedAt = nowIso();
+      key.updatedAt = nowIso();
+    }
+  }
+}
+
+export async function createApiKey(
+  input: CreateApiKeyInput,
+  createdBy: string,
+): Promise<ApiKeyCreateResult> {
+  if (!isScopeValid(input.scopes)) {
+    throw new Error('INVALID_SCOPES');
+  }
+
+  const { secret, prefix } = generateKeyMaterial();
+  const keyHash = await hashKey(secret);
+  const t = nowIso();
+  const id = newId();
+
+  const record: ApiKey = {
+    id,
+    name: input.name.trim(),
+    keyPrefix: prefix,
+    keyHash,
+    scopes: input.scopes,
+    status: 'active',
+    createdBy,
+    expiresAt: input.expiresAt,
+    createdAt: t,
+    updatedAt: t,
+  };
+
+  store.apiKeys.set(id, record);
+
+  return { key: toPublic(record), secret };
+}
+
+export function listApiKeys(): ApiKeyPublic[] {
+  processRotationExpiry();
+  return [...store.apiKeys.values()]
+    .map(toPublic)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export function getApiKey(id: string): ApiKeyPublic | undefined {
+  const key = store.apiKeys.get(id);
+  return key ? toPublic(key) : undefined;
+}
+
+export async function validateApiKey(secret: string): Promise<ApiKey | null> {
+  processRotationExpiry();
+
+  if (!secret.startsWith(`${PREFIX_SEGMENT}_`)) {
+    return null;
+  }
+
+  const prefix = secret.slice(0, PREFIX_SEGMENT.length + 9);
+  const candidates = [...store.apiKeys.values()].filter(
+    (k) => k.keyPrefix === prefix && isKeyUsable(k),
+  );
+
+  for (const candidate of candidates) {
+    if (await verifyKey(secret, candidate.keyHash)) {
+      candidate.lastUsedAt = nowIso();
+      candidate.updatedAt = nowIso();
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function hasScope(key: ApiKey, required: ApiKeyScope | ApiKeyScope[]): boolean {
+  const needed = Array.isArray(required) ? required : [required];
+  return needed.every((s) => key.scopes.includes(s));
+}
+
+/**
+ * Rotate an API key: issue a new secret, mark the old key as rotating with overlap.
+ */
+export async function rotateApiKey(
+  id: string,
+  overlapMs = DEFAULT_ROTATION_OVERLAP_MS,
+): Promise<ApiKeyCreateResult> {
+  const existing = store.apiKeys.get(id);
+  if (!existing) {
+    throw new Error('NOT_FOUND');
+  }
+  if (existing.status === 'revoked') {
+    throw new Error('ALREADY_REVOKED');
+  }
+
+  const overlapEnds = new Date(Date.now() + overlapMs).toISOString();
+  existing.status = 'rotating';
+  existing.rotationOverlapEndsAt = overlapEnds;
+  existing.updatedAt = nowIso();
+
+  const { secret, prefix } = generateKeyMaterial();
+  const keyHash = await hashKey(secret);
+  const t = nowIso();
+  const newKeyId = newId();
+
+  const record: ApiKey = {
+    id: newKeyId,
+    name: existing.name,
+    keyPrefix: prefix,
+    keyHash,
+    scopes: [...existing.scopes],
+    status: 'active',
+    createdBy: existing.createdBy,
+    expiresAt: existing.expiresAt,
+    rotatedFromId: existing.id,
+    createdAt: t,
+    updatedAt: t,
+  };
+
+  store.apiKeys.set(newKeyId, record);
+
+  return { key: toPublic(record), secret };
+}
+
+export function revokeApiKey(id: string): ApiKeyPublic | null {
+  const key = store.apiKeys.get(id);
+  if (!key) return null;
+  if (key.status === 'revoked') return toPublic(key);
+
+  key.status = 'revoked';
+  key.revokedAt = nowIso();
+  key.updatedAt = nowIso();
+  return toPublic(key);
+}
+
+export function recordUsage(
+  apiKeyId: string,
+  endpoint: string,
+  method: string,
+  statusCode: number,
+): void {
+  const record: ApiKeyUsageRecord = {
+    id: newId(),
+    apiKeyId,
+    endpoint,
+    method: method.toUpperCase(),
+    statusCode,
+    timestamp: nowIso(),
+  };
+  store.apiKeyUsage.push(record);
+}
+
+export function getUsageSummary(apiKeyId?: string): ApiKeyUsageSummary[] {
+  const records = apiKeyId
+    ? store.apiKeyUsage.filter((r) => r.apiKeyId === apiKeyId)
+    : store.apiKeyUsage;
+
+  const map = new Map<string, ApiKeyUsageSummary>();
+
+  for (const r of records) {
+    const bucketKey = `${r.apiKeyId}|${r.method}|${r.endpoint}`;
+    const existing = map.get(bucketKey);
+    if (!existing) {
+      map.set(bucketKey, {
+        apiKeyId: r.apiKeyId,
+        endpoint: r.endpoint,
+        method: r.method,
+        count: 1,
+        lastCalledAt: r.timestamp,
+      });
+    } else {
+      existing.count += 1;
+      if (r.timestamp > existing.lastCalledAt) {
+        existing.lastCalledAt = r.timestamp;
+      }
+    }
+  }
+
+  return [...map.values()].sort((a, b) => b.lastCalledAt.localeCompare(a.lastCalledAt));
+}
+
+/** Sliding-window rate limit per apiKeyId + endpoint. */
+export function checkRateLimit(apiKeyId: string, endpoint: string): boolean {
+  const bucketKey = createHash('sha256').update(`${apiKeyId}:${endpoint}`).digest('hex');
+  const now = Date.now();
+  let bucket = rateLimitBuckets.get(bucketKey);
+
+  if (!bucket || now - bucket.windowStart >= RATE_LIMIT_WINDOW_MS) {
+    bucket = { count: 0, windowStart: now };
+    rateLimitBuckets.set(bucketKey, bucket);
+  }
+
+  if (bucket.count >= RATE_LIMIT_MAX) {
+    return false;
+  }
+
+  bucket.count += 1;
+  return true;
+}
+
+/** Reset in-memory state (tests). */
+export function resetApiKeyStore(): void {
+  store.apiKeys.clear();
+  store.apiKeyUsage.length = 0;
+  rateLimitBuckets.clear();
+}
+
+export function getAvailableScopes(): readonly ApiKeyScope[] {
+  return API_KEY_SCOPES;
+}
+
+export default {
+  createApiKey,
+  listApiKeys,
+  getApiKey,
+  validateApiKey,
+  rotateApiKey,
+  revokeApiKey,
+  recordUsage,
+  getUsageSummary,
+  checkRateLimit,
+  hasScope,
+  generateKeyMaterial,
+  hashKey,
+  verifyKey,
+  processRotationExpiry,
+  resetApiKeyStore,
+  getAvailableScopes,
+  DEFAULT_ROTATION_OVERLAP_MS,
+};

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -16,6 +16,7 @@ const MIGRATION_FILES = [
   '005_community_and_health_metrics.sql',
   '006_audit_trail.sql',
   '009_pet_weight.sql',
+  '010_api_keys.sql',
   '20260528_create_forum_tables.sql',
 ];
 

--- a/backend/src/routes/__tests__/apiKeys.test.ts
+++ b/backend/src/routes/__tests__/apiKeys.test.ts
@@ -1,0 +1,130 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import request from 'supertest';
+
+import config from '../../../config';
+import { UserRole } from '../../../models/UserRole';
+import { store } from '../../../server/store';
+import apiKeyService from '../../../services/apiKeyService';
+import apiKeysRouter from '../apiKeys';
+import integrationsRouter from '../integrations';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api-keys', apiKeysRouter);
+  app.use('/integrations', integrationsRouter);
+  return app;
+}
+
+describe('API key management routes', () => {
+  let app: express.Express;
+  let adminToken: string;
+  let ownerToken: string;
+
+  beforeAll(() => {
+    jest.useRealTimers();
+  });
+
+  beforeEach(() => {
+    apiKeyService.resetApiKeyStore();
+    store.users.clear();
+    store.pets.clear();
+
+    store.users.set('admin-1', {
+      id: 'admin-1',
+      email: 'admin@test.com',
+      name: 'Admin',
+      role: UserRole.ADMIN,
+      pets: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      isEmailVerified: true,
+      twoFactorEnabled: true,
+    });
+
+    store.users.set('owner-1', {
+      id: 'owner-1',
+      email: 'owner@test.com',
+      name: 'Owner',
+      role: UserRole.OWNER,
+      pets: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      isEmailVerified: true,
+      twoFactorEnabled: false,
+    });
+
+    adminToken = jwt.sign(
+      { sub: 'admin-1', email: 'admin@test.com', role: UserRole.ADMIN },
+      config.app.jwtSecret,
+    );
+    ownerToken = jwt.sign(
+      { sub: 'owner-1', email: 'owner@test.com', role: UserRole.OWNER },
+      config.app.jwtSecret,
+    );
+
+    app = buildApp();
+  });
+
+  it('denies non-admin access', async () => {
+    const res = await request(app).get('/api-keys').set('Authorization', `Bearer ${ownerToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('creates, lists, rotates, and revokes keys', async () => {
+    const createRes = await request(app)
+      .post('/api-keys')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Partner', scopes: ['pets:read'] });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.data.secret).toMatch(/^pk_live_/);
+    expect(createRes.body.data.key.name).toBe('Partner');
+
+    const keyId = createRes.body.data.key.id;
+    const plaintext = createRes.body.data.secret;
+
+    const listRes = await request(app)
+      .get('/api-keys')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.data).toHaveLength(1);
+    expect(listRes.body.data[0].keyHash).toBeUndefined();
+
+    const rotateRes = await request(app)
+      .post(`/api-keys/${keyId}/rotate`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({});
+    expect(rotateRes.status).toBe(200);
+    expect(rotateRes.body.data.secret).not.toBe(plaintext);
+
+    const revokeRes = await request(app)
+      .delete(`/api-keys/${keyId}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(revokeRes.status).toBe(200);
+    expect(revokeRes.body.data.status).toBe('revoked');
+  });
+
+  it('integration endpoint accepts valid API key', async () => {
+    const createRes = await request(app)
+      .post('/api-keys')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Integration', scopes: ['pets:read'] });
+
+    const secret = createRes.body.data.secret;
+    store.pets.set('pet-1', {
+      id: 'pet-1',
+      name: 'Buddy',
+      species: 'dog',
+      ownerId: 'owner-1',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const res = await request(app).get('/integrations/pets').set('X-Api-Key', secret);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].name).toBe('Buddy');
+  });
+});

--- a/backend/src/routes/anchor.ts
+++ b/backend/src/routes/anchor.ts
@@ -29,10 +29,11 @@ router.post('/deposit', async (req: AuthenticatedRequest, res: Response) => {
 
   const SUPPORTED_CURRENCIES = ['USD', 'EUR'];
   if (!SUPPORTED_CURRENCIES.includes(currency.toUpperCase())) {
-    return res.status(400).json({ error: `Unsupported currency. Supported: ${SUPPORTED_CURRENCIES.join(', ')}` });
+    return res
+      .status(400)
+      .json({ error: `Unsupported currency. Supported: ${SUPPORTED_CURRENCIES.join(', ')}` });
   }
 
-  const userId = req.user!.id;
   const result = await stellarAnchorService.initiateDeposit(
     userId,
     walletAddress,

--- a/backend/src/routes/apiKeys.ts
+++ b/backend/src/routes/apiKeys.ts
@@ -1,0 +1,119 @@
+/**
+ * Admin API key management routes.
+ */
+
+import express from 'express';
+
+import { authenticateJWT, authorizeRoles, type AuthenticatedRequest } from '../../middleware/auth';
+import type { ApiKeyScope, CreateApiKeyInput } from '../../models/ApiKey';
+import { API_KEY_SCOPES } from '../../models/ApiKey';
+import { UserRole } from '../../models/UserRole';
+import { ok, sendError } from '../../server/response';
+import apiKeyService from '../../services/apiKeyService';
+
+const router = express.Router();
+
+router.use(authenticateJWT, authorizeRoles(UserRole.ADMIN));
+
+/** Available scopes for key creation UI. */
+router.get('/scopes', (_req, res) => {
+  return res.json(ok({ scopes: API_KEY_SCOPES }));
+});
+
+/** List all API keys (no secrets). */
+router.get('/', (_req, res) => {
+  return res.json(ok(apiKeyService.listApiKeys()));
+});
+
+/** Usage analytics aggregated per endpoint. */
+router.get('/usage', (req, res) => {
+  const apiKeyId = typeof req.query.apiKeyId === 'string' ? req.query.apiKeyId : undefined;
+  return res.json(ok(apiKeyService.getUsageSummary(apiKeyId)));
+});
+
+/** Create a new API key — plaintext secret returned once. */
+router.post('/', async (req: AuthenticatedRequest, res) => {
+  const body = req.body as Partial<CreateApiKeyInput>;
+  if (!body.name?.trim()) {
+    return sendError(res, 400, 'VALIDATION_ERROR', 'name is required');
+  }
+  if (!Array.isArray(body.scopes) || body.scopes.length === 0) {
+    return sendError(res, 400, 'VALIDATION_ERROR', 'scopes must be a non-empty array');
+  }
+
+  try {
+    const result = await apiKeyService.createApiKey(
+      {
+        name: body.name,
+        scopes: body.scopes as ApiKeyScope[],
+        expiresAt: body.expiresAt,
+      },
+      req.user!.id,
+    );
+    return res
+      .status(201)
+      .json(ok(result, 'API key created. Store the secret securely — it will not be shown again.'));
+  } catch (err) {
+    if (err instanceof Error && err.message === 'INVALID_SCOPES') {
+      return sendError(
+        res,
+        400,
+        'INVALID_SCOPES',
+        `scopes must be one of: ${API_KEY_SCOPES.join(', ')}`,
+      );
+    }
+    return sendError(res, 500, 'INTERNAL_ERROR', 'Failed to create API key');
+  }
+});
+
+router.get('/:id', (req, res) => {
+  const key = apiKeyService.getApiKey(req.params.id);
+  if (!key) {
+    return sendError(res, 404, 'NOT_FOUND', 'API key not found');
+  }
+  return res.json(ok(key));
+});
+
+router.get('/:id/usage', (req, res) => {
+  const key = apiKeyService.getApiKey(req.params.id);
+  if (!key) {
+    return sendError(res, 404, 'NOT_FOUND', 'API key not found');
+  }
+  return res.json(ok(apiKeyService.getUsageSummary(req.params.id)));
+});
+
+/** Rotate key — new secret with overlap period for the previous key. */
+router.post('/:id/rotate', async (req, res) => {
+  const overlapMs =
+    typeof req.body?.overlapMs === 'number' && req.body.overlapMs > 0
+      ? req.body.overlapMs
+      : undefined;
+
+  try {
+    const result = await apiKeyService.rotateApiKey(req.params.id, overlapMs);
+    return res.json(
+      ok(result, 'API key rotated. Old key remains valid until the overlap period ends.'),
+    );
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message === 'NOT_FOUND') {
+        return sendError(res, 404, 'NOT_FOUND', 'API key not found');
+      }
+      if (err.message === 'ALREADY_REVOKED') {
+        return sendError(res, 400, 'ALREADY_REVOKED', 'Cannot rotate a revoked key');
+      }
+    }
+    return sendError(res, 500, 'INTERNAL_ERROR', 'Failed to rotate API key');
+  }
+});
+
+/** Revoke an API key immediately. */
+router.delete('/:id', (req, res) => {
+  const key = apiKeyService.revokeApiKey(req.params.id);
+  if (!key) {
+    return sendError(res, 404, 'NOT_FOUND', 'API key not found');
+  }
+  return res.json(ok(key, 'API key revoked'));
+});
+
+export default router;

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -1,0 +1,25 @@
+/**
+ * Third-party integration endpoints authenticated via API keys.
+ */
+
+import express from 'express';
+
+import { authenticateApiKey } from '../../middleware/apiKeyAuth';
+import { ok } from '../../server/response';
+import { store } from '../../server/store';
+
+const router = express.Router();
+
+/** List pets (scoped integration access). */
+router.get('/pets', authenticateApiKey('pets:read'), (_req, res) => {
+  const pets = [...store.pets.values()].map((p) => ({
+    id: p.id,
+    name: p.name,
+    species: p.species,
+    breed: p.breed,
+    ownerId: p.ownerId,
+  }));
+  return res.json(ok(pets));
+});
+
+export default router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,12 @@
         "@react-navigation/native-stack": "6.11.0",
         "@sentry/react-native": "^6.5.0",
         "@stellar/freighter-api": "^6.0.1",
-        "@stellar/stellar-sdk": "^15.0.1",
+        "@stellar/stellar-sdk": "^13.1.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@urql/core": "^5.0.0",
-        "axios": "^1.15.2",
+        "axios": "^1.13.5",
+        "bcryptjs": "^2.4.3",
+        "bip39": "^3.0.4",
         "crypto-js": "^4.2.0",
         "expo-barcode-scanner": "^13.0.1",
         "expo-camera": "^55.0.16",
@@ -36,14 +38,24 @@
         "graphql": "^16.0.0",
         "helmet": "^8.0.0",
         "i18next": "^26.0.8",
+        "ioredis": "^5.6.1",
         "jsonwebtoken": "^9.0.3",
+        "otplib": "^12.0.1",
+        "pdf-parse": "^1.1.1",
+        "pdfkit": "0.15.1",
+        "qrcode": "1.5.4",
         "react-i18next": "^17.0.6",
         "react-native-image-picker": "^7.0.0",
         "react-native-image-resizer": "^1.4.5",
         "react-native-keychain": "^10.0.0",
         "react-native-ssl-pinning": "^1.5.3",
         "react-native-webrtc": "^124.0.3",
-        "swagger-ui-express": "^5.0.1"
+        "secrets.js-grempe": "^1.1.0",
+        "swagger-ui-express": "^5.0.1",
+        "tesseract.js": "^5.0.4",
+        "winston": "3.17.0",
+        "winston-daily-rotate-file": "5.0.0",
+        "ws": "^8.18.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.29.7",
@@ -56,6 +68,7 @@
         "@storybook/addon-ondevice-notes": "^8.6.0",
         "@storybook/blocks": "^8.6.0",
         "@storybook/react-native": "^8.6.0",
+        "@types/bcryptjs": "^2.4.6",
         "@types/connect-redis": "^0.0.23",
         "@types/cors": "^2.8.19",
         "@types/crypto-js": "^4.2.2",
@@ -63,11 +76,15 @@
         "@types/helmet": "^0.0.48",
         "@types/jest": "^29.5.14",
         "@types/node": "^20.0.0",
+        "@types/pdfkit": "0.13.9",
         "@types/pg": "^8.20.0",
+        "@types/qrcode": "^1.5.5",
         "@types/react": "^19.1.1",
         "@types/react-native": "^0.72.0",
         "@types/supertest": "^7.2.0",
         "@types/swagger-ui-express": "^4.1.8",
+        "@types/winston": "^2.4.4",
+        "@types/ws": "^8.5.14",
         "axios-mock-adapter": "^2.1.0",
         "babel-plugin-react-native-web": "^0.19.13",
         "babel-preset-expo": "^56.0.13",
@@ -2216,6 +2233,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -4020,7 +4057,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
       "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
@@ -4715,21 +4751,6 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
-    "node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -4795,6 +4816,56 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/plugin-crypto": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
+      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/plugin-thirty-two": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
+      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "thirty-two": "^1.0.2"
+      }
+    },
+    "node_modules/@otplib/preset-default": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
+      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/preset-v11": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
+      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
     },
     "node_modules/@oxc-project/types": {
       "version": "0.127.0",
@@ -5900,6 +5971,62 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@so-ric/colorspace/node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@so-ric/colorspace/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@so-ric/colorspace/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@so-ric/colorspace/node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "dev": true,
@@ -5952,30 +6079,29 @@
       }
     },
     "node_modules/@stellar/js-xdr": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-4.0.0.tgz",
-      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20.0.0",
-        "pnpm": ">=9.0.0"
-      }
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-15.0.0.tgz",
-      "integrity": "sha512-XQhxUr9BYiEcFcgc4oWcCMR9QJCny/GmmGsuwPKf/ieIcOeb5149KLHYx9mJCA0ea8QbucR2/GzV58QbXOTxQA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.1.0.tgz",
+      "integrity": "sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/curves": "^1.9.7",
-        "@stellar/js-xdr": "^4.0.0",
+        "@stellar/js-xdr": "^3.1.2",
         "base32.js": "^0.1.0",
-        "bignumber.js": "^9.3.1",
+        "bignumber.js": "^9.1.2",
         "buffer": "^6.0.3",
-        "sha.js": "^2.4.12"
+        "sha.js": "^2.3.6",
+        "tweetnacl": "^1.0.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "sodium-native": "^4.3.3"
       }
     },
     "node_modules/@stellar/stellar-base/node_modules/buffer": {
@@ -6003,46 +6129,22 @@
       }
     },
     "node_modules/@stellar/stellar-sdk": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-15.0.1.tgz",
-      "integrity": "sha512-iZjWKXtfohsPh+CX9wRyQNIlXLeA9VyuQB6UMC7AFBD9XnR92eOjnlfeONzk/Bsrkk6+UPlpzSy2MuF+ydHP1A==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.3.0.tgz",
+      "integrity": "sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/stellar-base": "^15.0.0",
-        "axios": "1.14.0",
-        "bignumber.js": "^9.3.1",
-        "commander": "^14.0.3",
+        "@stellar/stellar-base": "^13.1.0",
+        "axios": "^1.8.4",
+        "bignumber.js": "^9.3.0",
         "eventsource": "^2.0.2",
         "feaxios": "^0.0.23",
         "randombytes": "^2.1.0",
         "toml": "^3.0.0",
-        "urijs": "^1.19.11"
-      },
-      "bin": {
-        "stellar-js": "bin/stellar-js"
+        "urijs": "^1.19.1"
       },
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@stellar/stellar-sdk/node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/@stellar/stellar-sdk/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@stellar/stellar-sdk/node_modules/eventsource": {
@@ -7005,6 +7107,15 @@
         "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -7052,6 +7163,13 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -7246,6 +7364,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pdfkit": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.13.9.tgz",
+      "integrity": "sha512-RDG8Yb1zT7I01FfpwK7nMSA433XWpblMqSCtA5vJlSyavWZb303HUYPCel6JTiDDFqwGLvtAnYbH8N/e0Cb89g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
@@ -7256,6 +7384,16 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -7388,12 +7526,39 @@
         "@types/serve-static": "*"
       }
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/winston": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
+      "deprecated": "This is a stub types definition. winston provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "winston": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -7968,7 +8133,6 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -8145,6 +8309,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -8460,6 +8630,50 @@
       "integrity": "sha512-Q5kjXpVH5I3ItykNzbWmfWnNryFN1ZTWp10k9/PKJuS0RnoKR7jTrHEJODR4fn04bRomq7TJwie/Dr9fj/GoGQ==",
       "license": "MIT"
     },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
+      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.2.tgz",
+      "integrity": "sha512-j+hiD5k99qec4KjJvYsI67q5AOBifmy9JG3oeMVxTmvrhn2sIdp8StrUvZu4YNgwTpO+NhniQG16N1ETDe1k5w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-semver": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.3.tgz",
+      "integrity": "sha512-HS/A30bi2+PiRJfU6R4+Kp+6KeLSCSByjYM2iiobOKzLAvtu1CT+S8xWfiU7wz0erknjkUoC+yXy108tzIuP5Q==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/base32.js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
@@ -8496,6 +8710,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
     },
     "node_modules/better-opn": {
       "version": "3.0.2",
@@ -8539,6 +8759,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -8622,11 +8857,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browser-assert": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -8991,7 +9244,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
       "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
@@ -9448,6 +9700,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "license": "MIT",
@@ -9563,7 +9824,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
@@ -9623,6 +9883,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "dev": true,
@@ -9630,6 +9896,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dnssd-advertise": {
       "version": "1.1.4",
@@ -9797,6 +10069,12 @@
       "version": "8.0.0",
       "license": "MIT"
     },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -9922,6 +10200,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-iterator-helpers": {
@@ -12477,6 +12775,12 @@
         "is-retry-allowed": "^3.0.0"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/fetch-nodeshim": {
       "version": "0.4.10",
       "resolved": "https://registry.npmjs.org/fetch-nodeshim/-/fetch-nodeshim-0.4.10.tgz",
@@ -12493,6 +12797,15 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.1"
       }
     },
     "node_modules/fill-range": {
@@ -12550,7 +12863,6 @@
     },
     "node_modules/find-up": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -12584,6 +12896,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "funding": [
@@ -12608,6 +12926,64 @@
       "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==",
       "license": "BSD-2-Clause",
       "peer": true
+    },
+    "node_modules/fontkit": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
+      "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.3.13",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "deep-equal": "^2.0.5",
+        "dfa": "^1.2.0",
+        "restructure": "^2.0.1",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.3.1",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/fontkit/node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -12743,7 +13119,6 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12997,7 +13372,6 @@
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13273,6 +13647,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.4.tgz",
+      "integrity": "sha512-D/NzHWUmYJGXi++z67aMSrnisb9A3621CyRK5G89JyTlN13C8xf0g04DLxUKMufPem3e3L2JAXR6Z00OWy183Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "funding": [
@@ -13377,7 +13757,6 @@
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -13399,7 +13778,6 @@
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.0.tgz",
       "integrity": "sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ioredis/commands": "1.10.0",
@@ -13449,7 +13827,6 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -13488,7 +13865,6 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.2"
@@ -13502,7 +13878,6 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13578,7 +13953,6 @@
     },
     "node_modules/is-date-object": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -13603,6 +13977,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -13669,7 +14049,6 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13717,7 +14096,6 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13771,7 +14149,6 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13782,7 +14159,6 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -13796,7 +14172,6 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13807,7 +14182,6 @@
     },
     "node_modules/is-string": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -13822,7 +14196,6 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -13849,9 +14222,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13876,7 +14254,6 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -14675,6 +15052,13 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -14822,6 +15206,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
     },
     "node_modules/lan-network": {
       "version": "0.2.1",
@@ -15136,6 +15526,25 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "license": "MIT"
@@ -15385,7 +15794,6 @@
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -15718,6 +16126,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/loose-envify": {
@@ -16398,6 +16823,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
@@ -16578,6 +17012,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "dev": true,
@@ -16725,6 +17165,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -16876,6 +17325,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
     "node_modules/onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -16904,6 +17362,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/optionator": {
@@ -17041,6 +17508,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/otplib": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
+      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/preset-default": "^12.0.1",
+        "@otplib/preset-v11": "^12.0.1"
+      }
+    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "dev": true,
@@ -17078,7 +17556,6 @@
     },
     "node_modules/p-locate": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -17089,7 +17566,6 @@
     },
     "node_modules/p-locate/node_modules/p-limit": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -17103,7 +17579,6 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17112,6 +17587,12 @@
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -17160,7 +17641,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17218,6 +17698,35 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
+      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfkit": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.15.1.tgz",
+      "integrity": "sha512-sleaMQXbQ/Dk+38HlxdiMT6Lmw5+HoNc4vkJR1Tb9XGALuB1xrfdWYbDFta70F3jCrVkhA2DiQ52D7jbysGZrw==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^1.8.1",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.0.2",
+        "png-js": "^1.0.0"
+      }
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -17316,6 +17825,14 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
       }
     },
     "node_modules/pngjs": {
@@ -17588,6 +18105,119 @@
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -18069,7 +18699,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.9.1.tgz",
       "integrity": "sha512-kb6lGtBI5Ap41tvBPM09Np472r2GXuJ+jRApIFy1eXBk699eChG3U+lyqRC2/wz/VDpaJAy6i5XPcceNOoH3mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -18134,6 +18764,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -18165,7 +18809,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -18175,7 +18818,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "redis-errors": "^1.0.0"
@@ -18227,12 +18869,10 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -18284,6 +18924,19 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "license": "MIT",
@@ -18297,6 +18950,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -18367,6 +19026,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/restructure": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
+      "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg==",
+      "license": "MIT"
     },
     "node_modules/rettime": {
       "version": "0.11.8",
@@ -18523,6 +19188,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -18540,6 +19214,12 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/secrets.js-grempe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/secrets.js-grempe/-/secrets.js-grempe-1.1.0.tgz",
+      "integrity": "sha512-OsbpZUFTjvQPKHpseAbFPY82U3mVNP4G3WSbJiDtMLjzwsV52MTdc6rTwIooIkg3klf5eCrg62ZuGIz5GaW02A==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -18662,6 +19342,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-cookie-parser": {
       "version": "3.1.0",
       "dev": true,
@@ -18684,7 +19370,6 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -18927,6 +19612,16 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/sodium-native": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
+      "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "require-addon": "^1.1.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -18977,6 +19672,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "dev": true,
@@ -19025,7 +19729,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/statuses": {
@@ -19045,7 +19748,6 @@
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -19106,6 +19808,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -19538,6 +20249,31 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/tesseract.js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-5.1.1.tgz",
+      "integrity": "sha512-lzVl/Ar3P3zhpUT31NjqeCo1f+D5+YfpZ5J62eo2S14QNVOmHBTtbchHm/YAbOOOzCegFnKf4B3Qih9LuldcYQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-electron": "^2.2.2",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^5.1.1",
+        "wasm-feature-detect": "^1.2.11",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-5.1.1.tgz",
+      "integrity": "sha512-KX3bYSU5iGcO1XJa+QGPbi+Zjo2qq6eBhNjSGR5E5q0JtzkoipJKOUQD7ph8kFyteCEfEQ0maWLu8MCXtvX5uQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "dev": true,
@@ -19595,6 +20331,12 @@
         "node": "*"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "license": "MIT",
@@ -19612,12 +20354,26 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "engines": {
+        "node": ">=0.2.6"
+      }
+    },
     "node_modules/throat": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -19749,6 +20505,15 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "dev": true,
@@ -19870,7 +20635,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -19890,6 +20654,12 @@
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -20146,6 +20916,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
@@ -20154,6 +20934,22 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
     },
     "node_modules/unique-string": {
       "version": "2.0.0",
@@ -20248,6 +21044,12 @@
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -20487,6 +21289,12 @@
       "version": "0.1.1",
       "license": "MIT"
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -20563,7 +21371,6 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
@@ -20607,7 +21414,6 @@
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
@@ -20621,6 +21427,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
@@ -20654,6 +21466,60 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-daily-rotate-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
+      "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^3.0.0",
+        "triple-beam": "^1.4.1",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "winston": "^3"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/wonka": {
@@ -20861,6 +21727,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
       "^expo-sqlite$": "<rootDir>/src/__mocks__/expo-sqlite.ts",
       "^expo-notifications$": "<rootDir>/src/__mocks__/expo-notifications.ts",
       "^expo-secure-store$": "<rootDir>/src/__mocks__/expo-secure-store.ts",
-      "^@sentry/react-native$": "<rootDir>/src/__mocks__/@sentry/react-native.ts"
+      "^@sentry/react-native$": "<rootDir>/src/__mocks__/@sentry/react-native.ts",
       "^pg$": "<rootDir>/src/__mocks__/pg.js",
       "^@elastic/elasticsearch$": "<rootDir>/src/__mocks__/@elastic/elasticsearch.js",
       "^socket\\.io$": "<rootDir>/src/__mocks__/socket.io.js",
@@ -149,10 +149,9 @@
     "react-native-webrtc": "^124.0.3",
     "helmet": "^8.0.0",
     "swagger-ui-express": "^5.0.1",
-    "tesseract.js": "^5.0.4"
-    "swagger-ui-express": "^5.0.1"
+    "tesseract.js": "^5.0.4",
     "winston": "3.17.0",
-    "winston-daily-rotate-file": "5.0.0"
+    "winston-daily-rotate-file": "5.0.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
@@ -201,7 +200,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "8.59.0",
     "vitest": "^4.1.5",
-    "@types/winston": "^2.4.4"
+    "@types/winston": "^2.4.4",
     "vitest": "^4.1.5"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- Add cryptographically secure API keys with configurable scopes (pets, medical records, analytics, webhooks, etc.)
- Store keys as bcrypt hashes only; plaintext secret shown once on create/rotate
- Key rotation with a 7-day overlap window; rotated keys auto-revoke when overlap ends
- Per-endpoint usage tracking and rate limiting (100 requests/min per key + endpoint)
- Admin management UI at `/admin/api-keys.html`
- REST API at `/api/api-keys` (admin JWT) and sample integration route `/api/integrations/pets` (API key)
- PostgreSQL migration `010_api_keys.sql` for `api_keys` and `api_key_usage` tables
- 18 tests covering key generation, validation, rotation, middleware, and routes

Closes #330  issues #330


## Test plan
- [x] `npx jest --config jest.config.js --testPathPattern="apiKey" --runInBand`
- [x] `npm run migrate` (with `DATABASE_URL` set)
- [x] Open `http://localhost:3000/admin/api-keys.html`, create/rotate/revoke a key with admin JWT
- [x] Call `GET /api/integrations/pets` with `X-Api-Key` header
- [x] Verify usage analytics via `GET /api/api-keys/usage`