### PR TITLE
feat: in-app notification center with SQLite persistence, filtering, bulk actions & badge count

### DIFF
--- a/src/__tests__/notificationCenter.test.ts
+++ b/src/__tests__/notificationCenter.test.ts
@@ -1,0 +1,526 @@
+/**
+ * Comprehensive tests for the notification center feature.
+ *
+ * Covers:
+ *  - SQLite persistence (add, get, delete)
+ *  - Read/unread state transitions
+ *  - Filtering by category
+ *  - Bulk actions (markManyAsRead, deleteMany)
+ *  - Badge count synchronisation
+ *  - Duplicate prevention (INSERT OR IGNORE)
+ *  - Deep-link routing via resolveNavPayload
+ *  - Invalid / missing nav payload handling
+ *  - Database recovery (graceful error handling)
+ *  - Performance with large datasets
+ */
+
+// expo-sqlite is mapped to src/__mocks__/expo-sqlite.ts by jest moduleNameMapper.
+// We import it here so we can spy on the mock db methods.
+import * as SQLiteMock from 'expo-sqlite';
+
+import {
+  addNotification,
+  deleteAll,
+  deleteMany,
+  deleteNotification,
+  getNotifications,
+  getUnreadCount,
+  markAllAsRead,
+  markAsRead,
+  markManyAsRead,
+  type AppNotification,
+} from '../services/notificationStore';
+import { resolveNavPayload } from '../utils/notificationNavigation';
+
+// ─── In-memory store ──────────────────────────────────────────────────────────
+
+interface Row {
+  id: string;
+  category: string;
+  title: string;
+  body: string;
+  is_read: number;
+  created_at: number;
+  metadata: string | null;
+  nav_payload: string | null;
+}
+
+let rows: Row[] = [];
+
+// Get the mock db instance that the store module received at import time.
+
+const mockDb = (SQLiteMock.openDatabaseSync as jest.Mock).mock.results[0]?.value as any;
+
+function setupMockDb() {
+  if (!mockDb) return;
+
+  mockDb.execAsync.mockResolvedValue(undefined);
+
+  mockDb.runAsync.mockImplementation(async (sql: string, params: unknown[] = []) => {
+    const s = sql.trim().toUpperCase();
+
+    if (s.startsWith('INSERT OR IGNORE INTO NOTIFICATIONS')) {
+      const [id, category, title, body, is_read, created_at, metadata, nav_payload] = params as [
+        string,
+        string,
+        string,
+        string,
+        number,
+        number,
+        string | null,
+        string | null,
+      ];
+      if (!rows.find((r) => r.id === id)) {
+        rows.push({ id, category, title, body, is_read, created_at, metadata, nav_payload });
+      }
+    } else if (s.startsWith('UPDATE NOTIFICATIONS SET IS_READ = 1 WHERE ID IN')) {
+      const ids = params as string[];
+      rows.forEach((r) => {
+        if (ids.includes(r.id)) r.is_read = 1;
+      });
+    } else if (s.startsWith('UPDATE NOTIFICATIONS SET IS_READ = 1 WHERE CATEGORY =')) {
+      const [cat] = params as string[];
+      rows.forEach((r) => {
+        if (r.category === cat) r.is_read = 1;
+      });
+    } else if (s.startsWith('UPDATE NOTIFICATIONS SET IS_READ = 1 WHERE ID =')) {
+      const [id] = params as string[];
+      rows.forEach((r) => {
+        if (r.id === id) r.is_read = 1;
+      });
+    } else if (s.startsWith('UPDATE NOTIFICATIONS SET IS_READ = 1')) {
+      rows.forEach((r) => {
+        r.is_read = 1;
+      });
+    } else if (s.startsWith('DELETE FROM NOTIFICATIONS WHERE ID IN')) {
+      const ids = new Set(params as string[]);
+      rows = rows.filter((r) => !ids.has(r.id));
+    } else if (s.startsWith('DELETE FROM NOTIFICATIONS WHERE ID =')) {
+      const [id] = params as string[];
+      rows = rows.filter((r) => r.id !== id);
+    } else if (s.startsWith('DELETE FROM NOTIFICATIONS WHERE CATEGORY =')) {
+      const [cat] = params as string[];
+      rows = rows.filter((r) => r.category !== cat);
+    } else if (s.startsWith('DELETE FROM NOTIFICATIONS')) {
+      rows = [];
+    }
+    return { changes: 1, lastInsertRowId: 1 };
+  });
+
+  mockDb.getFirstAsync.mockImplementation(async (sql: string, params: unknown[] = []) => {
+    const s = sql.trim().toUpperCase();
+    if (s.includes('COUNT(*)') && s.includes('IS_READ = 0') && s.includes('CATEGORY =')) {
+      const [cat] = params as string[];
+      return { count: rows.filter((r) => r.is_read === 0 && r.category === cat).length };
+    }
+    if (s.includes('COUNT(*)') && s.includes('IS_READ = 0')) {
+      return { count: rows.filter((r) => r.is_read === 0).length };
+    }
+    if (s.includes('NOTIFICATION_META')) return { value: '1' };
+    return null;
+  });
+
+  mockDb.getAllAsync.mockImplementation(async (sql: string, params: unknown[] = []) => {
+    const s = sql.trim().toUpperCase();
+    const sorted = [...rows].sort((a, b) => b.created_at - a.created_at);
+    if (s.includes('WHERE CATEGORY =')) {
+      const [cat] = params as string[];
+      return sorted.filter((r) => r.category === cat);
+    }
+    return sorted;
+  });
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let idCounter = 0;
+
+function makeNotification(
+  overrides: Partial<AppNotification> = {},
+): Omit<AppNotification, 'isRead'> {
+  idCounter++;
+  return {
+    id: `notif-${idCounter}`,
+    category: 'system',
+    title: `Notification ${idCounter}`,
+    body: `Body ${idCounter}`,
+    createdAt: Date.now() - idCounter * 1000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  rows = [];
+  idCounter = 0;
+  setupMockDb();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('notificationStore — persistence', () => {
+  it('adds a notification and retrieves it', async () => {
+    const n = makeNotification({ category: 'medication', title: 'Take Aspirin' });
+    await addNotification(n);
+    const result = await getNotifications();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(n.id);
+    expect(result[0].title).toBe('Take Aspirin');
+    expect(result[0].isRead).toBe(false);
+  });
+
+  it('persists metadata and navPayload', async () => {
+    const n = makeNotification({
+      metadata: { petId: 'pet-1' },
+      navPayload: { screen: 'Medications', params: { petId: 'pet-1' } },
+    });
+    await addNotification(n);
+    const [saved] = await getNotifications();
+    expect(saved.metadata).toEqual({ petId: 'pet-1' });
+    expect(saved.navPayload).toEqual({ screen: 'Medications', params: { petId: 'pet-1' } });
+  });
+
+  it('returns notifications newest-first', async () => {
+    const now = Date.now();
+    await addNotification(makeNotification({ createdAt: now - 2000 }));
+    await addNotification(makeNotification({ createdAt: now - 1000 }));
+    await addNotification(makeNotification({ createdAt: now }));
+    const result = await getNotifications();
+    expect(result[0].createdAt).toBeGreaterThan(result[1].createdAt);
+    expect(result[1].createdAt).toBeGreaterThan(result[2].createdAt);
+  });
+});
+
+describe('notificationStore — duplicate prevention', () => {
+  it('ignores duplicate ids (INSERT OR IGNORE)', async () => {
+    const n = makeNotification({ id: 'dup-1' });
+    await addNotification(n);
+    await addNotification({ ...n, title: 'Different title' });
+    const result = await getNotifications();
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe(n.title);
+  });
+});
+
+describe('notificationStore — read/unread state', () => {
+  it('starts as unread', async () => {
+    await addNotification(makeNotification());
+    const [n] = await getNotifications();
+    expect(n.isRead).toBe(false);
+  });
+
+  it('markAsRead transitions to read', async () => {
+    const n = makeNotification();
+    await addNotification(n);
+    await markAsRead(n.id);
+    const [updated] = await getNotifications();
+    expect(updated.isRead).toBe(true);
+  });
+
+  it('markAllAsRead marks every notification', async () => {
+    await addNotification(makeNotification());
+    await addNotification(makeNotification());
+    await markAllAsRead();
+    const result = await getNotifications();
+    expect(result.every((n) => n.isRead)).toBe(true);
+  });
+
+  it('markManyAsRead marks only specified ids', async () => {
+    const a = makeNotification();
+    const b = makeNotification();
+    const c = makeNotification();
+    await addNotification(a);
+    await addNotification(b);
+    await addNotification(c);
+    await markManyAsRead([a.id, b.id]);
+    const result = await getNotifications();
+    const byId = Object.fromEntries(result.map((n) => [n.id, n]));
+    expect(byId[a.id].isRead).toBe(true);
+    expect(byId[b.id].isRead).toBe(true);
+    expect(byId[c.id].isRead).toBe(false);
+  });
+
+  it('markManyAsRead with empty array is a no-op', async () => {
+    await addNotification(makeNotification());
+    await markManyAsRead([]);
+    const [n] = await getNotifications();
+    expect(n.isRead).toBe(false);
+  });
+});
+
+describe('notificationStore — filtering', () => {
+  beforeEach(async () => {
+    await addNotification(makeNotification({ category: 'medication' }));
+    await addNotification(makeNotification({ category: 'appointment' }));
+    await addNotification(makeNotification({ category: 'sos' }));
+    await addNotification(makeNotification({ category: 'system' }));
+  });
+
+  it('filter=all returns all notifications', async () => {
+    expect(await getNotifications('all')).toHaveLength(4);
+  });
+
+  it('filter=medication returns only medication', async () => {
+    const result = await getNotifications('medication');
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('medication');
+  });
+
+  it('filter=appointment returns only appointment', async () => {
+    const result = await getNotifications('appointment');
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('appointment');
+  });
+
+  it('filter=sos returns only sos', async () => {
+    const result = await getNotifications('sos');
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('sos');
+  });
+
+  it('filter=system returns only system', async () => {
+    const result = await getNotifications('system');
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('system');
+  });
+
+  it('markAllAsRead with category filter only marks that category', async () => {
+    await markAllAsRead('medication');
+    const meds = await getNotifications('medication');
+    const others = await getNotifications('appointment');
+    expect(meds[0].isRead).toBe(true);
+    expect(others[0].isRead).toBe(false);
+  });
+});
+
+describe('notificationStore — deletion', () => {
+  it('deleteNotification removes a single entry', async () => {
+    const n = makeNotification();
+    await addNotification(n);
+    await deleteNotification(n.id);
+    expect(await getNotifications()).toHaveLength(0);
+  });
+
+  it('deleteMany removes specified ids', async () => {
+    const a = makeNotification();
+    const b = makeNotification();
+    const c = makeNotification();
+    await addNotification(a);
+    await addNotification(b);
+    await addNotification(c);
+    await deleteMany([a.id, b.id]);
+    const result = await getNotifications();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(c.id);
+  });
+
+  it('deleteMany with empty array is a no-op', async () => {
+    await addNotification(makeNotification());
+    await deleteMany([]);
+    expect(await getNotifications()).toHaveLength(1);
+  });
+
+  it('deleteAll removes everything', async () => {
+    await addNotification(makeNotification());
+    await addNotification(makeNotification());
+    await deleteAll();
+    expect(await getNotifications()).toHaveLength(0);
+  });
+
+  it('deleteAll with category filter removes only that category', async () => {
+    await addNotification(makeNotification({ category: 'medication' }));
+    await addNotification(makeNotification({ category: 'system' }));
+    await deleteAll('medication');
+    const result = await getNotifications();
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe('system');
+  });
+});
+
+describe('notificationStore — badge count', () => {
+  it('getUnreadCount returns 0 when empty', async () => {
+    expect(await getUnreadCount()).toBe(0);
+  });
+
+  it('getUnreadCount increments on add', async () => {
+    await addNotification(makeNotification());
+    await addNotification(makeNotification());
+    expect(await getUnreadCount()).toBe(2);
+  });
+
+  it('getUnreadCount decrements after markAsRead', async () => {
+    const n = makeNotification();
+    await addNotification(n);
+    await markAsRead(n.id);
+    expect(await getUnreadCount()).toBe(0);
+  });
+
+  it('getUnreadCount is 0 after markAllAsRead', async () => {
+    await addNotification(makeNotification());
+    await addNotification(makeNotification());
+    await markAllAsRead();
+    expect(await getUnreadCount()).toBe(0);
+  });
+
+  it('getUnreadCount decrements after deleteNotification', async () => {
+    const n = makeNotification();
+    await addNotification(n);
+    await deleteNotification(n.id);
+    expect(await getUnreadCount()).toBe(0);
+  });
+
+  it('getUnreadCount filtered by category', async () => {
+    await addNotification(makeNotification({ category: 'medication' }));
+    await addNotification(makeNotification({ category: 'system' }));
+    expect(await getUnreadCount('medication')).toBe(1);
+    expect(await getUnreadCount('system')).toBe(1);
+    expect(await getUnreadCount('appointment')).toBe(0);
+  });
+
+  it('already-read notification does not affect unread count', async () => {
+    await addNotification({ ...makeNotification(), isRead: true });
+    expect(await getUnreadCount()).toBe(0);
+  });
+});
+
+describe('resolveNavPayload — deep-link routing', () => {
+  function notif(screen: string, params?: Record<string, unknown>): AppNotification {
+    return {
+      id: 'x',
+      category: 'system',
+      title: 'T',
+      body: 'B',
+      isRead: false,
+      createdAt: Date.now(),
+      navPayload: { screen, params },
+    };
+  }
+
+  it('resolves Medications screen', () => {
+    expect(resolveNavPayload(notif('Medications'))).toEqual({
+      screen: 'Medications',
+      params: undefined,
+    });
+  });
+
+  it('resolves Appointments screen', () => {
+    expect(resolveNavPayload(notif('Appointments'))).toEqual({
+      screen: 'Appointments',
+      params: undefined,
+    });
+  });
+
+  it('resolves Emergency screen', () => {
+    expect(resolveNavPayload(notif('Emergency'))).toEqual({
+      screen: 'Emergency',
+      params: undefined,
+    });
+  });
+
+  it('resolves PetDetail with params', () => {
+    expect(resolveNavPayload(notif('PetDetail', { petId: 'pet-1' }))).toEqual({
+      screen: 'PetDetail',
+      params: { petId: 'pet-1' },
+    });
+  });
+
+  it('resolves PetHealthDashboard screen', () => {
+    expect(resolveNavPayload(notif('PetHealthDashboard', { petId: 'p1' }))).toEqual({
+      screen: 'PetHealthDashboard',
+      params: { petId: 'p1' },
+    });
+  });
+
+  it('resolves Community screen', () => {
+    expect(resolveNavPayload(notif('Community'))).toEqual({
+      screen: 'Community',
+      params: undefined,
+    });
+  });
+
+  it('returns null for unknown screen', () => {
+    expect(resolveNavPayload(notif('UnknownScreen'))).toBeNull();
+  });
+
+  it('returns null when navPayload is missing', () => {
+    const n: AppNotification = {
+      id: 'x',
+      category: 'system',
+      title: 'T',
+      body: 'B',
+      isRead: false,
+      createdAt: Date.now(),
+    };
+    expect(resolveNavPayload(n)).toBeNull();
+  });
+
+  it('returns null when screen is empty string', () => {
+    expect(resolveNavPayload(notif(''))).toBeNull();
+  });
+
+  it('returns null for SOS notification with invalid screen', () => {
+    expect(resolveNavPayload(notif('SOSDetail'))).toBeNull();
+  });
+
+  it('returns null for injection-style screen name', () => {
+    expect(resolveNavPayload(notif('../../Admin'))).toBeNull();
+  });
+});
+
+describe('notificationStore — database recovery', () => {
+  it('getNotifications rejects when db throws', async () => {
+    mockDb.getAllAsync.mockRejectedValueOnce(new Error('DB error'));
+    await expect(getNotifications()).rejects.toThrow('DB error');
+  });
+
+  it('getUnreadCount returns count after recovery', async () => {
+    mockDb.getFirstAsync.mockResolvedValueOnce({ count: 5 });
+    expect(await getUnreadCount()).toBe(5);
+  });
+});
+
+describe('notificationStore — performance with large datasets', () => {
+  it('handles 500 notifications without error', async () => {
+    const batch = Array.from({ length: 500 }, (_, i) =>
+      makeNotification({ id: `perf-${i}`, createdAt: Date.now() - i * 100 }),
+    );
+    for (const n of batch) await addNotification(n);
+    const result = await getNotifications();
+    expect(result.length).toBe(500);
+  });
+
+  it('bulk markManyAsRead on 100 ids completes without error', async () => {
+    const ids = Array.from({ length: 100 }, (_, i) => {
+      const n = makeNotification({ id: `bulk-${i}` });
+      rows.push({
+        id: n.id,
+        category: n.category as string,
+        title: n.title,
+        body: n.body,
+        is_read: 0,
+        created_at: n.createdAt,
+        metadata: null,
+        nav_payload: null,
+      });
+      return n.id;
+    });
+    await expect(markManyAsRead(ids)).resolves.not.toThrow();
+  });
+
+  it('deleteMany on 100 ids completes without error', async () => {
+    const ids = Array.from({ length: 100 }, (_, i) => {
+      const n = makeNotification({ id: `del-${i}` });
+      rows.push({
+        id: n.id,
+        category: n.category as string,
+        title: n.title,
+        body: n.body,
+        is_read: 0,
+        created_at: n.createdAt,
+        metadata: null,
+        nav_payload: null,
+      });
+      return n.id;
+    });
+    await expect(deleteMany(ids)).resolves.not.toThrow();
+  });
+});

--- a/src/components/NotificationItem.tsx
+++ b/src/components/NotificationItem.tsx
@@ -1,0 +1,177 @@
+/**
+ * NotificationItem — reusable row for the notification center.
+ *
+ * Renders read/unread distinction, category icon, timestamp, and handles
+ * deep-link navigation via validated navPayload.
+ */
+import React, { memo, useCallback } from 'react';
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+
+import type { AppNotification, NotificationCategory } from '../services/notificationStore';
+
+// Re-export so existing imports from this file continue to work.
+export { resolveNavPayload } from '../utils/notificationNavigation';
+
+// ─── Category metadata ────────────────────────────────────────────────────────
+
+const CATEGORY_META: Record<NotificationCategory, { icon: string; label: string }> = {
+  medication: { icon: '💊', label: 'Medication' },
+  appointment: { icon: '📅', label: 'Appointment' },
+  sos: { icon: '🆘', label: 'Emergency' },
+  system: { icon: '🔔', label: 'System' },
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatRelativeTime(ms: number): string {
+  const diff = Date.now() - ms;
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return 'Just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface NotificationItemProps {
+  notification: AppNotification;
+  onPress: (notification: AppNotification) => void;
+  onLongPress?: (notification: AppNotification) => void;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+function NotificationItem({
+  notification,
+  onPress,
+  onLongPress,
+  style,
+  testID,
+}: NotificationItemProps) {
+  const meta = CATEGORY_META[notification.category] ?? CATEGORY_META.system;
+
+  const handlePress = useCallback(() => onPress(notification), [onPress, notification]);
+  const handleLongPress = useCallback(
+    () => onLongPress?.(notification),
+    [onLongPress, notification],
+  );
+
+  return (
+    <TouchableOpacity
+      testID={testID ?? `notification-item-${notification.id}`}
+      accessibilityRole="button"
+      accessibilityLabel={`${meta.label}: ${notification.title}. ${notification.isRead ? 'Read' : 'Unread'}`}
+      accessibilityHint="Tap to open, long press for options"
+      onPress={handlePress}
+      onLongPress={onLongPress ? handleLongPress : undefined}
+      style={[styles.container, !notification.isRead && styles.unread, style]}
+      activeOpacity={0.7}
+    >
+      {/* Unread indicator */}
+      {!notification.isRead && <View style={styles.unreadDot} accessibilityElementsHidden />}
+
+      {/* Icon */}
+      <Text style={styles.icon} accessibilityElementsHidden>
+        {meta.icon}
+      </Text>
+
+      {/* Content */}
+      <View style={styles.content}>
+        <View style={styles.headerRow}>
+          <Text
+            style={[styles.title, !notification.isRead && styles.titleUnread]}
+            numberOfLines={1}
+          >
+            {notification.title}
+          </Text>
+          <Text style={styles.time}>{formatRelativeTime(notification.createdAt)}</Text>
+        </View>
+        <Text style={styles.body} numberOfLines={2}>
+          {notification.body}
+        </Text>
+        <Text style={styles.category}>{meta.label}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+export default memo(NotificationItem);
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: '#FFFFFF',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#D1D5DB',
+  },
+  unread: {
+    backgroundColor: '#F0FDF4',
+  },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#4CAF50',
+    marginTop: 6,
+    marginRight: 4,
+    flexShrink: 0,
+  },
+  icon: {
+    fontSize: 24,
+    marginRight: 12,
+    marginTop: 2,
+  },
+  content: {
+    flex: 1,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 2,
+  },
+  title: {
+    flex: 1,
+    fontSize: 15,
+    color: '#111827',
+    marginRight: 8,
+  },
+  titleUnread: {
+    fontWeight: '600',
+  },
+  time: {
+    fontSize: 12,
+    color: '#6B7280',
+    flexShrink: 0,
+  },
+  body: {
+    fontSize: 13,
+    color: '#4B5563',
+    lineHeight: 18,
+    marginBottom: 4,
+  },
+  category: {
+    fontSize: 11,
+    color: '#9CA3AF',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+});

--- a/src/hooks/useNotificationBadge.ts
+++ b/src/hooks/useNotificationBadge.ts
@@ -1,0 +1,34 @@
+/**
+ * useNotificationBadge
+ *
+ * Returns the current unread notification count and a refresh function.
+ * Polls on mount and whenever `refresh()` is called (e.g. after navigation focus).
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { getUnreadCount } from '../services/notificationStore';
+
+export function useNotificationBadge(): { count: number; refresh: () => void } {
+  const [count, setCount] = useState(0);
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(() => {
+    getUnreadCount()
+      .then((n) => {
+        if (isMounted.current) setCount(n);
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { count, refresh };
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -2,11 +2,12 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { NavigationContainer, type LinkingOptions } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
-import { StatusBar } from 'react-native';
+import { StatusBar, Text } from 'react-native';
 
 import { useNavigationTheme } from '../theme';
 import type { RootStackParamList, MainTabParamList, PetStackParamList } from './types';
 import { DEEP_LINK_PREFIX } from './types';
+import { useNotificationBadge } from '../hooks/useNotificationBadge';
 import type { Pet } from '../models/Pet';
 import AppointmentScreen from '../screens/AppointmentScreen';
 import AuthNavigator from '../screens/AuthNavigator';
@@ -18,6 +19,7 @@ import MedicalRecordSearchScreen from '../screens/MedicalRecordSearchScreen';
 import MedicalRecordViewerScreen from '../screens/MedicalRecordViewerScreen';
 import MedicationScreen from '../screens/MedicationScreen';
 import NearbyVetScreen from '../screens/NearbyVetScreen';
+import NotificationCenterScreen from '../screens/NotificationCenterScreen';
 import NotificationPreferencesScreen from '../screens/NotificationPreferencesScreen';
 import OnboardingScreen from '../screens/OnboardingScreen';
 import PaymentScreen from '../screens/PaymentScreen';
@@ -148,8 +150,17 @@ function PetNavigator() {
 
 // ─── Main Tabs ────────────────────────────────────────────────────────────────
 function MainTabs() {
+  const { count: badgeCount, refresh: refreshBadge } = useNotificationBadge();
+
   return (
-    <Tab.Navigator>
+    <Tab.Navigator
+      screenListeners={{
+        tabPress: () => {
+          // Refresh badge whenever any tab is pressed (covers returning from Notifications)
+          refreshBadge();
+        },
+      }}
+    >
       <Tab.Screen
         name="PetList"
         component={PetNavigator}
@@ -170,6 +181,24 @@ function MainTabs() {
         name="Emergency"
         component={EmergencyContactsScreen}
         options={{ title: 'Emergency' }}
+      />
+      <Tab.Screen
+        name="Notifications"
+        component={NotificationCenterScreen}
+        options={{
+          title: 'Notifications',
+          tabBarBadge: badgeCount > 0 ? badgeCount : undefined,
+          tabBarBadgeStyle: { backgroundColor: '#EF4444' },
+          tabBarIcon: ({ color, size }: { color: string; size: number }) => (
+            <Text style={{ fontSize: size, color }}>🔔</Text>
+          ),
+        }}
+        listeners={{
+          tabPress: () => {
+            // Refresh badge when navigating away from Notifications tab
+            refreshBadge();
+          },
+        }}
       />
       <Tab.Screen name="Profile" component={ProfileScreen} options={{ title: 'Profile' }} />
     </Tab.Navigator>
@@ -200,6 +229,7 @@ const linking: LinkingOptions<RootStackParamList> = {
           Appointments: 'appointments',
           Community: 'community',
           Emergency: 'emergency',
+          Notifications: 'notifications',
           Profile: 'profile',
         },
       },

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -23,6 +23,7 @@ export type MainTabParamList = {
   Appointments: undefined;
   Community: undefined;
   Emergency: undefined;
+  Notifications: undefined;
   Profile: undefined;
 };
 

--- a/src/screens/NotificationCenterScreen.tsx
+++ b/src/screens/NotificationCenterScreen.tsx
@@ -1,0 +1,538 @@
+/**
+ * NotificationCenterScreen
+ *
+ * Aggregated notification inbox with:
+ *  - Category filter tabs
+ *  - Bulk mark-as-read / delete
+ *  - Pull-to-refresh
+ *  - Empty / loading / error states
+ *  - Deep-link navigation on item press
+ */
+import { useNavigation } from '@react-navigation/native';
+import React, { useCallback, useEffect, useReducer, useRef } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import NotificationItem, { resolveNavPayload } from '../components/NotificationItem';
+import {
+  deleteAll,
+  deleteMany,
+  getNotifications,
+  getUnreadCount,
+  markAllAsRead,
+  markAsRead,
+  markManyAsRead,
+  type AppNotification,
+  type NotificationFilter,
+} from '../services/notificationStore';
+
+// ─── State ────────────────────────────────────────────────────────────────────
+
+type Filter = NotificationFilter;
+
+interface State {
+  notifications: AppNotification[];
+  filter: Filter;
+  loading: boolean;
+  refreshing: boolean;
+  error: string | null;
+  selected: Set<string>;
+  unreadCount: number;
+}
+
+type Action =
+  | { type: 'LOAD_START' }
+  | { type: 'LOAD_SUCCESS'; notifications: AppNotification[]; unreadCount: number }
+  | { type: 'LOAD_ERROR'; error: string }
+  | { type: 'REFRESH_START' }
+  | { type: 'SET_FILTER'; filter: Filter }
+  | { type: 'TOGGLE_SELECT'; id: string }
+  | { type: 'CLEAR_SELECTION' }
+  | { type: 'SELECT_ALL' }
+  | { type: 'MARK_READ'; ids: string[] }
+  | { type: 'DELETE'; ids: string[] }
+  | { type: 'SET_UNREAD'; count: number };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'LOAD_START':
+      return { ...state, loading: true, error: null };
+    case 'REFRESH_START':
+      return { ...state, refreshing: true, error: null };
+    case 'LOAD_SUCCESS':
+      return {
+        ...state,
+        loading: false,
+        refreshing: false,
+        notifications: action.notifications,
+        unreadCount: action.unreadCount,
+        error: null,
+      };
+    case 'LOAD_ERROR':
+      return { ...state, loading: false, refreshing: false, error: action.error };
+    case 'SET_FILTER':
+      return { ...state, filter: action.filter, selected: new Set(), loading: true };
+    case 'TOGGLE_SELECT': {
+      const next = new Set(state.selected);
+      if (next.has(action.id)) next.delete(action.id);
+      else next.add(action.id);
+      return { ...state, selected: next };
+    }
+    case 'CLEAR_SELECTION':
+      return { ...state, selected: new Set() };
+    case 'SELECT_ALL':
+      return { ...state, selected: new Set(state.notifications.map((n) => n.id)) };
+    case 'MARK_READ': {
+      const ids = new Set(action.ids);
+      return {
+        ...state,
+        selected: new Set(),
+        notifications: state.notifications.map((n) => (ids.has(n.id) ? { ...n, isRead: true } : n)),
+        unreadCount: Math.max(
+          0,
+          state.unreadCount - state.notifications.filter((n) => ids.has(n.id) && !n.isRead).length,
+        ),
+      };
+    }
+    case 'DELETE': {
+      const ids = new Set(action.ids);
+      const removed = state.notifications.filter((n) => ids.has(n.id));
+      const removedUnread = removed.filter((n) => !n.isRead).length;
+      return {
+        ...state,
+        selected: new Set(),
+        notifications: state.notifications.filter((n) => !ids.has(n.id)),
+        unreadCount: Math.max(0, state.unreadCount - removedUnread),
+      };
+    }
+    case 'SET_UNREAD':
+      return { ...state, unreadCount: action.count };
+    default:
+      return state;
+  }
+}
+
+const INITIAL_STATE: State = {
+  notifications: [],
+  filter: 'all',
+  loading: true,
+  refreshing: false,
+  error: null,
+  selected: new Set(),
+  unreadCount: 0,
+};
+
+// ─── Filter tabs ──────────────────────────────────────────────────────────────
+
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'medication', label: '💊 Meds' },
+  { key: 'appointment', label: '📅 Appts' },
+  { key: 'sos', label: '🆘 SOS' },
+  { key: 'system', label: '🔔 System' },
+];
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function NotificationCenterScreen() {
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+  const navigation = useNavigation<{ navigate: (screen: string, params?: unknown) => void }>();
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  // ── Data loading ────────────────────────────────────────────────────────────
+
+  const load = useCallback(
+    async (isRefresh = false) => {
+      dispatch({ type: isRefresh ? 'REFRESH_START' : 'LOAD_START' });
+      try {
+        const [notifications, unreadCount] = await Promise.all([
+          getNotifications(state.filter),
+          getUnreadCount(),
+        ]);
+        if (isMounted.current) {
+          dispatch({ type: 'LOAD_SUCCESS', notifications, unreadCount });
+        }
+      } catch (err) {
+        if (isMounted.current) {
+          dispatch({
+            type: 'LOAD_ERROR',
+            error: err instanceof Error ? err.message : 'Failed to load notifications',
+          });
+        }
+      }
+    },
+    [state.filter],
+  );
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // ── Actions ─────────────────────────────────────────────────────────────────
+
+  const handleFilterChange = useCallback((filter: Filter) => {
+    dispatch({ type: 'SET_FILTER', filter });
+  }, []);
+
+  const handleItemPress = useCallback(
+    async (notification: AppNotification) => {
+      // Mark as read
+      if (!notification.isRead) {
+        dispatch({ type: 'MARK_READ', ids: [notification.id] });
+        await markAsRead(notification.id).catch(() => {});
+      }
+
+      // Navigate if valid payload
+      const target = resolveNavPayload(notification);
+      if (target) {
+        try {
+          navigation.navigate(target.screen, target.params);
+        } catch {
+          // Navigation target may not be reachable from this context; ignore
+        }
+      }
+    },
+    [navigation],
+  );
+
+  const handleItemLongPress = useCallback((notification: AppNotification) => {
+    dispatch({ type: 'TOGGLE_SELECT', id: notification.id });
+  }, []);
+
+  const handleMarkAllRead = useCallback(async () => {
+    const ids = state.notifications.filter((n) => !n.isRead).map((n) => n.id);
+    if (ids.length === 0) return;
+    dispatch({ type: 'MARK_READ', ids });
+    await markAllAsRead(state.filter).catch(() => {});
+  }, [state.notifications, state.filter]);
+
+  const handleMarkSelectedRead = useCallback(async () => {
+    const ids = [...state.selected];
+    dispatch({ type: 'MARK_READ', ids });
+    await markManyAsRead(ids).catch(() => {});
+  }, [state.selected]);
+
+  const handleDeleteSelected = useCallback(() => {
+    const ids = [...state.selected];
+    Alert.alert(
+      'Delete notifications',
+      `Delete ${ids.length} notification${ids.length !== 1 ? 's' : ''}?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            dispatch({ type: 'DELETE', ids });
+            await deleteMany(ids).catch(() => {});
+          },
+        },
+      ],
+    );
+  }, [state.selected]);
+
+  const handleDeleteAll = useCallback(() => {
+    Alert.alert('Clear all', 'Delete all notifications in this view?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete all',
+        style: 'destructive',
+        onPress: async () => {
+          const ids = state.notifications.map((n) => n.id);
+          dispatch({ type: 'DELETE', ids });
+          await deleteAll(state.filter).catch(() => {});
+        },
+      },
+    ]);
+  }, [state.notifications, state.filter]);
+
+  // ── Render helpers ──────────────────────────────────────────────────────────
+
+  const renderItem = useCallback(
+    ({ item }: { item: AppNotification }) => (
+      <NotificationItem
+        notification={item}
+        onPress={handleItemPress}
+        onLongPress={handleItemLongPress}
+        style={state.selected.has(item.id) ? styles.selectedItem : undefined}
+        testID={`notification-item-${item.id}`}
+      />
+    ),
+    [handleItemPress, handleItemLongPress, state.selected],
+  );
+
+  const keyExtractor = useCallback((item: AppNotification) => item.id, []);
+
+  const hasSelection = state.selected.size > 0;
+  const hasUnread = state.notifications.some((n) => !n.isRead);
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <View style={styles.container} testID="notification-center-screen">
+      {/* Header */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle} accessibilityRole="header">
+          Notifications
+          {state.unreadCount > 0 ? ` (${state.unreadCount})` : ''}
+        </Text>
+        <View style={styles.headerActions}>
+          {hasUnread && !hasSelection && (
+            <TouchableOpacity
+              onPress={handleMarkAllRead}
+              accessibilityLabel="Mark all as read"
+              testID="mark-all-read-btn"
+            >
+              <Text style={styles.actionText}>Mark all read</Text>
+            </TouchableOpacity>
+          )}
+          {state.notifications.length > 0 && !hasSelection && (
+            <TouchableOpacity
+              onPress={handleDeleteAll}
+              accessibilityLabel="Delete all notifications"
+              testID="delete-all-btn"
+              style={styles.actionSpacer}
+            >
+              <Text style={[styles.actionText, styles.destructiveText]}>Clear all</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+
+      {/* Bulk action bar */}
+      {hasSelection && (
+        <View style={styles.bulkBar} testID="bulk-action-bar">
+          <Text style={styles.bulkCount}>{state.selected.size} selected</Text>
+          <View style={styles.bulkActions}>
+            <TouchableOpacity
+              onPress={handleMarkSelectedRead}
+              accessibilityLabel="Mark selected as read"
+              testID="bulk-mark-read-btn"
+            >
+              <Text style={styles.actionText}>Mark read</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={handleDeleteSelected}
+              accessibilityLabel="Delete selected notifications"
+              testID="bulk-delete-btn"
+              style={styles.actionSpacer}
+            >
+              <Text style={[styles.actionText, styles.destructiveText]}>Delete</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => dispatch({ type: 'CLEAR_SELECTION' })}
+              accessibilityLabel="Cancel selection"
+              testID="cancel-selection-btn"
+              style={styles.actionSpacer}
+            >
+              <Text style={styles.actionText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
+
+      {/* Filter tabs */}
+      <View style={styles.filterRow} accessibilityRole="tablist">
+        {FILTERS.map(({ key, label }) => (
+          <TouchableOpacity
+            key={key}
+            onPress={() => handleFilterChange(key)}
+            style={[styles.filterTab, state.filter === key && styles.filterTabActive]}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: state.filter === key }}
+            accessibilityLabel={`Filter by ${label}`}
+            testID={`filter-tab-${key}`}
+          >
+            <Text style={[styles.filterLabel, state.filter === key && styles.filterLabelActive]}>
+              {label}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {/* Content */}
+      {state.loading && !state.refreshing ? (
+        <View style={styles.centered} testID="loading-indicator">
+          <ActivityIndicator size="large" color="#4CAF50" />
+        </View>
+      ) : state.error ? (
+        <View style={styles.centered} testID="error-state">
+          <Text style={styles.errorText}>{state.error}</Text>
+          <TouchableOpacity onPress={() => load()} style={styles.retryBtn}>
+            <Text style={styles.retryText}>Retry</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <FlatList
+          data={state.notifications}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          refreshControl={
+            <RefreshControl
+              refreshing={state.refreshing}
+              onRefresh={() => load(true)}
+              tintColor="#4CAF50"
+            />
+          }
+          ListEmptyComponent={
+            <View style={styles.centered} testID="empty-state">
+              <Text style={styles.emptyIcon}>🔔</Text>
+              <Text style={styles.emptyTitle}>No notifications</Text>
+              <Text style={styles.emptyBody}>
+                {state.filter === 'all'
+                  ? "You're all caught up!"
+                  : `No ${state.filter} notifications.`}
+              </Text>
+            </View>
+          }
+          contentContainerStyle={
+            state.notifications.length === 0 ? styles.emptyContainer : undefined
+          }
+          removeClippedSubviews
+          maxToRenderPerBatch={20}
+          windowSize={10}
+          testID="notification-list"
+        />
+      )}
+    </View>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F5F7FA',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: '#FFFFFF',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#D1D5DB',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  actionText: {
+    fontSize: 14,
+    color: '#4CAF50',
+    fontWeight: '500',
+  },
+  destructiveText: {
+    color: '#EF4444',
+  },
+  actionSpacer: {
+    marginLeft: 16,
+  },
+  bulkBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    backgroundColor: '#EFF6FF',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#BFDBFE',
+  },
+  bulkCount: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1D4ED8',
+  },
+  bulkActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  filterRow: {
+    flexDirection: 'row',
+    backgroundColor: '#FFFFFF',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#D1D5DB',
+    paddingHorizontal: 8,
+  },
+  filterTab: {
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    marginRight: 4,
+  },
+  filterTabActive: {
+    borderBottomWidth: 2,
+    borderBottomColor: '#4CAF50',
+  },
+  filterLabel: {
+    fontSize: 13,
+    color: '#6B7280',
+  },
+  filterLabelActive: {
+    color: '#4CAF50',
+    fontWeight: '600',
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+  },
+  emptyContainer: {
+    flexGrow: 1,
+  },
+  emptyIcon: {
+    fontSize: 48,
+    marginBottom: 12,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#111827',
+    marginBottom: 6,
+  },
+  emptyBody: {
+    fontSize: 14,
+    color: '#6B7280',
+    textAlign: 'center',
+  },
+  errorText: {
+    fontSize: 14,
+    color: '#EF4444',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  retryBtn: {
+    paddingHorizontal: 20,
+    paddingVertical: 8,
+    backgroundColor: '#4CAF50',
+    borderRadius: 8,
+  },
+  retryText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+  },
+  selectedItem: {
+    backgroundColor: '#DBEAFE',
+  },
+});

--- a/src/services/notificationStore.ts
+++ b/src/services/notificationStore.ts
@@ -1,0 +1,230 @@
+/**
+ * SQLite-backed notification store.
+ *
+ * Single source of truth for all in-app notifications.
+ * Uses the same petchain.db database as localDB.ts.
+ */
+import * as SQLite from 'expo-sqlite';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type NotificationCategory = 'medication' | 'appointment' | 'sos' | 'system';
+
+export interface NavPayload {
+  screen: string;
+  params?: Record<string, unknown>;
+}
+
+export interface AppNotification {
+  id: string;
+  category: NotificationCategory;
+  title: string;
+  body: string;
+  isRead: boolean;
+  createdAt: number; // Unix ms
+  metadata?: Record<string, unknown>;
+  navPayload?: NavPayload;
+}
+
+export type NotificationFilter = NotificationCategory | 'all';
+
+// ─── DB setup ─────────────────────────────────────────────────────────────────
+
+const db = SQLite.openDatabaseSync('petchain.db');
+
+const SCHEMA_VERSION = 1;
+
+async function ensureTable(): Promise<void> {
+  await db.execAsync(`
+    CREATE TABLE IF NOT EXISTS notifications (
+      id          TEXT PRIMARY KEY NOT NULL,
+      category    TEXT NOT NULL,
+      title       TEXT NOT NULL,
+      body        TEXT NOT NULL,
+      is_read     INTEGER NOT NULL DEFAULT 0,
+      created_at  INTEGER NOT NULL,
+      metadata    TEXT,
+      nav_payload TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_notifications_created_at
+      ON notifications (created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_notifications_category
+      ON notifications (category);
+    CREATE TABLE IF NOT EXISTS notification_meta (
+      key   TEXT PRIMARY KEY NOT NULL,
+      value TEXT NOT NULL
+    );
+  `);
+
+  // Record schema version
+  await db.runAsync(
+    `INSERT OR IGNORE INTO notification_meta (key, value) VALUES ('schema_version', ?)`,
+    [String(SCHEMA_VERSION)],
+  );
+}
+
+// Initialise on module load; errors are swallowed so the app doesn't crash.
+const _ready = ensureTable().catch(() => {});
+
+async function waitReady(): Promise<void> {
+  await _ready;
+}
+
+// ─── Row ↔ AppNotification ────────────────────────────────────────────────────
+
+interface Row {
+  id: string;
+  category: string;
+  title: string;
+  body: string;
+  is_read: number;
+  created_at: number;
+  metadata: string | null;
+  nav_payload: string | null;
+}
+
+function rowToNotification(row: Row): AppNotification {
+  return {
+    id: row.id,
+    category: row.category as NotificationCategory,
+    title: row.title,
+    body: row.body,
+    isRead: row.is_read === 1,
+    createdAt: row.created_at,
+    metadata: row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : undefined,
+    navPayload: row.nav_payload ? (JSON.parse(row.nav_payload) as NavPayload) : undefined,
+  };
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Add a notification. Silently ignores duplicates (same id).
+ */
+export async function addNotification(
+  notification: Omit<AppNotification, 'isRead'> & { isRead?: boolean },
+): Promise<void> {
+  await waitReady();
+  await db.runAsync(
+    `INSERT OR IGNORE INTO notifications
+       (id, category, title, body, is_read, created_at, metadata, nav_payload)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      notification.id,
+      notification.category,
+      notification.title,
+      notification.body,
+      notification.isRead ? 1 : 0,
+      notification.createdAt,
+      notification.metadata ? JSON.stringify(notification.metadata) : null,
+      notification.navPayload ? JSON.stringify(notification.navPayload) : null,
+    ],
+  );
+}
+
+/**
+ * Fetch all notifications, newest first.
+ * Optionally filter by category.
+ */
+export async function getNotifications(
+  filter: NotificationFilter = 'all',
+): Promise<AppNotification[]> {
+  await waitReady();
+  const rows =
+    filter === 'all'
+      ? await db.getAllAsync<Row>(`SELECT * FROM notifications ORDER BY created_at DESC`)
+      : await db.getAllAsync<Row>(
+          `SELECT * FROM notifications WHERE category = ? ORDER BY created_at DESC`,
+          [filter],
+        );
+  return rows.map(rowToNotification);
+}
+
+/**
+ * Count unread notifications (optionally filtered by category).
+ */
+export async function getUnreadCount(filter: NotificationFilter = 'all'): Promise<number> {
+  await waitReady();
+  const row =
+    filter === 'all'
+      ? await db.getFirstAsync<{ count: number }>(
+          `SELECT COUNT(*) AS count FROM notifications WHERE is_read = 0`,
+        )
+      : await db.getFirstAsync<{ count: number }>(
+          `SELECT COUNT(*) AS count FROM notifications WHERE is_read = 0 AND category = ?`,
+          [filter],
+        );
+  return row?.count ?? 0;
+}
+
+/**
+ * Mark a single notification as read.
+ */
+export async function markAsRead(id: string): Promise<void> {
+  await waitReady();
+  await db.runAsync(`UPDATE notifications SET is_read = 1 WHERE id = ?`, [id]);
+}
+
+/**
+ * Mark all notifications as read (optionally filtered by category).
+ */
+export async function markAllAsRead(filter: NotificationFilter = 'all'): Promise<void> {
+  await waitReady();
+  if (filter === 'all') {
+    await db.runAsync(`UPDATE notifications SET is_read = 1`);
+  } else {
+    await db.runAsync(`UPDATE notifications SET is_read = 1 WHERE category = ?`, [filter]);
+  }
+}
+
+/**
+ * Delete a single notification by id.
+ */
+export async function deleteNotification(id: string): Promise<void> {
+  await waitReady();
+  await db.runAsync(`DELETE FROM notifications WHERE id = ?`, [id]);
+}
+
+/**
+ * Delete all notifications (optionally filtered by category).
+ */
+export async function deleteAll(filter: NotificationFilter = 'all'): Promise<void> {
+  await waitReady();
+  if (filter === 'all') {
+    await db.runAsync(`DELETE FROM notifications`);
+  } else {
+    await db.runAsync(`DELETE FROM notifications WHERE category = ?`, [filter]);
+  }
+}
+
+/**
+ * Delete a batch of notifications by ids.
+ */
+export async function deleteMany(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  await waitReady();
+  const placeholders = ids.map(() => '?').join(',');
+  await db.runAsync(`DELETE FROM notifications WHERE id IN (${placeholders})`, ids);
+}
+
+/**
+ * Mark a batch of notifications as read.
+ */
+export async function markManyAsRead(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  await waitReady();
+  const placeholders = ids.map(() => '?').join(',');
+  await db.runAsync(`UPDATE notifications SET is_read = 1 WHERE id IN (${placeholders})`, ids);
+}
+
+export default {
+  addNotification,
+  getNotifications,
+  getUnreadCount,
+  markAsRead,
+  markAllAsRead,
+  deleteNotification,
+  deleteAll,
+  deleteMany,
+  markManyAsRead,
+};

--- a/src/utils/notificationNavigation.ts
+++ b/src/utils/notificationNavigation.ts
@@ -1,0 +1,26 @@
+/**
+ * Validated deep-link navigation helper for notifications.
+ * Pure TypeScript — no JSX — so it can be imported in tests without JSX transform.
+ */
+import type { AppNotification } from '../services/notificationStore';
+
+/** Screens that are valid navigation targets from a notification. */
+export const VALID_NAV_SCREENS = new Set([
+  'Medications',
+  'Appointments',
+  'Emergency',
+  'PetList',
+  'PetDetail',
+  'PetHealthDashboard',
+  'Community',
+  'Profile',
+]);
+
+export function resolveNavPayload(
+  notification: AppNotification,
+): { screen: string; params?: Record<string, unknown> } | null {
+  const payload = notification.navPayload;
+  if (!payload || typeof payload.screen !== 'string' || !payload.screen) return null;
+  if (!VALID_NAV_SCREENS.has(payload.screen)) return null;
+  return { screen: payload.screen, params: payload.params };
+}


### PR DESCRIPTION
## Summary

Implements a production-ready in-app notification center that aggregates all app notifications into a single, persistent, filterable inbox.

Closes #339

---

## What changed

### New files
| File | Purpose |
|------|---------|
| `src/services/notificationStore.ts` | SQLite-backed store — single source of truth for all notifications |
| `src/screens/NotificationCenterScreen.tsx` | Full notification inbox screen |
| `src/components/NotificationItem.tsx` | Reusable notification row component |
| `src/utils/notificationNavigation.ts` | Validated deep-link routing helper (pure TS, no JSX) |
| `src/hooks/useNotificationBadge.ts` | Hook that returns live unread count for the tab badge |
| `src/__tests__/notificationCenter.test.ts` | 43 automated tests |

### Modified files
| File | Change |
|------|--------|
| `src/navigation/types.ts` | Added `Notifications` to `MainTabParamList` |
| `src/navigation/AppNavigator.tsx` | Wired Notifications tab with live badge, deep-link config |

---

## Feature details

**Storage (`notificationStore.ts`)**
- Uses `expo-sqlite` / `openDatabaseSync('petchain.db')` — same DB as the rest of the app
- Schema: `notifications` table with `id`, `category`, `title`, `body`, `is_read`, `created_at`, `metadata`, `nav_payload`
- `INSERT OR IGNORE` prevents duplicate entries
- Indexed on `created_at DESC` and `category` for fast filtered queries
- Exports: `addNotification`, `getNotifications`, `getUnreadCount`, `markAsRead`, `markAllAsRead`, `markManyAsRead`, `deleteNotification`, `deleteMany`, `deleteAll`

**Notification Center Screen (`NotificationCenterScreen.tsx`)**
- Filter tabs: All · 💊 Meds · 📅 Appts · 🆘 SOS · 🔔 System
- Bulk mark-as-read and bulk delete (with confirmation alert)
- Pull-to-refresh
- Loading, empty, and error states
- Long-press to enter multi-select mode; tap to open + mark read
- `FlatList` with `removeClippedSubviews`, `maxToRenderPerBatch`, `windowSize` for large datasets

**NotificationItem (`NotificationItem.tsx`)**
- Unread dot + bold title for unread; muted style for read
- Category icon, relative timestamp ("Just now" → "5m ago" → "2h ago" → "3d ago")
- Full accessibility labels and roles
- `memo`-wrapped for render performance

**Deep-link routing (`notificationNavigation.ts`)**
- Allowlist of valid screens: `Medications`, `Appointments`, `Emergency`, `PetList`, `PetDetail`, `PetHealthDashboard`, `Community`, `Profile`
- Returns `null` for any unknown, empty, or injection-style screen name — no crashes on stale payloads

**Tab badge (`useNotificationBadge.ts` + `AppNavigator.tsx`)**
- `useNotificationBadge` polls `getUnreadCount()` on mount and on every `refresh()` call
- Badge refreshes on every tab press (covers returning from the Notifications tab)
- Badge hidden when count is 0; red background when > 0

---

## Tests (43 passing)

```
notificationStore — persistence          (3 tests)
notificationStore — duplicate prevention (1 test)
notificationStore — read/unread state    (5 tests)
notificationStore — filtering            (6 tests)
notificationStore — deletion             (5 tests)
notificationStore — badge count          (7 tests)
resolveNavPayload — deep-link routing    (11 tests)
notificationStore — database recovery   (2 tests)
notificationStore — performance         (3 tests)
```

All tests pass. Husky pre-commit ran ESLint + Prettier — no issues.

---

## Testing checklist

- [x] 43 unit tests pass (`npm test`)
- [x] ESLint passes (run by husky pre-commit)
- [x] Prettier passes (run by husky pre-commit)
- [x] No regressions to existing navigation, SQLite, or notification services
- [x] Duplicate notification prevention verified
- [x] Invalid nav payload returns `null` (no crash)
- [x] 500-item performance test passes