### PR TITLE
feat: implement automated medication and push notification reminders

### DIFF
--- a/src/models/Medication.ts
+++ b/src/models/Medication.ts
@@ -12,6 +12,16 @@ export interface PharmacyInfo {
 
 export type MedicationStatus = 'active' | 'paused' | 'completed' | 'discontinued';
 
+/**
+ * Refill status derived from current supply and dosage schedule.
+ * - 'ok'       : supply will last > 7 days
+ * - 'warning'  : supply will run out in 4-7 days (7-day reminder window)
+ * - 'urgent'   : supply will run out within 3 days (3-day reminder window)
+ * - 'out'      : no supply remaining
+ * - 'unknown'  : supply information not provided
+ */
+export type RefillStatus = 'ok' | 'warning' | 'urgent' | 'out' | 'unknown';
+
 export interface Medication {
   id: string;
   petId: string;
@@ -30,6 +40,22 @@ export interface Medication {
   notes?: string;
   createdAt?: string;
   updatedAt?: string;
+
+  // ── Refill tracking fields ──────────────────────────────────────────────────
+  /** Current number of doses/pills on hand (writable; decremented each dose). */
+  currentSupply?: number;
+  /** How many doses are taken per day based on the frequency schedule. */
+  dosesPerDay?: number;
+  /** ISO date string of the most-recent refill (used to calculate next run-out). */
+  lastRefillDate?: string;
+  /**
+   * Estimated date the supply will run out, as an ISO date string.
+   * Derived from currentSupply, dosesPerDay, and the current date.
+   * Persisted so the value survives restarts without re-calculation.
+   */
+  estimatedRunOutDate?: string;
+  /** IDs of the scheduled refill-reminder push notifications for this medication. */
+  refillNotificationIds?: string[];
 }
 
 export interface CreateMedicationInput extends Omit<Medication, 'id' | 'createdAt' | 'updatedAt'> {

--- a/src/screens/MedicationScreen.tsx
+++ b/src/screens/MedicationScreen.tsx
@@ -14,13 +14,17 @@ import {
 import {
   type DoseLog,
   type Medication,
+  type RefillStatus,
   deleteMedication,
   getDaySchedule,
   getDoseLogs,
   getMedications,
+  getRefillStatus,
   logDose,
+  markRefillComplete,
   saveMedication,
   scheduleRefillReminder,
+  syncRefillReminders,
 } from '../services/medicationService';
 import {
   checkDrugInteractions,
@@ -77,6 +81,10 @@ const MedicationScreen: React.FC = () => {
   const [vetOverrideMode, setVetOverrideMode] = useState(false);
   const [vetId, setVetId] = useState('');
   const [overrideJustification, setOverrideJustification] = useState('');
+  // Refill modal state
+  const [refillModalVisible, setRefillModalVisible] = useState(false);
+  const [refillTargetMed, setRefillTargetMed] = useState<Medication | null>(null);
+  const [newSupplyInput, setNewSupplyInput] = useState('');
 
   const loadData = useCallback(async () => {
     const [meds, logs] = await Promise.all([getMedications(), getDoseLogs()]);
@@ -132,16 +140,22 @@ const MedicationScreen: React.FC = () => {
       }
     }
 
+    const remainingPills = form.remainingPills ? Number(form.remainingPills) : undefined;
+    const currentSupply =
+      form.currentSupply !== undefined ? Number(form.currentSupply) : remainingPills;
     const med: Medication = {
       ...form,
       id: editingMed?.id ?? Date.now().toString(),
       frequency: Number(form.frequency) || 8,
       totalPills: form.totalPills ? Number(form.totalPills) : undefined,
-      remainingPills: form.remainingPills ? Number(form.remainingPills) : undefined,
+      remainingPills,
+      currentSupply,
     };
     await saveMedication(med);
     await scheduleRefillReminder(med);
     await scheduleMedicationReminder(med);
+    // Sync refill reminder notifications whenever supply/frequency changes
+    await syncRefillReminders(med);
     setInteractionResult(null);
     setVetOverrideMode(false);
     setVetId('');
@@ -177,11 +191,18 @@ const MedicationScreen: React.FC = () => {
       };
       await logDose(log);
       const med = medications.find((m) => m.id === medicationId);
-      if (med?.remainingPills !== undefined && !skipped) {
-        await saveMedication({
+      if (med && !skipped) {
+        // Decrement both supply fields, then resync run-out & notifications
+        const newSupply = Math.max(
+          0,
+          (med.currentSupply ?? med.remainingPills ?? 0) - 1,
+        );
+        const updatedMed: Medication = {
           ...med,
-          remainingPills: Math.max(0, med.remainingPills - 1),
-        });
+          currentSupply: newSupply,
+          remainingPills: newSupply,
+        };
+        await syncRefillReminders(updatedMed);
       }
       void loadData();
     },
@@ -198,17 +219,61 @@ const MedicationScreen: React.FC = () => {
     );
   };
 
+  const openRefillModal = useCallback((med: Medication) => {
+    setRefillTargetMed(med);
+    setNewSupplyInput('');
+    setRefillModalVisible(true);
+  }, []);
+
+  const handleRefillComplete = async () => {
+    if (!refillTargetMed) return;
+    const qty = parseInt(newSupplyInput, 10);
+    if (isNaN(qty) || qty <= 0) {
+      Alert.alert('Invalid quantity', 'Please enter a positive number of doses/pills.');
+      return;
+    }
+    await markRefillComplete(refillTargetMed, qty);
+    setRefillModalVisible(false);
+    setRefillTargetMed(null);
+    setNewSupplyInput('');
+    void loadData();
+  };
+
   const renderMedItem = useCallback(
     ({ item }: { item: Medication }) => {
+      const supply = item.currentSupply ?? item.remainingPills;
       const lowStock =
         item.remainingPills !== undefined &&
         item.totalPills !== undefined &&
         item.remainingPills <= item.totalPills * 0.2;
+      const refillStatus: RefillStatus = getRefillStatus(item);
+
+      const refillBadgeStyle = [
+        styles.refillBadge,
+        refillStatus === 'urgent' || refillStatus === 'out'
+          ? styles.refillBadgeUrgent
+          : refillStatus === 'warning'
+            ? styles.refillBadgeWarning
+            : styles.refillBadgeOk,
+      ];
+      const refillBadgeLabel: Record<RefillStatus, string> = {
+        ok: '✅ Supply OK',
+        warning: '⚠️ Refill Soon',
+        urgent: '🚨 Refill Now',
+        out: '❌ Out of Stock',
+        unknown: '',
+      };
+
       return (
         <View style={styles.card}>
           <View style={styles.cardHeader}>
             <Text style={styles.medName}>{item.name}</Text>
             <View style={styles.cardActions}>
+              {refillStatus !== 'unknown' && (
+                <View style={refillBadgeStyle}>
+                  <Text style={styles.refillBadgeText}>{refillBadgeLabel[refillStatus]}</Text>
+                </View>
+              )}
               <TouchableOpacity onPress={() => openEdit(item)} style={styles.actionBtn}>
                 <Text style={styles.actionBtnText}>Edit</Text>
               </TouchableOpacity>
@@ -243,12 +308,22 @@ const MedicationScreen: React.FC = () => {
           {item.endDate ? (
             <Text style={styles.medDetail}>Ends: {formatLocalDate(item.endDate)}</Text>
           ) : null}
-          {item.remainingPills !== undefined && (
+          {supply !== undefined && (
             <Text style={[styles.medDetail, lowStock && styles.lowStock]}>
-              Pills remaining: {item.remainingPills}
+              Supply remaining: {supply} dose{supply !== 1 ? 's' : ''}
               {lowStock ? ' ⚠ Low stock' : ''}
             </Text>
           )}
+          {item.estimatedRunOutDate ? (
+            <Text style={styles.medDetail}>
+              Est. run-out: {formatLocalDate(item.estimatedRunOutDate)}
+            </Text>
+          ) : null}
+          {item.lastRefillDate ? (
+            <Text style={styles.medDetail}>
+              Last refilled: {formatLocalDate(item.lastRefillDate)}
+            </Text>
+          ) : null}
           {item.refillDate ? (
             <Text style={styles.medDetail}>Refill by: {formatLocalDate(item.refillDate)}</Text>
           ) : null}
@@ -265,11 +340,17 @@ const MedicationScreen: React.FC = () => {
             >
               <Text style={styles.logBtnText}>✗ Skip</Text>
             </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.logBtn, styles.refillBtn]}
+              onPress={() => openRefillModal(item)}
+            >
+              <Text style={styles.logBtnText}>+ Refill</Text>
+            </TouchableOpacity>
           </View>
         </View>
       );
     },
-    [openEdit, handleDelete, handleLogDose],
+    [openEdit, handleDelete, handleLogDose, openRefillModal],
   );
   const renderSchedule = (dates: Date[]) => (
     <ScrollView style={styles.scheduleContainer}>
@@ -456,6 +537,18 @@ const MedicationScreen: React.FC = () => {
             }
           />
           <TextInput
+            style={styles.input}
+            placeholder="Current supply (doses on hand — used for refill reminders)"
+            keyboardType="numeric"
+            value={form.currentSupply !== undefined ? String(form.currentSupply) : ''}
+            onChangeText={(v) =>
+              setForm((f) => ({
+                ...f,
+                currentSupply: v ? Number(v) : undefined,
+              }))
+            }
+          />
+          <TextInput
             style={[styles.input, styles.textArea]}
             placeholder="Notes"
             multiline
@@ -516,6 +609,45 @@ const MedicationScreen: React.FC = () => {
     </Modal>
   );
 
+  const renderRefillModal = () => (
+    <Modal
+      visible={refillModalVisible}
+      animationType="slide"
+      transparent
+      onRequestClose={() => setRefillModalVisible(false)}
+    >
+      <View style={styles.modalOverlay}>
+        <View style={[styles.modalContent, { paddingBottom: 30 }]}>
+          <Text style={styles.modalTitle}>Mark Refill Complete</Text>
+          {refillTargetMed && (
+            <Text style={[styles.medDetail, { marginBottom: 12 }]}>
+              {refillTargetMed.name} — enter new supply count
+            </Text>
+          )}
+          <TextInput
+            style={styles.input}
+            placeholder="New dose / pill count"
+            keyboardType="numeric"
+            value={newSupplyInput}
+            onChangeText={setNewSupplyInput}
+            autoFocus
+          />
+          <View style={styles.modalActions}>
+            <TouchableOpacity
+              style={styles.cancelBtn}
+              onPress={() => setRefillModalVisible(false)}
+            >
+              <Text style={styles.cancelBtnText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.saveBtn} onPress={() => void handleRefillComplete()}>
+              <Text style={styles.saveBtnText}>Confirm Refill</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+
   return (
     <View style={styles.container}>
       <View style={styles.header}>
@@ -553,6 +685,7 @@ const MedicationScreen: React.FC = () => {
       {tab === 'daily' && renderSchedule(todayDates())}
       {tab === 'weekly' && renderSchedule(weekDates())}
       {renderModal()}
+      {renderRefillModal()}
     </View>
   );
 };
@@ -616,7 +749,18 @@ const styles = StyleSheet.create({
   deleteBtnText: { color: '#e53935' },
   medDetail: { fontSize: 13, color: '#555', marginTop: 2 },
   lowStock: { color: '#e65100', fontWeight: '600' },
-  doseActions: { flexDirection: 'row', gap: 8, marginTop: 10 },
+  doseActions: { flexDirection: 'row', gap: 8, marginTop: 10, flexWrap: 'wrap' },
+  // Refill badge
+  refillBadge: {
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    marginRight: 4,
+  },
+  refillBadgeOk: { backgroundColor: '#e8f5e9' },
+  refillBadgeWarning: { backgroundColor: '#fff8e1' },
+  refillBadgeUrgent: { backgroundColor: '#fdecea' },
+  refillBadgeText: { fontSize: 11, fontWeight: '700' },
   logBtn: {
     flex: 1,
     backgroundColor: '#4CAF50',
@@ -625,6 +769,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   skipBtn: { backgroundColor: '#9e9e9e' },
+  refillBtn: { backgroundColor: '#1565C0' },
   logBtnText: { color: '#fff', fontWeight: '600', fontSize: 13 },
   scheduleContainer: { flex: 1, padding: 12 },
   dayBlock: { marginBottom: 16 },

--- a/src/services/medicationService.ts
+++ b/src/services/medicationService.ts
@@ -7,9 +7,9 @@ import {
   getDoseLogs as dbGetDoseLogs,
   addDoseLog as dbAddDoseLog,
 } from './localDB';
-import type { Medication } from '../models/Medication';
+import type { Medication, RefillStatus } from '../models/Medication';
 
-export type { Medication };
+export type { Medication, RefillStatus };
 
 export interface DoseLog {
   id: string;
@@ -157,6 +157,202 @@ export function getUpcomingDoseTimes(med: Medication, days = 7, fromDate = new D
   windowEnd.setDate(windowEnd.getDate() + days);
   return getScheduleForRange(med, fromDate, windowEnd);
 }
+
+// ── Refill estimation ─────────────────────────────────────────────────────────
+
+/**
+ * Compute how many doses per day a medication requires based on its frequency
+ * (hours between doses). Returns a positive number; minimum 0.01 to avoid
+ * divide-by-zero when frequency is unreasonably large.
+ */
+export function computeDosesPerDay(frequencyHours: number): number {
+  if (frequencyHours <= 0) return 1;
+  return Math.max(0.01, 24 / frequencyHours);
+}
+
+/**
+ * Estimate the date when the current supply will run out.
+ *
+ * @param supply         Number of doses/pills currently on hand.
+ * @param frequencyHours Hours between each dose.
+ * @param fromDate       Reference date (defaults to now).
+ * @returns ISO string of the estimated run-out date, or null if inputs are invalid.
+ */
+export function estimateRunOutDate(
+  supply: number,
+  frequencyHours: number,
+  fromDate: Date = new Date(),
+): string | null {
+  if (supply <= 0 || frequencyHours <= 0) return null;
+  const dosesPerDay = computeDosesPerDay(frequencyHours);
+  const daysLeft = supply / dosesPerDay;
+  const runOut = new Date(fromDate.getTime() + daysLeft * 24 * 60 * 60 * 1000);
+  return runOut.toISOString();
+}
+
+/**
+ * Derive the human-readable refill status from the estimated run-out date.
+ *
+ * Thresholds:
+ *  - out     : 0 days remaining
+ *  - urgent  : ≤ 3 days remaining
+ *  - warning : ≤ 7 days remaining
+ *  - ok      : > 7 days remaining
+ *  - unknown : no supply information
+ */
+export function getRefillStatus(med: Medication, now: Date = new Date()): RefillStatus {
+  const supply = med.currentSupply ?? med.remainingPills;
+  if (supply === undefined || supply === null) return 'unknown';
+  if (supply <= 0) return 'out';
+
+  const runOutIso = med.estimatedRunOutDate ?? estimateRunOutDate(supply, med.frequency);
+  if (!runOutIso) return 'unknown';
+
+  const runOut = new Date(runOutIso);
+  const daysLeft = (runOut.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+
+  if (daysLeft <= 0) return 'out';
+  if (daysLeft <= 3) return 'urgent';
+  if (daysLeft <= 7) return 'warning';
+  return 'ok';
+}
+
+/**
+ * Recalculate the estimated run-out date for a medication and persist it back
+ * to the DB.  Should be called after every dose log or supply update.
+ */
+export async function refreshRunOutDate(med: Medication): Promise<Medication> {
+  const supply = med.currentSupply ?? med.remainingPills;
+  const runOutIso =
+    supply !== undefined && supply > 0
+      ? estimateRunOutDate(supply, med.frequency)
+      : undefined;
+
+  const updated: Medication = {
+    ...med,
+    estimatedRunOutDate: runOutIso ?? undefined,
+    dosesPerDay: computeDosesPerDay(med.frequency),
+  };
+  await upsertMedication(updated);
+  return updated;
+}
+
+// ── Refill push notifications ─────────────────────────────────────────────────
+
+/**
+ * Cancel any previously-scheduled refill reminder notifications for a
+ * medication so we don't send stale alerts after a supply update.
+ */
+async function cancelRefillNotifications(med: Medication): Promise<void> {
+  if (!med.refillNotificationIds?.length) return;
+  await Promise.all(
+    med.refillNotificationIds.map((id) =>
+      Notifications.cancelScheduledNotificationAsync(id).catch(() => {}),
+    ),
+  );
+}
+
+/**
+ * Schedule push notifications 7 days and 3 days before the estimated run-out
+ * date.  Previous refill reminders for this medication are cancelled first.
+ *
+ * @returns Array of scheduled notification IDs (empty if nothing was scheduled).
+ */
+export async function scheduleRefillNotifications(med: Medication): Promise<string[]> {
+  await cancelRefillNotifications(med);
+
+  const supply = med.currentSupply ?? med.remainingPills;
+  if (supply === undefined || supply <= 0) return [];
+
+  const runOutIso = med.estimatedRunOutDate ?? estimateRunOutDate(supply, med.frequency);
+  if (!runOutIso) return [];
+
+  const runOut = new Date(runOutIso);
+  const now = new Date();
+  const notificationIds: string[] = [];
+
+  for (const leadDays of [7, 3]) {
+    const triggerDate = new Date(runOut);
+    triggerDate.setDate(runOut.getDate() - leadDays);
+    triggerDate.setHours(9, 0, 0, 0); // 9 AM on the reminder day
+
+    if (triggerDate <= now) continue; // already past, skip
+
+    try {
+      const id = await Notifications.scheduleNotificationAsync({
+        content: {
+          title: '💊 Refill Reminder',
+          body:
+            leadDays === 7
+              ? `${med.name} will run out in about 7 days. Time to request a refill!`
+              : `⚠️ ${med.name} supply is critically low — runs out in ~3 days!`,
+          sound: 'default',
+          data: {
+            type: 'medication',
+            subType: 'refill',
+            medicationId: med.id,
+            leadDays,
+            estimatedRunOutDate: runOutIso,
+          },
+          categoryIdentifier: 'medication',
+        },
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.DATE,
+          date: triggerDate,
+        },
+      });
+      notificationIds.push(id);
+    } catch {
+      // Non-fatal — scheduling may fail in Expo Go without native build
+    }
+  }
+
+  return notificationIds;
+}
+
+/**
+ * Full refill-reminder pipeline:
+ *  1. Recalculate estimated run-out date.
+ *  2. Cancel stale refill notifications.
+ *  3. Schedule new notifications at 7-day and 3-day lead times.
+ *  4. Persist the updated medication (with new notification IDs).
+ *
+ * @returns Updated medication object.
+ */
+export async function syncRefillReminders(med: Medication): Promise<Medication> {
+  const withRunOut = await refreshRunOutDate(med);
+  const notificationIds = await scheduleRefillNotifications(withRunOut);
+
+  const final: Medication = {
+    ...withRunOut,
+    refillNotificationIds: notificationIds,
+  };
+  await upsertMedication(final);
+  return final;
+}
+
+// ── Refill completion ─────────────────────────────────────────────────────────
+
+/**
+ * Mark a medication refill as completed: reset the supply count, update
+ * lastRefillDate, recalculate the run-out date, and reschedule notifications.
+ *
+ * @param med          The medication to update.
+ * @param newSupply    Number of doses/pills after refill.
+ * @returns Updated medication.
+ */
+export async function markRefillComplete(med: Medication, newSupply: number): Promise<Medication> {
+  const now = new Date().toISOString();
+  const updated: Medication = {
+    ...med,
+    currentSupply: newSupply,
+    remainingPills: newSupply, // keep legacy field in sync
+    lastRefillDate: now,
+  };
+  return syncRefillReminders(updated);
+}
+
+// ── Legacy refill reminder (kept for backwards compat) ─────────────────────
 
 export async function scheduleRefillReminder(med: Medication): Promise<void> {
   if (!med.refillDate) return;


### PR DESCRIPTION
## Summary

The **smart medication refill reminder** feature was implemented across three files on the `feature/medication-refill-reminders` branch. The `Medication` model (`src/models/Medication.ts`) was extended with new fields — `currentSupply`, `dosesPerDay`, `lastRefillDate`, `estimatedRunOutDate`, `refillNotificationIds` — and a `RefillStatus` union type (`'ok' | 'warning' | 'urgent' | 'out' | 'unknown'`) was added to describe supply health at a glance. The medication service (`src/services/medicationService.ts`) gained the core logic: `estimateRunOutDate` calculates when supply will run out based on dosage frequency, `getRefillStatus` maps that to a `RefillStatus`, `scheduleRefillNotifications` schedules two push notifications via `expo-notifications` at exactly **7 days and 3 days** before the estimated run-out date, and `markRefillComplete` resets the supply count, stamps `lastRefillDate`, and re-schedules all reminders in one atomic call. `syncRefillReminders` ties everything together and is called after every dose log or save.

On the UI side (`src/screens/MedicationScreen.tsx`), each medication card in the list now shows a color-coded **refill status badge** (green for OK, amber for soon, red for now/out), plus the estimated run-out date and last-refill date when available. A new **"+ Refill" button** on each card opens a dedicated modal where the user enters the new pill/dose count; confirming it calls `markRefillComplete`, resets the supply counter, and reschedules all push notifications automatically. Logging a dose also decrements `currentSupply` and re-syncs the run-out estimate in real time. The Add/Edit medication form also exposes the **"Current supply"** field so users can set an initial count when adding a new medication.


Close #409 