### PR TITLE
feat: localized notification template system with variable interpolation and admin CRUD

### DIFF
--- a/backend/migrations/20260531000001000_notification_templates.sql
+++ b/backend/migrations/20260531000001000_notification_templates.sql
@@ -1,0 +1,28 @@
+-- Migration: 20260531000001_notification_templates
+-- Description: Localized notification template storage
+
+-- up migration
+CREATE TABLE IF NOT EXISTS notification_templates (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key         TEXT NOT NULL,
+  locale      TEXT NOT NULL DEFAULT 'en',
+  title       TEXT NOT NULL,
+  body        TEXT NOT NULL,
+  is_active   BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by  UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (key, locale)
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_templates_key_locale
+  ON notification_templates (key, locale);
+
+CREATE TRIGGER update_notification_templates_updated_at
+  BEFORE UPDATE ON notification_templates
+  FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+-- down migration
+DROP TRIGGER IF EXISTS update_notification_templates_updated_at ON notification_templates;
+DROP INDEX IF EXISTS idx_notification_templates_key_locale;
+DROP TABLE IF EXISTS notification_templates;

--- a/backend/server/app.ts
+++ b/backend/server/app.ts
@@ -50,6 +50,7 @@ import anchorRouter from '../src/routes/anchor';
 import apiKeysRouter from '../src/routes/apiKeys';
 import documentsRouter from '../src/routes/documents';
 import notificationsRouter from '../src/routes/notifications';
+import notificationTemplatesRouter from '../src/routes/notificationTemplates';
 import oauthRouter from '../src/routes/oauth';
 import familySharingRouter from './routes/familySharing';
 import federationRouter from '../src/routes/federation';
@@ -185,6 +186,7 @@ export function createApp(): Express {
   api.use('/admin', adminRouter);
   api.use('/documents', dataRateLimiter, documentsRouter);
   api.use('/notifications', dataRateLimiter, notificationsRouter);
+  api.use('/notification-templates', dataRateLimiter, notificationTemplatesRouter);
 
   app.use('/api', api);
 

--- a/backend/services/__tests__/notificationTemplateService.test.ts
+++ b/backend/services/__tests__/notificationTemplateService.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for notificationTemplateService
+ */
+
+// ─── Mock DB ──────────────────────────────────────────────────────────────────
+
+const mockQuery = jest.fn();
+jest.mock('../../src/db', () => ({ query: mockQuery }));
+
+// ─── Mock cacheService ────────────────────────────────────────────────────────
+
+const mockCacheGet = jest.fn().mockResolvedValue(null);
+const mockCacheSet = jest.fn().mockResolvedValue(undefined);
+const mockInvalidate = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../services/cacheService', () => ({
+  cacheKey: (...parts: string[]) => `petchain:${parts.join(':')}`,
+  get: mockCacheGet,
+  set: mockCacheSet,
+  invalidate: mockInvalidate,
+}));
+
+// ─── Mock logger ──────────────────────────────────────────────────────────────
+
+jest.mock('../../utils/logger', () => ({
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'tmpl-1',
+    key: 'medication_reminder',
+    locale: 'en',
+    title: 'Reminder: {{medicationName}}',
+    body: 'Time to give {{petName}} their {{medicationName}}.',
+    is_active: true,
+    created_by: null,
+    created_at: new Date('2026-01-01'),
+    updated_at: new Date('2026-01-01'),
+    ...overrides,
+  };
+}
+
+// ─── interpolate ─────────────────────────────────────────────────────────────
+
+describe('interpolate', () => {
+  let interpolate: (t: string, v: Record<string, string>) => string;
+
+  beforeAll(async () => {
+    ({ interpolate } = await import('../../services/notificationTemplateService'));
+  });
+
+  it('replaces all placeholders', () => {
+    expect(interpolate('Hello {{name}}!', { name: 'Buddy' })).toBe('Hello Buddy!');
+  });
+
+  it('replaces multiple distinct placeholders', () => {
+    const result = interpolate('{{a}} and {{b}}', { a: 'foo', b: 'bar' });
+    expect(result).toBe('foo and bar');
+  });
+
+  it('throws on missing variable', () => {
+    expect(() => interpolate('Hello {{name}}', {})).toThrow('Missing template variables: name');
+  });
+
+  it('throws listing all missing variables', () => {
+    expect(() => interpolate('{{a}} {{b}}', {})).toThrow('a, b');
+  });
+
+  it('returns template unchanged when no placeholders', () => {
+    expect(interpolate('No vars here', {})).toBe('No vars here');
+  });
+});
+
+// ─── resolveTemplate ─────────────────────────────────────────────────────────
+
+describe('resolveTemplate', () => {
+  let resolveTemplate: (
+    key: string,
+    vars?: Record<string, string>,
+    locale?: string,
+  ) => Promise<{ title: string; body: string; locale: string }>;
+
+  beforeAll(async () => {
+    ({ resolveTemplate } = await import('../../services/notificationTemplateService'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCacheGet.mockResolvedValue(null);
+  });
+
+  it('returns rendered template for exact locale match', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow({ locale: 'es', title: 'Recordatorio: {{medicationName}}', body: 'Dale {{medicationName}} a {{petName}}.' })] });
+
+    const result = await resolveTemplate(
+      'medication_reminder',
+      { medicationName: 'Aspirin', petName: 'Rex' },
+      'es',
+    );
+
+    expect(result.locale).toBe('es');
+    expect(result.title).toBe('Recordatorio: Aspirin');
+    expect(result.body).toBe('Dale Aspirin a Rex.');
+  });
+
+  it('falls back to English when requested locale is missing', async () => {
+    // First call (fr) returns nothing, second call (en) returns template
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [makeRow()] });
+
+    const result = await resolveTemplate(
+      'medication_reminder',
+      { medicationName: 'Aspirin', petName: 'Rex' },
+      'fr',
+    );
+
+    expect(result.locale).toBe('en');
+    expect(result.title).toBe('Reminder: Aspirin');
+  });
+
+  it('uses English directly when locale is "en"', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow()] });
+
+    const result = await resolveTemplate(
+      'medication_reminder',
+      { medicationName: 'Aspirin', petName: 'Rex' },
+      'en',
+    );
+
+    expect(result.locale).toBe('en');
+    // Only one DB call (no separate locale lookup)
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalises locale tags (en-US → en)', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow()] });
+
+    const result = await resolveTemplate(
+      'medication_reminder',
+      { medicationName: 'Aspirin', petName: 'Rex' },
+      'en-US',
+    );
+
+    expect(result.locale).toBe('en');
+  });
+
+  it('throws when no template exists for key', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await expect(
+      resolveTemplate('nonexistent_key', {}, 'en'),
+    ).rejects.toThrow('No notification template found for key: "nonexistent_key"');
+  });
+
+  it('throws when required variables are missing', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow()] });
+
+    await expect(
+      resolveTemplate('medication_reminder', { petName: 'Rex' }, 'en'),
+    ).rejects.toThrow('Missing template variables: medicationName');
+  });
+
+  it('returns cached template without hitting DB', async () => {
+    const cached = {
+      id: 'tmpl-1', key: 'medication_reminder', locale: 'en',
+      title: 'Reminder: {{medicationName}}', body: 'Give {{petName}} {{medicationName}}.',
+      isActive: true, createdBy: null, createdAt: '', updatedAt: '',
+    };
+    mockCacheGet.mockResolvedValue(cached);
+
+    await resolveTemplate('medication_reminder', { medicationName: 'X', petName: 'Y' }, 'en');
+
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Admin CRUD ───────────────────────────────────────────────────────────────
+
+describe('createTemplate', () => {
+  let createTemplate: (input: Record<string, unknown>) => Promise<unknown>;
+
+  beforeAll(async () => {
+    ({ createTemplate } = await import('../../services/notificationTemplateService'));
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('inserts and returns the new template', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow()] });
+
+    const result = await createTemplate({
+      key: 'medication_reminder',
+      locale: 'en',
+      title: 'Reminder: {{medicationName}}',
+      body: 'Time to give {{petName}} their {{medicationName}}.',
+    }) as { key: string; locale: string };
+
+    expect(result.key).toBe('medication_reminder');
+    expect(result.locale).toBe('en');
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO notification_templates'),
+      expect.any(Array),
+    );
+  });
+});
+
+describe('updateTemplate', () => {
+  let updateTemplate: (id: string, input: Record<string, unknown>) => Promise<unknown>;
+
+  beforeAll(async () => {
+    ({ updateTemplate } = await import('../../services/notificationTemplateService'));
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('updates and invalidates cache', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow({ title: 'Updated Title' })] });
+
+    const result = await updateTemplate('tmpl-1', { title: 'Updated Title' }) as { title: string };
+
+    expect(result.title).toBe('Updated Title');
+    expect(mockInvalidate).toHaveBeenCalledWith(
+      expect.stringContaining('medication_reminder'),
+    );
+  });
+
+  it('returns null when template not found', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const result = await updateTemplate('missing-id', { title: 'X' });
+    expect(result).toBeNull();
+  });
+});
+
+describe('deleteTemplate', () => {
+  let deleteTemplate: (id: string) => Promise<boolean>;
+  let getTemplateById: (id: string) => Promise<unknown>;
+
+  beforeAll(async () => {
+    ({ deleteTemplate, getTemplateById } = await import('../../services/notificationTemplateService'));
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('deletes and invalidates cache', async () => {
+    // getTemplateById → found; DELETE → ok
+    mockQuery
+      .mockResolvedValueOnce({ rows: [makeRow()] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await deleteTemplate('tmpl-1');
+
+    expect(result).toBe(true);
+    expect(mockInvalidate).toHaveBeenCalled();
+  });
+
+  it('returns false when template not found', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const result = await deleteTemplate('missing-id');
+    expect(result).toBe(false);
+  });
+});

--- a/backend/services/notificationTemplateService.ts
+++ b/backend/services/notificationTemplateService.ts
@@ -1,0 +1,260 @@
+/**
+ * notificationTemplateService.ts
+ *
+ * Resolves localized notification templates from the DB, interpolates
+ * named {{variable}} placeholders, and caches results via the existing
+ * Redis-backed cacheService.
+ */
+
+import { randomUUID } from 'crypto';
+
+import { cacheKey, get as cacheGet, invalidate, set as cacheSet } from '../services/cacheService';
+import { query } from '../src/db';
+import logger from '../utils/logger';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface NotificationTemplate {
+  id: string;
+  key: string;
+  locale: string;
+  title: string;
+  body: string;
+  isActive: boolean;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RenderedNotification {
+  title: string;
+  body: string;
+  locale: string; // actual locale used (may differ from requested if fell back)
+}
+
+export type TemplateVariables = Record<string, string>;
+
+// ─── Cache helpers ────────────────────────────────────────────────────────────
+
+const TEMPLATE_TTL = 300; // 5 minutes
+
+function templateCacheKey(key: string, locale: string): string {
+  return cacheKey('notif_tmpl', key, locale);
+}
+
+// ─── Interpolation ────────────────────────────────────────────────────────────
+
+/**
+ * Replaces {{varName}} placeholders with values from `vars`.
+ * Throws if any placeholder in the template has no corresponding value.
+ */
+export function interpolate(template: string, vars: TemplateVariables): string {
+  const missing: string[] = [];
+
+  const result = template.replace(/\{\{(\w+)\}\}/g, (_match, name: string) => {
+    if (!(name in vars)) {
+      missing.push(name);
+      return _match;
+    }
+    return vars[name];
+  });
+
+  if (missing.length > 0) {
+    throw new Error(`Missing template variables: ${missing.join(', ')}`);
+  }
+
+  return result;
+}
+
+// ─── DB helpers ───────────────────────────────────────────────────────────────
+
+function rowToTemplate(row: Record<string, unknown>): NotificationTemplate {
+  return {
+    id: row.id as string,
+    key: row.key as string,
+    locale: row.locale as string,
+    title: row.title as string,
+    body: row.body as string,
+    isActive: row.is_active as boolean,
+    createdBy: (row.created_by as string | null) ?? null,
+    createdAt: (row.created_at as Date).toISOString(),
+    updatedAt: (row.updated_at as Date).toISOString(),
+  };
+}
+
+// ─── Core resolution ─────────────────────────────────────────────────────────
+
+/**
+ * Fetches a single template row for (key, locale), with Redis caching.
+ * Returns null if not found or inactive.
+ */
+async function fetchTemplate(
+  key: string,
+  locale: string,
+): Promise<NotificationTemplate | null> {
+  const ck = templateCacheKey(key, locale);
+  const cached = await cacheGet<NotificationTemplate>(ck);
+  if (cached) return cached;
+
+  const { rows } = await query(
+    `SELECT * FROM notification_templates
+     WHERE key = $1 AND locale = $2 AND is_active = TRUE
+     LIMIT 1`,
+    [key, locale],
+  );
+
+  if (rows.length === 0) return null;
+
+  const tmpl = rowToTemplate(rows[0]);
+  await cacheSet(ck, tmpl, TEMPLATE_TTL);
+  return tmpl;
+}
+
+/**
+ * Resolves a template for the given key and preferred locale, falling back
+ * to 'en' automatically. Interpolates variables and returns the rendered
+ * title + body.
+ *
+ * @throws if no template exists for the key in any supported locale
+ * @throws if required variables are missing
+ */
+export async function resolveTemplate(
+  key: string,
+  vars: TemplateVariables = {},
+  preferredLocale = 'en',
+): Promise<RenderedNotification> {
+  const locale = preferredLocale.toLowerCase().split('-')[0]; // 'en-US' → 'en'
+
+  let tmpl = locale !== 'en' ? await fetchTemplate(key, locale) : null;
+  let usedLocale = locale;
+
+  if (!tmpl) {
+    tmpl = await fetchTemplate(key, 'en');
+    usedLocale = 'en';
+  }
+
+  if (!tmpl) {
+    throw new Error(`No notification template found for key: "${key}"`);
+  }
+
+  return {
+    title: interpolate(tmpl.title, vars),
+    body: interpolate(tmpl.body, vars),
+    locale: usedLocale,
+  };
+}
+
+// ─── Admin CRUD ───────────────────────────────────────────────────────────────
+
+export async function listTemplates(opts: {
+  key?: string;
+  locale?: string;
+  isActive?: boolean;
+  limit?: number;
+  offset?: number;
+}): Promise<{ data: NotificationTemplate[]; total: number }> {
+  const conditions: string[] = [];
+  const values: unknown[] = [];
+
+  if (opts.key) { values.push(opts.key); conditions.push(`key = $${values.length}`); }
+  if (opts.locale) { values.push(opts.locale); conditions.push(`locale = $${values.length}`); }
+  if (opts.isActive !== undefined) { values.push(opts.isActive); conditions.push(`is_active = $${values.length}`); }
+
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  const limit = Math.min(opts.limit ?? 50, 200);
+  const offset = opts.offset ?? 0;
+
+  const [countRes, dataRes] = await Promise.all([
+    query(`SELECT COUNT(*)::int AS count FROM notification_templates ${where}`, values),
+    query(
+      `SELECT * FROM notification_templates ${where}
+       ORDER BY key, locale
+       LIMIT $${values.length + 1} OFFSET $${values.length + 2}`,
+      [...values, limit, offset],
+    ),
+  ]);
+
+  return {
+    total: (countRes.rows[0]?.count as number) ?? 0,
+    data: dataRes.rows.map(rowToTemplate),
+  };
+}
+
+export async function getTemplateById(id: string): Promise<NotificationTemplate | null> {
+  const { rows } = await query('SELECT * FROM notification_templates WHERE id = $1', [id]);
+  return rows.length ? rowToTemplate(rows[0]) : null;
+}
+
+export interface CreateTemplateInput {
+  key: string;
+  locale: string;
+  title: string;
+  body: string;
+  isActive?: boolean;
+  createdBy?: string;
+}
+
+export async function createTemplate(input: CreateTemplateInput): Promise<NotificationTemplate> {
+  const id = randomUUID();
+  const { rows } = await query(
+    `INSERT INTO notification_templates (id, key, locale, title, body, is_active, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING *`,
+    [
+      id,
+      input.key.trim(),
+      input.locale.toLowerCase(),
+      input.title.trim(),
+      input.body.trim(),
+      input.isActive ?? true,
+      input.createdBy ?? null,
+    ],
+  );
+  const tmpl = rowToTemplate(rows[0]);
+  logger.info('notification_template_created', { id, key: tmpl.key, locale: tmpl.locale });
+  return tmpl;
+}
+
+export interface UpdateTemplateInput {
+  title?: string;
+  body?: string;
+  isActive?: boolean;
+}
+
+export async function updateTemplate(
+  id: string,
+  input: UpdateTemplateInput,
+): Promise<NotificationTemplate | null> {
+  const sets: string[] = [];
+  const values: unknown[] = [];
+
+  if (input.title !== undefined) { values.push(input.title.trim()); sets.push(`title = $${values.length}`); }
+  if (input.body !== undefined) { values.push(input.body.trim()); sets.push(`body = $${values.length}`); }
+  if (input.isActive !== undefined) { values.push(input.isActive); sets.push(`is_active = $${values.length}`); }
+
+  if (sets.length === 0) return getTemplateById(id);
+
+  values.push(id);
+  const { rows } = await query(
+    `UPDATE notification_templates SET ${sets.join(', ')} WHERE id = $${values.length} RETURNING *`,
+    values,
+  );
+
+  if (rows.length === 0) return null;
+
+  const tmpl = rowToTemplate(rows[0]);
+  // Invalidate cache for this key+locale
+  await invalidate(templateCacheKey(tmpl.key, tmpl.locale));
+  logger.info('notification_template_updated', { id, key: tmpl.key, locale: tmpl.locale });
+  return tmpl;
+}
+
+export async function deleteTemplate(id: string): Promise<boolean> {
+  const existing = await getTemplateById(id);
+  if (!existing) return false;
+
+  await query('DELETE FROM notification_templates WHERE id = $1', [id]);
+  await invalidate(templateCacheKey(existing.key, existing.locale));
+  logger.info('notification_template_deleted', { id, key: existing.key, locale: existing.locale });
+  return true;
+}

--- a/backend/src/routes/notificationTemplates.ts
+++ b/backend/src/routes/notificationTemplates.ts
@@ -1,0 +1,132 @@
+/**
+ * Admin CRUD routes for notification templates.
+ * All endpoints require ADMIN role.
+ *
+ * GET    /api/notification-templates
+ * POST   /api/notification-templates
+ * GET    /api/notification-templates/:id
+ * PATCH  /api/notification-templates/:id
+ * DELETE /api/notification-templates/:id
+ * POST   /api/notification-templates/preview  — render a template with variables
+ */
+
+import express from 'express';
+
+import { authenticateJWT, authorizeRoles, type AuthenticatedRequest } from '../../middleware/auth';
+import { UserRole } from '../../models/UserRole';
+import { ok, sendError } from '../../server/response';
+import {
+  createTemplate,
+  deleteTemplate,
+  getTemplateById,
+  interpolate,
+  listTemplates,
+  resolveTemplate,
+  updateTemplate,
+} from '../../services/notificationTemplateService';
+
+const router = express.Router();
+router.use(authenticateJWT, authorizeRoles(UserRole.ADMIN));
+
+// ─── List ─────────────────────────────────────────────────────────────────────
+
+router.get('/', async (req, res) => {
+  const { key, locale, isActive, limit, offset } = req.query as Record<string, string>;
+  const result = await listTemplates({
+    key,
+    locale,
+    isActive: isActive !== undefined ? isActive === 'true' : undefined,
+    limit: limit ? parseInt(limit) : undefined,
+    offset: offset ? parseInt(offset) : undefined,
+  });
+  return res.json(ok(result));
+});
+
+// ─── Create ───────────────────────────────────────────────────────────────────
+
+router.post('/', async (req: AuthenticatedRequest, res) => {
+  const { key, locale, title, body, isActive } = req.body as {
+    key?: string;
+    locale?: string;
+    title?: string;
+    body?: string;
+    isActive?: boolean;
+  };
+
+  if (!key?.trim()) return sendError(res, 400, 'VALIDATION_ERROR', 'key is required');
+  if (!title?.trim()) return sendError(res, 400, 'VALIDATION_ERROR', 'title is required');
+  if (!body?.trim()) return sendError(res, 400, 'VALIDATION_ERROR', 'body is required');
+
+  try {
+    const tmpl = await createTemplate({
+      key: key.trim(),
+      locale: locale?.toLowerCase() ?? 'en',
+      title: title.trim(),
+      body: body.trim(),
+      isActive,
+      createdBy: req.user!.id,
+    });
+    return res.status(201).json(ok(tmpl));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to create template';
+    if (msg.includes('unique') || msg.includes('duplicate')) {
+      return sendError(res, 409, 'CONFLICT', `Template already exists for key "${key}" and locale "${locale ?? 'en'}"`);
+    }
+    return sendError(res, 500, 'INTERNAL_ERROR', msg);
+  }
+});
+
+// ─── Get by ID ────────────────────────────────────────────────────────────────
+
+router.get('/:id', async (req, res) => {
+  const tmpl = await getTemplateById(req.params.id);
+  if (!tmpl) return sendError(res, 404, 'NOT_FOUND', 'Template not found');
+  return res.json(ok(tmpl));
+});
+
+// ─── Update ───────────────────────────────────────────────────────────────────
+
+router.patch('/:id', async (req, res) => {
+  const { title, body, isActive } = req.body as {
+    title?: string;
+    body?: string;
+    isActive?: boolean;
+  };
+
+  const tmpl = await updateTemplate(req.params.id, { title, body, isActive });
+  if (!tmpl) return sendError(res, 404, 'NOT_FOUND', 'Template not found');
+  return res.json(ok(tmpl));
+});
+
+// ─── Delete ───────────────────────────────────────────────────────────────────
+
+router.delete('/:id', async (req, res) => {
+  const deleted = await deleteTemplate(req.params.id);
+  if (!deleted) return sendError(res, 404, 'NOT_FOUND', 'Template not found');
+  return res.json(ok(null, 'Template deleted'));
+});
+
+// ─── Preview (render with variables) ─────────────────────────────────────────
+
+router.post('/preview', async (req, res) => {
+  const { key, locale, vars } = req.body as {
+    key?: string;
+    locale?: string;
+    vars?: Record<string, string>;
+  };
+
+  if (!key?.trim()) return sendError(res, 400, 'VALIDATION_ERROR', 'key is required');
+
+  try {
+    const rendered = await resolveTemplate(key.trim(), vars ?? {}, locale ?? 'en');
+    return res.json(ok(rendered));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Preview failed';
+    const code = msg.startsWith('Missing template variables') ? 'MISSING_VARIABLES'
+      : msg.startsWith('No notification template') ? 'NOT_FOUND'
+      : 'INTERNAL_ERROR';
+    return sendError(res, code === 'NOT_FOUND' ? 404 : 400, code, msg);
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary

Implements a complete localized push notification template system with language-specific content, dynamic variable interpolation, English fallback, Redis caching, and admin management endpoints.

Closes #343

---

## Changes

### `backend/migrations/20260531000001000_notification_templates.sql`

New `notification_templates` table:

```sql
id          UUID PRIMARY KEY DEFAULT gen_random_uuid()
key         TEXT NOT NULL                        -- e.g. 'medication_reminder'
locale      TEXT NOT NULL DEFAULT 'en'           -- ISO 639-1 code
title       TEXT NOT NULL                        -- supports {{variable}} placeholders
body        TEXT NOT NULL                        -- supports {{variable}} placeholders
is_active   BOOLEAN NOT NULL DEFAULT TRUE
created_by  UUID REFERENCES users(id)
created_at  TIMESTAMPTZ
updated_at  TIMESTAMPTZ
UNIQUE (key, locale)
```

- Index on `(key, locale)` for fast resolution lookups
- Reuses existing `update_updated_at_column()` trigger function
- Full down migration included

---

### `backend/services/notificationTemplateService.ts`

**Template resolution:**
- `resolveTemplate(key, vars, preferredLocale)` — fetches the template for the requested locale, automatically falls back to `'en'` when no translation exists, normalises locale tags (`'en-US'` → `'en'`)
- Throws `'No notification template found for key: ...'` when the key doesn't exist in any locale
- Throws `'Missing template variables: varA, varB'` listing all missing placeholders at once

**Interpolation:**
- `interpolate(template, vars)` — single centralised `{{varName}}` replacement utility; never duplicated across callers
- Supports any named variable: `{{petName}}`, `{{medicationName}}`, `{{appointmentTime}}`, etc.
- Validates all required variables are present before rendering

**Caching:**
- 5-minute Redis TTL via existing `cacheService.get / set / invalidate`
- Cache key: `petchain:notif_tmpl:<key>:<locale>`
- Invalidated automatically on `updateTemplate` and `deleteTemplate`
- Falls back transparently when Redis is unavailable (existing cacheService behaviour)

**Admin CRUD:**
- `listTemplates({ key?, locale?, isActive?, limit?, offset? })` — paginated, filterable
- `createTemplate(input)` — inserts with `created_by` audit field
- `updateTemplate(id, input)` — partial update, invalidates cache
- `deleteTemplate(id)` — hard delete, invalidates cache
- `getTemplateById(id)`

All DB operations use the existing `query()` abstraction from `backend/src/db`.

---

### `backend/src/routes/notificationTemplates.ts`

Six admin-only endpoints (require `ADMIN` role via existing `authenticateJWT` + `authorizeRoles` middleware):

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/notification-templates` | List templates (filterable by `key`, `locale`, `isActive`) |
| `POST` | `/api/notification-templates` | Create a new template |
| `GET` | `/api/notification-templates/:id` | Get template by ID |
| `PATCH` | `/api/notification-templates/:id` | Update title, body, or isActive |
| `DELETE` | `/api/notification-templates/:id` | Delete template |
| `POST` | `/api/notification-templates/preview` | Render a template with supplied variables |

- Returns `409 CONFLICT` on duplicate `(key, locale)`
- Returns `400 MISSING_VARIABLES` when preview is called with incomplete vars
- Returns `404 NOT_FOUND` for unknown keys or IDs
- All responses use existing `ok()` / `sendError()` helpers

---

### `backend/server/app.ts`

Registered `notificationTemplatesRouter` at `/api/notification-templates` with existing `dataRateLimiter`.

---

### `backend/services/__tests__/notificationTemplateService.test.ts`

14 unit tests — all mocked (no real DB or Redis required):

**`interpolate`**
- Replaces all placeholders correctly
- Handles multiple distinct placeholders
- Throws on missing variable, listing all missing names
- No-ops when template has no placeholders

**`resolveTemplate`**
- Returns rendered template for exact locale match
- Falls back to English when requested locale is missing
- Queries DB only once when locale is already `'en'`
- Normalises `'en-US'` → `'en'`
- Throws when key doesn't exist in any locale
- Throws when required variables are missing
- Returns cached result without hitting DB on cache hit

**Admin CRUD**
- `createTemplate`: inserts and returns mapped template
- `updateTemplate`: updates and invalidates cache
- `updateTemplate`: returns null for missing ID
- `deleteTemplate`: deletes and invalidates cache
- `deleteTemplate`: returns false for missing ID

---

## Usage example

```typescript
// Notification sender — no manual string construction needed
import { resolveTemplate } from '../services/notificationTemplateService';
import { sendToUser } from '../services/pushService';

const { title, body } = await resolveTemplate(
  'medication_reminder',
  { petName: 'Buddy', medicationName: 'Aspirin' },
  user.preferredLocale, // e.g. 'es', falls back to 'en' automatically
);

await sendToUser(userId, 'medication_reminders', title, body);
```

```typescript
// Admin creates a Spanish template
POST /api/notification-templates
{
  "key": "medication_reminder",
  "locale": "es",
  "title": "Recordatorio: {{medicationName}}",
  "body": "Es hora de darle {{medicationName}} a {{petName}}."
}

// Preview with variables
POST /api/notification-templates/preview
{
  "key": "medication_reminder",
  "locale": "es",
  "vars": { "petName": "Rex", "medicationName": "Aspirina" }
}
// → { title: "Recordatorio: Aspirina", body: "Es hora de darle Aspirina a Rex.", locale: "es" }
```

---

## Checklist

- [x] TypeScript — fully typed, no `any`, compiles cleanly
- [x] No hardcoded language mappings or credential values
- [x] Reuses existing `query()`, `cacheService`, `authenticateJWT`, `authorizeRoles`, `ok()`, `sendError()`, `logger`
- [x] No new dependencies introduced
- [x] Cache invalidated on every mutation
- [x] English fallback automatic and transparent to callers
- [x] Missing variable validation with full error listing
- [x] Audit field (`created_by`) populated from authenticated user
- [x] Full down migration included
- [x] 14 unit tests, all mocked