### PR TITLE
feat(vet-checkin-qr): add appointment check-in QR generation and display

### DIFF
--- a/src/screens/AppointmentDetailScreen.tsx
+++ b/src/screens/AppointmentDetailScreen.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  Modal,
+  SafeAreaView,
+  Share,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { generateAppointmentCheckinQRCode } from '../services/qrService';
+import { getPetById } from '../services/petService';
+
+interface AppointmentDetailScreenProps {
+  route: {
+    params: {
+      appointmentId: string;
+      petId: string;
+      appointmentTitle?: string;
+      appointmentDate?: string;
+    };
+  };
+}
+
+const AppointmentDetailScreen: React.FC<AppointmentDetailScreenProps> = ({ route }) => {
+  const { appointmentId, petId, appointmentTitle, appointmentDate } = route.params;
+
+  const [loading, setLoading] = useState(false);
+  const [qrUrl, setQrUrl] = useState<string | null>(null);
+  const [qrPayload, setQrPayload] = useState<string | null>(null);
+  const [modalVisible, setModalVisible] = useState(false);
+
+  const onShowQR = async () => {
+    try {
+      setLoading(true);
+      // Ensure pet exists locally / fetch
+      await getPetById(petId);
+
+      const { payload, imageUrl } = await generateAppointmentCheckinQRCode(petId, appointmentId, {
+        imageSize: 600,
+      });
+
+      setQrPayload(payload);
+      setQrUrl(imageUrl);
+      setModalVisible(true);
+    } catch (err) {
+      Alert.alert('Unable to generate QR', String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onShare = async () => {
+    if (!qrUrl) return;
+    try {
+      await Share.share({ message: `Check-in QR: ${qrUrl}`, url: qrUrl, title: 'PetChain Check-in QR' });
+    } catch (err) {
+      // ignore
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>{appointmentTitle ?? 'Appointment'}</Text>
+        <Text style={styles.subtitle}>{appointmentDate ?? ''}</Text>
+      </View>
+
+      <View style={styles.body}>
+        <TouchableOpacity style={styles.button} onPress={onShowQR} accessibilityRole="button">
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.buttonText}>Show Check-in QR</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+
+      <Modal visible={modalVisible} animationType="slide" onRequestClose={() => setModalVisible(false)}>
+        <SafeAreaView style={styles.modalContainer}>
+          <View style={styles.modalHeader}>
+            <TouchableOpacity onPress={() => setModalVisible(false)} style={styles.closeButton}>
+              <Text style={styles.closeText}>Close</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={onShare} style={styles.shareButton}>
+              <Text style={styles.shareText}>Share</Text>
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.qrContainer}>
+            {qrUrl ? (
+              <Image source={{ uri: qrUrl }} style={styles.qrImage} resizeMode="contain" />
+            ) : (
+              <ActivityIndicator size="large" />
+            )}
+            <Text style={styles.expiryText}>QR expires in 24 hours from generation</Text>
+          </View>
+        </SafeAreaView>
+      </Modal>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#ffffff' },
+  header: { padding: 20, borderBottomWidth: 1, borderColor: '#eee' },
+  title: { fontSize: 20, fontWeight: '600' },
+  subtitle: { marginTop: 6, color: '#6b7280' },
+  body: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  button: {
+    backgroundColor: '#10B981',
+    paddingHorizontal: 28,
+    paddingVertical: 14,
+    borderRadius: 10,
+  },
+  buttonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  modalContainer: { flex: 1, backgroundColor: '#000' },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    padding: 16,
+    alignItems: 'center',
+  },
+  closeButton: {},
+  closeText: { color: '#fff', fontSize: 16 },
+  shareButton: {},
+  shareText: { color: '#fff', fontSize: 16 },
+  qrContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  qrImage: { width: '92%', height: '70%' },
+  expiryText: { color: '#fff', marginTop: 12 },
+});
+
+export default AppointmentDetailScreen;

--- a/src/services/qrService.ts
+++ b/src/services/qrService.ts
@@ -1,0 +1,114 @@
+import CryptoJS from 'crypto-js';
+import * as SecureStore from 'expo-secure-store';
+import StellarSdk from '@stellar/stellar-sdk';
+
+import { encodePayload } from '../utils/qrUtils';
+import { getQRImageUrl } from './qrCodeService';
+import * as petService from './petService';
+import * as medicationService from './medicationService';
+import * as vaccinationService from './vaccinationService';
+
+const STELLAR_SECRET_KEY = 'stellar.secret';
+
+export interface CheckinHealthSummary {
+  weightKg?: number | null;
+  medications: Array<{ id: string; name: string; dosage?: string; status?: string }>;
+  allergies: string[];
+  recentVaccinations: Array<{ id: string; vaccineName: string; administeredDate?: string }>;
+}
+
+export interface CheckinPayload {
+  type: 'vet_checkin';
+  version: number;
+  petId: string;
+  appointmentId: string;
+  generatedAt: number;
+  expiresAt: number;
+  healthSummaryHash: string; // hex
+  healthSummary: CheckinHealthSummary;
+  signerPublicKey?: string;
+  signature?: string; // base64
+}
+
+/** Default: 24 hours expiry */
+const DEFAULT_EXPIRY_MS = 24 * 60 * 60 * 1000;
+
+async function getStoredStellarSecret(): Promise<string | null> {
+  try {
+    return await SecureStore.getItemAsync(STELLAR_SECRET_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function computeHash(obj: unknown): string {
+  const json = JSON.stringify(obj);
+  return CryptoJS.SHA256(json).toString(CryptoJS.enc.Hex);
+}
+
+export const generateAppointmentCheckinQRCode = async (
+  petId: string,
+  appointmentId: string,
+  opts?: { signerSecret?: string; expiryMs?: number; imageSize?: number },
+): Promise<{ payload: string; imageUrl: string; raw: CheckinPayload }> => {
+  const expiryMs = opts?.expiryMs ?? DEFAULT_EXPIRY_MS;
+
+  const pet = await petService.getPetById(petId);
+
+  const allMeds = await medicationService.getMedications();
+  const meds = allMeds.filter((m) => m.petId === petId).map((m) => ({ id: m.id, name: m.name, dosage: m.dosage, status: m.status }));
+
+  let vaccinations: Array<{ id: string; vaccineName: string; administeredDate?: string }> = [];
+  try {
+    const v = await vaccinationService.getVaccinationReminders(petId);
+    vaccinations = v.map((r) => ({ id: r.id, vaccineName: r.vaccineName, administeredDate: r.lastAdministeredDate }));
+  } catch {
+    vaccinations = [];
+  }
+
+  const healthSummary: CheckinHealthSummary = {
+    weightKg: pet.weightKg ?? null,
+    medications: meds,
+    allergies: (pet as any).allergies ?? [],
+    recentVaccinations: vaccinations,
+  };
+
+  const generatedAt = Date.now();
+  const expiresAt = generatedAt + expiryMs;
+
+  const healthSummaryHash = computeHash(healthSummary);
+
+  const payload: CheckinPayload = {
+    type: 'vet_checkin',
+    version: 1,
+    petId: petId,
+    appointmentId: appointmentId,
+    generatedAt,
+    expiresAt,
+    healthSummaryHash,
+    healthSummary,
+  };
+
+  // Determine signer
+  const secret = opts?.signerSecret ?? (await getStoredStellarSecret());
+  if (secret) {
+    try {
+      const keypair = StellarSdk.Keypair.fromSecret(secret);
+      const sig = keypair.sign(Buffer.from(healthSummaryHash, 'hex'));
+      payload.signerPublicKey = keypair.publicKey();
+      payload.signature = Buffer.from(sig).toString('base64');
+    } catch (err) {
+      // Do not fail QR generation if signing fails — return unsigned payload
+      // but include an error log via console for visibility.
+      // eslint-disable-next-line no-console
+      console.warn('QR signing failed:', err);
+    }
+  }
+
+  const encoded = encodePayload(payload);
+  const imageUrl = getQRImageUrl(encoded, opts?.imageSize ?? 420);
+
+  return { payload: encoded, imageUrl, raw: payload };
+};
+
+export default { generateAppointmentCheckinQRCode };


### PR DESCRIPTION
This PR adds a vet appointment check-in QR flow.

- Generates a QR payload containing petId, appointmentId, 24h expiry, health summary hash and embedded summary.
- Optionally signs the health summary hash with the user's Stellar keypair (if stored under secure key `stellar.secret`).
- Persists image URL via existing QR image service for easy full-screen display in the appointment screen.

Security: QR payload expires after 24 hours and includes a SHA256 hash of the health summary.

Closes #410
Closes #412
Closes #334
Closes #331