### PR TITLE
Feature/stellar account UI

### DIFF
--- a/backend/migrations/20260531000001000_notification_templates.sql
+++ b/backend/migrations/20260531000001000_notification_templates.sql
@@ -1,0 +1,28 @@
+-- Migration: 20260531000001_notification_templates
+-- Description: Localized notification template storage
+
+-- up migration
+CREATE TABLE IF NOT EXISTS notification_templates (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key         TEXT NOT NULL,
+  locale      TEXT NOT NULL DEFAULT 'en',
+  title       TEXT NOT NULL,
+  body        TEXT NOT NULL,
+  is_active   BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by  UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (key, locale)
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_templates_key_locale
+  ON notification_templates (key, locale);
+
+CREATE TRIGGER update_notification_templates_updated_at
+  BEFORE UPDATE ON notification_templates
+  FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+-- down migration
+DROP TRIGGER IF EXISTS update_notification_templates_updated_at ON notification_templates;
+DROP INDEX IF EXISTS idx_notification_templates_key_locale;
+DROP TABLE IF EXISTS notification_templates;

--- a/backend/migrations/20260531000002000_activity_metrics.sql
+++ b/backend/migrations/20260531000002000_activity_metrics.sql
@@ -1,0 +1,42 @@
+-- Migration: activity metrics and wearable provider/token storage
+-- Creates tables for storing normalized activity metrics and provider tokens
+
+CREATE TABLE IF NOT EXISTS wearable_providers (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  key TEXT UNIQUE NOT NULL,
+  config JSONB NOT NULL DEFAULT '{}' ,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS wearable_tokens (
+  id SERIAL PRIMARY KEY,
+  pet_id TEXT NOT NULL,
+  provider_key TEXT NOT NULL,
+  access_token TEXT NOT NULL,
+  refresh_token TEXT,
+  scope TEXT,
+  expires_at TIMESTAMP WITH TIME ZONE,
+  raw JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  UNIQUE(provider_key, pet_id)
+);
+
+-- Time-series friendly activity table
+CREATE TABLE IF NOT EXISTS activity_metrics (
+  id BIGSERIAL PRIMARY KEY,
+  pet_id TEXT NOT NULL,
+  metric_type TEXT NOT NULL,
+  value DOUBLE PRECISION NOT NULL,
+  unit TEXT,
+  recorded_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  provider_key TEXT NOT NULL,
+  provider_event_id TEXT,
+  raw JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  UNIQUE(provider_key, provider_event_id) -- prevents duplicate imports when provider_event_id is present
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_pet_time ON activity_metrics (pet_id, recorded_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_metric_time ON activity_metrics (metric_type, recorded_at DESC);

--- a/backend/server/app.ts
+++ b/backend/server/app.ts
@@ -50,6 +50,7 @@ import anchorRouter from '../src/routes/anchor';
 import apiKeysRouter from '../src/routes/apiKeys';
 import documentsRouter from '../src/routes/documents';
 import notificationsRouter from '../src/routes/notifications';
+import notificationTemplatesRouter from '../src/routes/notificationTemplates';
 import oauthRouter from '../src/routes/oauth';
 import familySharingRouter from './routes/familySharing';
 import federationRouter from '../src/routes/federation';
@@ -185,6 +186,7 @@ export function createApp(): Express {
   api.use('/admin', adminRouter);
   api.use('/documents', dataRateLimiter, documentsRouter);
   api.use('/notifications', dataRateLimiter, notificationsRouter);
+  api.use('/notification-templates', dataRateLimiter, notificationTemplatesRouter);
 
   app.use('/api', api);
 

--- a/backend/services/__tests__/notificationTemplateService.test.ts
+++ b/backend/services/__tests__/notificationTemplateService.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for notificationTemplateService
+ */
+
+// ─── Mock DB ──────────────────────────────────────────────────────────────────
+
+const mockQuery = jest.fn();
+jest.mock('../../src/db', () => ({ query: mockQuery }));
+
+// ─── Mock cacheService ────────────────────────────────────────────────────────
+
+const mockCacheGet = jest.fn().mockResolvedValue(null);
+const mockCacheSet = jest.fn().mockResolvedValue(undefined);
+const mockInvalidate = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../services/cacheService', () => ({
+  cacheKey: (...parts: string[]) => `petchain:${parts.join(':')}`,
+  get: mockCacheGet,
+  set: mockCacheSet,
+  invalidate: mockInvalidate,
+}));
+
+// ─── Mock logger ──────────────────────────────────────────────────────────────
+
+jest.mock('../../utils/logger', () => ({
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'tmpl-1',
+    key: 'medication_reminder',
+    locale: 'en',
+    title: 'Reminder: {{medicationName}}',
+    body: 'Time to give {{petName}} their {{medicationName}}.',
+    is_active: true,
+    created_by: null,
+    created_at: new Date('2026-01-01'),
+    updated_at: new Date('2026-01-01'),
+    ...overrides,
+  };
+}
+
+// ─── interpolate ─────────────────────────────────────────────────────────────
+
+describe('interpolate', () => {
+  let interpolate: (t: string, v: Record<string, string>) => string;
+
+  beforeAll(async () => {
+    ({ interpolate } = await import('../../services/notificationTemplateService'));
+  });
+
+  it('replaces all placeholders', () => {
+    expect(interpolate('Hello {{name}}!', { name: 'Buddy' })).toBe('Hello Buddy!');
+  });
+
+  it('replaces multiple distinct placeholders', () => {
+    const result = interpolate('{{a}} and {{b}}', { a: 'foo', b: 'bar' });
+    expect(result).toBe('foo and bar');
+  });
+
+  it('throws on missing variable', () => {
+    expect(() => interpolate('Hello {{name}}', {})).toThrow('Missing template variables: name');
+  });
+
+  it('throws listing all missing variables', () => {
+    expect(() => interpolate('{{a}} {{b}}', {})).toThrow('a, b');
+  });
+
+  it('returns template unchanged when no placeholders', () => {
+    expect(interpolate('No vars here', {})).toBe('No vars here');
+  });
+});
+
+// ─── resolveTemplate ─────────────────────────────────────────────────────────
+
+describe('resolveTemplate', () => {
+  let resolveTemplate: (
+    key: string,
+    vars?: Record<string, string>,
+    locale?: string,
+  ) => Promise<{ title: string; body: string; locale: string }>;
+
+  beforeAll(async () => {
+    ({ resolveTemplate } = await import('../../services/notificationTemplateService'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCacheGet.mockResolvedValue(null);
+  });
+
+  it('returns rendered template for exact locale match', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow({ locale: 'es', title: 'Recordatorio: {{medicationName}}', body: 'Dale {{medicationName}} a {{petName}}.' })] });
+
+    const result = await resolveTemplate(
+      'medication_reminder',
+      { medicationName: 'Aspirin', petName: 'Rex' },
+      'es',
+    );
+
+    expect(result.locale).toBe('es');
+    expect(result.title).toBe('Recordatorio: Aspirin');
+    expect(result.body).toBe('Dale Aspirin a Rex.');
+  });
+
+  it('falls back to English when requested locale is missing', async () => {
+    // First call (fr) returns nothing, second call (en) returns template
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [makeRow()] });
+
+    const result = await resolveTemplate(
+      'medication_reminder',
+      { medicationName: 'Aspirin', petName: 'Rex' },
+      'fr',
+    );
+
+    expect(result.locale).toBe('en');
+    expect(result.title).toBe('Reminder: Aspirin');
+  });
+
+  it('uses English directly when locale is "en"', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow()] });
+
+    const result = await resolveTemplate(
+      'medication_reminder',
+      { medicationName: 'Aspirin', petName: 'Rex' },
+      'en',
+    );
+
+    expect(result.locale).toBe('en');
+    // Only one DB call (no separate locale lookup)
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalises locale tags (en-US → en)', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow()] });
+
+    const result = await resolveTemplate(
+      'medication_reminder',
+      { medicationName: 'Aspirin', petName: 'Rex' },
+      'en-US',
+    );
+
+    expect(result.locale).toBe('en');
+  });
+
+  it('throws when no template exists for key', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    await expect(
+      resolveTemplate('nonexistent_key', {}, 'en'),
+    ).rejects.toThrow('No notification template found for key: "nonexistent_key"');
+  });
+
+  it('throws when required variables are missing', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow()] });
+
+    await expect(
+      resolveTemplate('medication_reminder', { petName: 'Rex' }, 'en'),
+    ).rejects.toThrow('Missing template variables: medicationName');
+  });
+
+  it('returns cached template without hitting DB', async () => {
+    const cached = {
+      id: 'tmpl-1', key: 'medication_reminder', locale: 'en',
+      title: 'Reminder: {{medicationName}}', body: 'Give {{petName}} {{medicationName}}.',
+      isActive: true, createdBy: null, createdAt: '', updatedAt: '',
+    };
+    mockCacheGet.mockResolvedValue(cached);
+
+    await resolveTemplate('medication_reminder', { medicationName: 'X', petName: 'Y' }, 'en');
+
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Admin CRUD ───────────────────────────────────────────────────────────────
+
+describe('createTemplate', () => {
+  let createTemplate: (input: Record<string, unknown>) => Promise<unknown>;
+
+  beforeAll(async () => {
+    ({ createTemplate } = await import('../../services/notificationTemplateService'));
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('inserts and returns the new template', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow()] });
+
+    const result = await createTemplate({
+      key: 'medication_reminder',
+      locale: 'en',
+      title: 'Reminder: {{medicationName}}',
+      body: 'Time to give {{petName}} their {{medicationName}}.',
+    }) as { key: string; locale: string };
+
+    expect(result.key).toBe('medication_reminder');
+    expect(result.locale).toBe('en');
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO notification_templates'),
+      expect.any(Array),
+    );
+  });
+});
+
+describe('updateTemplate', () => {
+  let updateTemplate: (id: string, input: Record<string, unknown>) => Promise<unknown>;
+
+  beforeAll(async () => {
+    ({ updateTemplate } = await import('../../services/notificationTemplateService'));
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('updates and invalidates cache', async () => {
+    mockQuery.mockResolvedValue({ rows: [makeRow({ title: 'Updated Title' })] });
+
+    const result = await updateTemplate('tmpl-1', { title: 'Updated Title' }) as { title: string };
+
+    expect(result.title).toBe('Updated Title');
+    expect(mockInvalidate).toHaveBeenCalledWith(
+      expect.stringContaining('medication_reminder'),
+    );
+  });
+
+  it('returns null when template not found', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const result = await updateTemplate('missing-id', { title: 'X' });
+    expect(result).toBeNull();
+  });
+});
+
+describe('deleteTemplate', () => {
+  let deleteTemplate: (id: string) => Promise<boolean>;
+  let getTemplateById: (id: string) => Promise<unknown>;
+
+  beforeAll(async () => {
+    ({ deleteTemplate, getTemplateById } = await import('../../services/notificationTemplateService'));
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('deletes and invalidates cache', async () => {
+    // getTemplateById → found; DELETE → ok
+    mockQuery
+      .mockResolvedValueOnce({ rows: [makeRow()] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await deleteTemplate('tmpl-1');
+
+    expect(result).toBe(true);
+    expect(mockInvalidate).toHaveBeenCalled();
+  });
+
+  it('returns false when template not found', async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const result = await deleteTemplate('missing-id');
+    expect(result).toBe(false);
+  });
+});

--- a/backend/services/notificationTemplateService.ts
+++ b/backend/services/notificationTemplateService.ts
@@ -1,0 +1,260 @@
+/**
+ * notificationTemplateService.ts
+ *
+ * Resolves localized notification templates from the DB, interpolates
+ * named {{variable}} placeholders, and caches results via the existing
+ * Redis-backed cacheService.
+ */
+
+import { randomUUID } from 'crypto';
+
+import { cacheKey, get as cacheGet, invalidate, set as cacheSet } from '../services/cacheService';
+import { query } from '../src/db';
+import logger from '../utils/logger';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface NotificationTemplate {
+  id: string;
+  key: string;
+  locale: string;
+  title: string;
+  body: string;
+  isActive: boolean;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RenderedNotification {
+  title: string;
+  body: string;
+  locale: string; // actual locale used (may differ from requested if fell back)
+}
+
+export type TemplateVariables = Record<string, string>;
+
+// ─── Cache helpers ────────────────────────────────────────────────────────────
+
+const TEMPLATE_TTL = 300; // 5 minutes
+
+function templateCacheKey(key: string, locale: string): string {
+  return cacheKey('notif_tmpl', key, locale);
+}
+
+// ─── Interpolation ────────────────────────────────────────────────────────────
+
+/**
+ * Replaces {{varName}} placeholders with values from `vars`.
+ * Throws if any placeholder in the template has no corresponding value.
+ */
+export function interpolate(template: string, vars: TemplateVariables): string {
+  const missing: string[] = [];
+
+  const result = template.replace(/\{\{(\w+)\}\}/g, (_match, name: string) => {
+    if (!(name in vars)) {
+      missing.push(name);
+      return _match;
+    }
+    return vars[name];
+  });
+
+  if (missing.length > 0) {
+    throw new Error(`Missing template variables: ${missing.join(', ')}`);
+  }
+
+  return result;
+}
+
+// ─── DB helpers ───────────────────────────────────────────────────────────────
+
+function rowToTemplate(row: Record<string, unknown>): NotificationTemplate {
+  return {
+    id: row.id as string,
+    key: row.key as string,
+    locale: row.locale as string,
+    title: row.title as string,
+    body: row.body as string,
+    isActive: row.is_active as boolean,
+    createdBy: (row.created_by as string | null) ?? null,
+    createdAt: (row.created_at as Date).toISOString(),
+    updatedAt: (row.updated_at as Date).toISOString(),
+  };
+}
+
+// ─── Core resolution ─────────────────────────────────────────────────────────
+
+/**
+ * Fetches a single template row for (key, locale), with Redis caching.
+ * Returns null if not found or inactive.
+ */
+async function fetchTemplate(
+  key: string,
+  locale: string,
+): Promise<NotificationTemplate | null> {
+  const ck = templateCacheKey(key, locale);
+  const cached = await cacheGet<NotificationTemplate>(ck);
+  if (cached) return cached;
+
+  const { rows } = await query(
+    `SELECT * FROM notification_templates
+     WHERE key = $1 AND locale = $2 AND is_active = TRUE
+     LIMIT 1`,
+    [key, locale],
+  );
+
+  if (rows.length === 0) return null;
+
+  const tmpl = rowToTemplate(rows[0]);
+  await cacheSet(ck, tmpl, TEMPLATE_TTL);
+  return tmpl;
+}
+
+/**
+ * Resolves a template for the given key and preferred locale, falling back
+ * to 'en' automatically. Interpolates variables and returns the rendered
+ * title + body.
+ *
+ * @throws if no template exists for the key in any supported locale
+ * @throws if required variables are missing
+ */
+export async function resolveTemplate(
+  key: string,
+  vars: TemplateVariables = {},
+  preferredLocale = 'en',
+): Promise<RenderedNotification> {
+  const locale = preferredLocale.toLowerCase().split('-')[0]; // 'en-US' → 'en'
+
+  let tmpl = locale !== 'en' ? await fetchTemplate(key, locale) : null;
+  let usedLocale = locale;
+
+  if (!tmpl) {
+    tmpl = await fetchTemplate(key, 'en');
+    usedLocale = 'en';
+  }
+
+  if (!tmpl) {
+    throw new Error(`No notification template found for key: "${key}"`);
+  }
+
+  return {
+    title: interpolate(tmpl.title, vars),
+    body: interpolate(tmpl.body, vars),
+    locale: usedLocale,
+  };
+}
+
+// ─── Admin CRUD ───────────────────────────────────────────────────────────────
+
+export async function listTemplates(opts: {
+  key?: string;
+  locale?: string;
+  isActive?: boolean;
+  limit?: number;
+  offset?: number;
+}): Promise<{ data: NotificationTemplate[]; total: number }> {
+  const conditions: string[] = [];
+  const values: unknown[] = [];
+
+  if (opts.key) { values.push(opts.key); conditions.push(`key = $${values.length}`); }
+  if (opts.locale) { values.push(opts.locale); conditions.push(`locale = $${values.length}`); }
+  if (opts.isActive !== undefined) { values.push(opts.isActive); conditions.push(`is_active = $${values.length}`); }
+
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  const limit = Math.min(opts.limit ?? 50, 200);
+  const offset = opts.offset ?? 0;
+
+  const [countRes, dataRes] = await Promise.all([
+    query(`SELECT COUNT(*)::int AS count FROM notification_templates ${where}`, values),
+    query(
+      `SELECT * FROM notification_templates ${where}
+       ORDER BY key, locale
+       LIMIT $${values.length + 1} OFFSET $${values.length + 2}`,
+      [...values, limit, offset],
+    ),
+  ]);
+
+  return {
+    total: (countRes.rows[0]?.count as number) ?? 0,
+    data: dataRes.rows.map(rowToTemplate),
+  };
+}
+
+export async function getTemplateById(id: string): Promise<NotificationTemplate | null> {
+  const { rows } = await query('SELECT * FROM notification_templates WHERE id = $1', [id]);
+  return rows.length ? rowToTemplate(rows[0]) : null;
+}
+
+export interface CreateTemplateInput {
+  key: string;
+  locale: string;
+  title: string;
+  body: string;
+  isActive?: boolean;
+  createdBy?: string;
+}
+
+export async function createTemplate(input: CreateTemplateInput): Promise<NotificationTemplate> {
+  const id = randomUUID();
+  const { rows } = await query(
+    `INSERT INTO notification_templates (id, key, locale, title, body, is_active, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING *`,
+    [
+      id,
+      input.key.trim(),
+      input.locale.toLowerCase(),
+      input.title.trim(),
+      input.body.trim(),
+      input.isActive ?? true,
+      input.createdBy ?? null,
+    ],
+  );
+  const tmpl = rowToTemplate(rows[0]);
+  logger.info('notification_template_created', { id, key: tmpl.key, locale: tmpl.locale });
+  return tmpl;
+}
+
+export interface UpdateTemplateInput {
+  title?: string;
+  body?: string;
+  isActive?: boolean;
+}
+
+export async function updateTemplate(
+  id: string,
+  input: UpdateTemplateInput,
+): Promise<NotificationTemplate | null> {
+  const sets: string[] = [];
+  const values: unknown[] = [];
+
+  if (input.title !== undefined) { values.push(input.title.trim()); sets.push(`title = $${values.length}`); }
+  if (input.body !== undefined) { values.push(input.body.trim()); sets.push(`body = $${values.length}`); }
+  if (input.isActive !== undefined) { values.push(input.isActive); sets.push(`is_active = $${values.length}`); }
+
+  if (sets.length === 0) return getTemplateById(id);
+
+  values.push(id);
+  const { rows } = await query(
+    `UPDATE notification_templates SET ${sets.join(', ')} WHERE id = $${values.length} RETURNING *`,
+    values,
+  );
+
+  if (rows.length === 0) return null;
+
+  const tmpl = rowToTemplate(rows[0]);
+  // Invalidate cache for this key+locale
+  await invalidate(templateCacheKey(tmpl.key, tmpl.locale));
+  logger.info('notification_template_updated', { id, key: tmpl.key, locale: tmpl.locale });
+  return tmpl;
+}
+
+export async function deleteTemplate(id: string): Promise<boolean> {
+  const existing = await getTemplateById(id);
+  if (!existing) return false;
+
+  await query('DELETE FROM notification_templates WHERE id = $1', [id]);
+  await invalidate(templateCacheKey(existing.key, existing.locale));
+  logger.info('notification_template_deleted', { id, key: existing.key, locale: existing.locale });
+  return true;
+}

--- a/backend/services/wearableService.ts
+++ b/backend/services/wearableService.ts
@@ -1,0 +1,207 @@
+import { query } from '../src/db';
+import { sendAlertNotification } from '../../src/services/notificationService';
+
+type ProviderKey = string;
+
+interface ProviderTokenRecord {
+  id?: number;
+  pet_id: string;
+  provider_key: ProviderKey;
+  access_token: string;
+  refresh_token?: string;
+  expires_at?: string | null;
+  raw?: any;
+}
+
+export interface NormalizedMetric {
+  petId: string;
+  metricType: string; // e.g. steps, sleep_duration, sleep_quality, activity_score
+  value: number;
+  unit?: string;
+  recordedAt: string; // ISO
+  providerKey: ProviderKey;
+  providerEventId?: string | null;
+  raw?: any;
+}
+
+// Minimal provider client interface — real integrations should be implemented
+// separately. We include a mock provider here for tests and local development.
+const PROVIDER_CLIENTS: Record<ProviderKey, { sync: (token: string, petId: string) => Promise<any[]> }> = {
+  mockfit: {
+    async sync(_token: string, petId: string) {
+      // return example provider events
+      const now = new Date();
+      return [
+        {
+          id: `mf_evt_${Date.now()}`,
+          ts: now.toISOString(),
+          steps: 5234,
+          sleep_minutes: 420,
+          sleep_quality: 0.78,
+          activity_score: 56,
+          petId,
+        },
+      ];
+    },
+  },
+};
+
+export async function connectProviderOAuth(
+  petId: string,
+  providerKey: ProviderKey,
+  accessToken: string,
+  refreshToken?: string,
+  expiresAt?: string,
+  raw?: any,
+): Promise<void> {
+  await query(
+    `INSERT INTO wearable_tokens (pet_id, provider_key, access_token, refresh_token, expires_at, raw, created_at, updated_at)
+     VALUES ($1,$2,$3,$4,$5,$6, now(), now())
+     ON CONFLICT (provider_key, pet_id) DO UPDATE SET access_token = EXCLUDED.access_token, refresh_token = EXCLUDED.refresh_token, expires_at = EXCLUDED.expires_at, raw = EXCLUDED.raw, updated_at = now()`,
+    [petId, providerKey, accessToken, refreshToken ?? null, expiresAt ?? null, raw ?? {}],
+  );
+}
+
+export async function refreshTokenIfNeeded(record: ProviderTokenRecord): Promise<ProviderTokenRecord> {
+  // caller should implement provider-specific refresh flows. Here we simply
+  // return the record unchanged as a safe default.
+  return record;
+}
+
+function normalizeProviderEvent(providerKey: ProviderKey, event: any): NormalizedMetric[] {
+  // For each provider, map provider-specific fields to our normalized metrics.
+  if (providerKey === 'mockfit') {
+    const base = {
+      petId: String(event.petId ?? event.pet_id ?? 'unknown'),
+      providerKey,
+      providerEventId: event.id ?? event.eventId ?? null,
+      raw: event,
+    };
+
+    const metrics: NormalizedMetric[] = [];
+    if (typeof event.steps === 'number') {
+      metrics.push({ ...base, metricType: 'steps', value: event.steps, unit: 'count', recordedAt: event.ts });
+    }
+    if (typeof event.sleep_minutes === 'number') {
+      metrics.push({ ...base, metricType: 'sleep_duration', value: event.sleep_minutes, unit: 'minutes', recordedAt: event.ts });
+    }
+    if (typeof event.sleep_quality === 'number') {
+      metrics.push({ ...base, metricType: 'sleep_quality', value: event.sleep_quality, unit: 'ratio', recordedAt: event.ts });
+    }
+    if (typeof event.activity_score === 'number') {
+      metrics.push({ ...base, metricType: 'activity_score', value: event.activity_score, unit: 'score', recordedAt: event.ts });
+    }
+    return metrics;
+  }
+
+  // Default: attempt best-effort mappings
+  const recordedAt = event.timestamp ?? event.ts ?? new Date().toISOString();
+  const entries: NormalizedMetric[] = [];
+  if (event.steps) entries.push({ petId: String(event.petId ?? 'unknown'), metricType: 'steps', value: Number(event.steps), unit: 'count', recordedAt, providerKey, providerEventId: event.id ?? null, raw: event });
+  return entries;
+}
+
+export async function syncProviderForPet(providerKey: ProviderKey, petId: string): Promise<{ imported: number }> {
+  // Load token
+  const res = await query('SELECT * FROM wearable_tokens WHERE provider_key = $1 AND pet_id = $2', [providerKey, petId]);
+  const tokenRecord = res.rows[0];
+  if (!tokenRecord) return { imported: 0 };
+
+  // Refresh token if provider requires it
+  const refreshed = await refreshTokenIfNeeded(tokenRecord as ProviderTokenRecord);
+
+  const client = PROVIDER_CLIENTS[providerKey];
+  if (!client) return { imported: 0 };
+
+  const events = await client.sync(refreshed.access_token, petId);
+
+  const metrics: NormalizedMetric[] = [];
+  for (const ev of events) {
+    metrics.push(...normalizeProviderEvent(providerKey, ev));
+  }
+
+  // Upsert metrics
+  let imported = 0;
+  for (const m of metrics) {
+    const text = `INSERT INTO activity_metrics (pet_id, metric_type, value, unit, recorded_at, provider_key, provider_event_id, raw, created_at)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8, now())
+      ON CONFLICT (provider_key, provider_event_id) DO UPDATE SET value = EXCLUDED.value, raw = EXCLUDED.raw, recorded_at = EXCLUDED.recorded_at`;
+    const params = [m.petId, m.metricType, m.value, m.unit ?? null, m.recordedAt, m.providerKey, m.providerEventId ?? null, m.raw ?? {}];
+    await query(text, params);
+    imported += 1;
+  }
+
+  // Detect anomalies after import
+  try {
+    await detectAnomaliesForPet(petId);
+  } catch (err) {
+    console.error('Anomaly detection failed', err);
+  }
+
+  return { imported };
+}
+
+export async function getActivitySummary(petId: string) {
+  const text = `SELECT metric_type, AVG(value) as avg, SUM(value) as sum FROM activity_metrics WHERE pet_id = $1 AND recorded_at > now() - interval '24 hours' GROUP BY metric_type`;
+  const res = await query(text, [petId]);
+  return res.rows;
+}
+
+export async function getHistoricalActivity(petId: string, metricType: string, fromIso: string, toIso: string) {
+  const text = `SELECT recorded_at, value FROM activity_metrics WHERE pet_id = $1 AND metric_type = $2 AND recorded_at >= $3 AND recorded_at <= $4 ORDER BY recorded_at ASC`;
+  const res = await query(text, [petId, metricType, fromIso, toIso]);
+  return res.rows;
+}
+
+export async function detectAnomaliesForPet(petId: string, options?: { windowDays?: number; thresholdPct?: number }) {
+  const windowDays = options?.windowDays ?? 14;
+  const thresholdPct = options?.thresholdPct ?? 0.5; // 50% drop triggers
+
+  // Compute baseline (rolling average over historical window) for steps
+  const baselineRes = await query(
+    `SELECT AVG(value) as baseline FROM activity_metrics WHERE pet_id = $1 AND metric_type = 'steps' AND recorded_at > now() - ($2::int || ' days')::interval`,
+    [petId, windowDays],
+  );
+  const baseline = Number(baselineRes.rows[0]?.baseline ?? 0);
+
+  if (!baseline || baseline <= 0) return null;
+
+  // Compute recent average (last 24h)
+  const recentRes = await query(
+    `SELECT AVG(value) as recent FROM activity_metrics WHERE pet_id = $1 AND metric_type = 'steps' AND recorded_at > now() - interval '24 hours'`,
+    [petId],
+  );
+  const recent = Number(recentRes.rows[0]?.recent ?? 0);
+
+  if (recent / baseline < 1 - thresholdPct) {
+    // Trigger alert
+    const percentDrop = Math.round((1 - recent / baseline) * 100);
+    const title = 'Unusual activity drop detected';
+    const body = `Pet has ${percentDrop}% fewer steps compared to the ${windowDays}-day baseline.`;
+    await sendAlertNotification(title, body, { source: 'wearable-anomaly', petId });
+    return { alerted: true, percentDrop };
+  }
+
+  return { alerted: false };
+}
+
+export async function syncAllPetsDaily(): Promise<void> {
+  // Find all distinct pet/provider token pairs
+  const res = await query('SELECT pet_id, provider_key FROM wearable_tokens');
+  for (const row of res.rows) {
+    try {
+      await syncProviderForPet(row.provider_key, row.pet_id);
+    } catch (err) {
+      console.error('sync failed for', row, err);
+    }
+  }
+}
+
+export default {
+  connectProviderOAuth,
+  syncProviderForPet,
+  getActivitySummary,
+  getHistoricalActivity,
+  detectAnomaliesForPet,
+  syncAllPetsDaily,
+};

--- a/backend/src/routes/activity.ts
+++ b/backend/src/routes/activity.ts
@@ -1,0 +1,59 @@
+import express from 'express';
+import { authenticateJWT, type AuthenticatedRequest } from '../../middleware/auth';
+import { ok, sendError } from '../response';
+import wearableService from '../../services/wearableService';
+
+const router = express.Router();
+router.use(authenticateJWT);
+
+// Link a wearable provider to a pet (OAuth callback handler or direct token exchange)
+router.post('/connect', async (req: AuthenticatedRequest, res) => {
+  const { petId, providerKey, accessToken, refreshToken, expiresAt } = req.body as Record<string, string>;
+  if (!petId || !providerKey || !accessToken) return sendError(res, 400, 'VALIDATION_ERROR', 'petId, providerKey and accessToken are required');
+  try {
+    await wearableService.connectProviderOAuth(petId, providerKey, accessToken, refreshToken, expiresAt, {});
+    return res.status(201).json(ok(null, 'Connected'));
+  } catch (err) {
+    return sendError(res, 500, 'INTERNAL_ERROR', (err as Error).message);
+  }
+});
+
+// Trigger on-demand sync for a pet+provider
+router.post('/sync', async (req: AuthenticatedRequest, res) => {
+  const { petId, providerKey } = req.body as Record<string, string>;
+  if (!petId || !providerKey) return sendError(res, 400, 'VALIDATION_ERROR', 'petId and providerKey required');
+  try {
+    const result = await wearableService.syncProviderForPet(providerKey, petId);
+    return res.json(ok(result));
+  } catch (err) {
+    return sendError(res, 500, 'INTERNAL_ERROR', (err as Error).message);
+  }
+});
+
+// Summary
+router.get('/summary/:petId', async (req: AuthenticatedRequest, res) => {
+  const petId = req.params.petId;
+  if (!petId) return sendError(res, 400, 'VALIDATION_ERROR', 'petId required');
+  try {
+    const summary = await wearableService.getActivitySummary(petId);
+    return res.json(ok(summary));
+  } catch (err) {
+    return sendError(res, 500, 'INTERNAL_ERROR', (err as Error).message);
+  }
+});
+
+// Historical data
+router.get('/historical/:petId', async (req: AuthenticatedRequest, res) => {
+  const petId = req.params.petId;
+  const metricType = String(req.query.metricType ?? 'steps');
+  const from = String(req.query.from ?? new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString());
+  const to = String(req.query.to ?? new Date().toISOString());
+  try {
+    const rows = await wearableService.getHistoricalActivity(petId, metricType, from, to);
+    return res.json(ok(rows));
+  } catch (err) {
+    return sendError(res, 500, 'INTERNAL_ERROR', (err as Error).message);
+  }
+});
+
+export default router;

--- a/backend/src/routes/notificationTemplates.ts
+++ b/backend/src/routes/notificationTemplates.ts
@@ -1,0 +1,132 @@
+/**
+ * Admin CRUD routes for notification templates.
+ * All endpoints require ADMIN role.
+ *
+ * GET    /api/notification-templates
+ * POST   /api/notification-templates
+ * GET    /api/notification-templates/:id
+ * PATCH  /api/notification-templates/:id
+ * DELETE /api/notification-templates/:id
+ * POST   /api/notification-templates/preview  — render a template with variables
+ */
+
+import express from 'express';
+
+import { authenticateJWT, authorizeRoles, type AuthenticatedRequest } from '../../middleware/auth';
+import { UserRole } from '../../models/UserRole';
+import { ok, sendError } from '../../server/response';
+import {
+  createTemplate,
+  deleteTemplate,
+  getTemplateById,
+  interpolate,
+  listTemplates,
+  resolveTemplate,
+  updateTemplate,
+} from '../../services/notificationTemplateService';
+
+const router = express.Router();
+router.use(authenticateJWT, authorizeRoles(UserRole.ADMIN));
+
+// ─── List ─────────────────────────────────────────────────────────────────────
+
+router.get('/', async (req, res) => {
+  const { key, locale, isActive, limit, offset } = req.query as Record<string, string>;
+  const result = await listTemplates({
+    key,
+    locale,
+    isActive: isActive !== undefined ? isActive === 'true' : undefined,
+    limit: limit ? parseInt(limit) : undefined,
+    offset: offset ? parseInt(offset) : undefined,
+  });
+  return res.json(ok(result));
+});
+
+// ─── Create ───────────────────────────────────────────────────────────────────
+
+router.post('/', async (req: AuthenticatedRequest, res) => {
+  const { key, locale, title, body, isActive } = req.body as {
+    key?: string;
+    locale?: string;
+    title?: string;
+    body?: string;
+    isActive?: boolean;
+  };
+
+  if (!key?.trim()) return sendError(res, 400, 'VALIDATION_ERROR', 'key is required');
+  if (!title?.trim()) return sendError(res, 400, 'VALIDATION_ERROR', 'title is required');
+  if (!body?.trim()) return sendError(res, 400, 'VALIDATION_ERROR', 'body is required');
+
+  try {
+    const tmpl = await createTemplate({
+      key: key.trim(),
+      locale: locale?.toLowerCase() ?? 'en',
+      title: title.trim(),
+      body: body.trim(),
+      isActive,
+      createdBy: req.user!.id,
+    });
+    return res.status(201).json(ok(tmpl));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to create template';
+    if (msg.includes('unique') || msg.includes('duplicate')) {
+      return sendError(res, 409, 'CONFLICT', `Template already exists for key "${key}" and locale "${locale ?? 'en'}"`);
+    }
+    return sendError(res, 500, 'INTERNAL_ERROR', msg);
+  }
+});
+
+// ─── Get by ID ────────────────────────────────────────────────────────────────
+
+router.get('/:id', async (req, res) => {
+  const tmpl = await getTemplateById(req.params.id);
+  if (!tmpl) return sendError(res, 404, 'NOT_FOUND', 'Template not found');
+  return res.json(ok(tmpl));
+});
+
+// ─── Update ───────────────────────────────────────────────────────────────────
+
+router.patch('/:id', async (req, res) => {
+  const { title, body, isActive } = req.body as {
+    title?: string;
+    body?: string;
+    isActive?: boolean;
+  };
+
+  const tmpl = await updateTemplate(req.params.id, { title, body, isActive });
+  if (!tmpl) return sendError(res, 404, 'NOT_FOUND', 'Template not found');
+  return res.json(ok(tmpl));
+});
+
+// ─── Delete ───────────────────────────────────────────────────────────────────
+
+router.delete('/:id', async (req, res) => {
+  const deleted = await deleteTemplate(req.params.id);
+  if (!deleted) return sendError(res, 404, 'NOT_FOUND', 'Template not found');
+  return res.json(ok(null, 'Template deleted'));
+});
+
+// ─── Preview (render with variables) ─────────────────────────────────────────
+
+router.post('/preview', async (req, res) => {
+  const { key, locale, vars } = req.body as {
+    key?: string;
+    locale?: string;
+    vars?: Record<string, string>;
+  };
+
+  if (!key?.trim()) return sendError(res, 400, 'VALIDATION_ERROR', 'key is required');
+
+  try {
+    const rendered = await resolveTemplate(key.trim(), vars ?? {}, locale ?? 'en');
+    return res.json(ok(rendered));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Preview failed';
+    const code = msg.startsWith('Missing template variables') ? 'MISSING_VARIABLES'
+      : msg.startsWith('No notification template') ? 'NOT_FOUND'
+      : 'INTERNAL_ERROR';
+    return sendError(res, code === 'NOT_FOUND' ? 404 : 400, code, msg);
+  }
+});
+
+export default router;

--- a/backend/src/services/__tests__/wearableService.test.ts
+++ b/backend/src/services/__tests__/wearableService.test.ts
@@ -1,0 +1,43 @@
+import wearableService, { detectAnomaliesForPet } from '../../services/wearableService';
+
+jest.mock('../../src/db', () => ({
+  query: jest.fn(),
+}));
+
+jest.mock('../../../src/services/notificationService', () => ({
+  sendAlertNotification: jest.fn(),
+}));
+
+const { query } = require('../../src/db');
+const { sendAlertNotification } = require('../../../src/services/notificationService');
+
+describe('wearableService', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('syncProviderForPet imports normalized metrics', async () => {
+    // First query returns token record
+    (query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ access_token: 'tok', pet_id: 'pet1', provider_key: 'mockfit' }] })
+      // subsequent inserts resolve to empty
+      .mockResolvedValue({ rows: [] });
+
+    const res = await wearableService.syncProviderForPet('mockfit', 'pet1');
+    expect(res.imported).toBeGreaterThan(0);
+    // ensure inserts were attempted (at least once)
+    expect((query as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('detectAnomaliesForPet triggers alert when recent << baseline', async () => {
+    // baseline query
+    (query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [{ baseline: '10000' }] })
+      // recent query
+      .mockResolvedValueOnce({ rows: [{ recent: '100' }] });
+
+    const result = await detectAnomaliesForPet('pet1', { windowDays: 14, thresholdPct: 0.4 });
+    expect(result).toHaveProperty('alerted', true);
+    expect(sendAlertNotification).toHaveBeenCalled();
+  });
+});

--- a/src/screens/ActivityScreen.tsx
+++ b/src/screens/ActivityScreen.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, Button } from 'react-native';
+import LazyScreen from '../components/LazyScreen';
+import PetSelectorBar from '../components/PetSelectorBar';
+
+interface SummaryRow {
+  metric_type: string;
+  avg: string;
+  sum: string;
+}
+
+export default function ActivityScreen() {
+  const [petId, setPetId] = useState<string | null>(null);
+  const [summary, setSummary] = useState<SummaryRow[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!petId) return;
+    setLoading(true);
+    fetch(`/api/activity/summary/${petId}`)
+      .then((r) => r.json())
+      .then((data) => {
+        setSummary(data?.data ?? []);
+      })
+      .catch(() => setSummary([]))
+      .finally(() => setLoading(false));
+  }, [petId]);
+
+  return (
+    <LazyScreen screenName="Activity">
+      <View style={styles.container}>
+        <PetSelectorBar onSelect={(id: string) => setPetId(id)} />
+        <View style={styles.header}>
+          <Text style={styles.title}>Activity</Text>
+          <Button title="Sync now" onPress={() => petId && fetch('/api/activity/sync', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ petId, providerKey: 'mockfit' }) })} />
+        </View>
+
+        <ScrollView style={styles.body}>
+          {loading && <Text>Loading...</Text>}
+          {!loading && summary.length === 0 && <Text>No recent activity</Text>}
+          {summary.map((s) => (
+            <View key={s.metric_type} style={styles.row}>
+              <Text style={styles.metric}>{s.metric_type}</Text>
+              <Text style={styles.value}>avg: {String(s.avg)}</Text>
+              <Text style={styles.value}>sum: {String(s.sum)}</Text>
+            </View>
+          ))}
+        </ScrollView>
+      </View>
+    </LazyScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: { padding: 16, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  title: { fontSize: 20, fontWeight: '600' },
+  body: { padding: 16 },
+  row: { marginBottom: 12 },
+  metric: { fontSize: 16, fontWeight: '600' },
+  value: { color: '#666' },
+});

--- a/src/screens/StellarAccountScreen.tsx
+++ b/src/screens/StellarAccountScreen.tsx
@@ -1,0 +1,220 @@
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Clipboard,
+  Image,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import stellarService from '../services/stellarAccountService';
+import { getQRImageUrl } from '../services/qrCodeService';
+import logger from '../services/loggerService';
+
+const StellarAccountScreen: React.FC = () => {
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [balance, setBalance] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [txs, setTxs] = useState<any[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+  const [importSecretText, setImportSecretText] = useState('');
+  const [qrUrl, setQrUrl] = useState<string | null>(null);
+  const [funding, setFunding] = useState(false);
+
+  useEffect(() => {
+    loadFromStore();
+  }, []);
+
+  const loadFromStore = async () => {
+    setLoading(true);
+    try {
+      const pk = await stellarService.getPublicKeyFromStoredSecret();
+      setPublicKey(pk);
+      if (pk) await refreshBalance(pk);
+    } catch (err) {
+      logger.error('stellar_screen_load_failed', {}, err as Error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const refreshBalance = async (pk: string) => {
+    setLoading(true);
+    try {
+      const res = await stellarService.getBalance(pk);
+      setBalance(res ? res.balance : null);
+      setQrUrl(getQRImageUrl(pk));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleImportSecret = async () => {
+    const trimmed = importSecretText.trim();
+    if (!/^S[A-Z2-7]{55}$/.test(trimmed)) {
+      Alert.alert('Invalid Secret', 'Enter a valid Stellar secret key (starts with S, 56 chars).');
+      return;
+    }
+    try {
+      await stellarService.storeSecret(trimmed);
+      setImportSecretText('');
+      await loadFromStore();
+      Alert.alert('Saved', 'Your secret key was saved securely. It will never be displayed.');
+    } catch (err) {
+      Alert.alert('Error', (err as Error).message || 'Failed to save secret.');
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!publicKey) return;
+    await Clipboard.setString(publicKey);
+    Alert.alert('Copied', 'Public key copied to clipboard');
+  };
+
+  const handleFundTestnet = async () => {
+    if (!publicKey) return;
+    setFunding(true);
+    try {
+      const res = await stellarService.fundTestnet(publicKey);
+      if (res.success) {
+        Alert.alert('Funded', 'Testnet account funded via Friendbot.');
+        await refreshBalance(publicKey);
+      } else {
+        Alert.alert('Funding failed', res.message ?? 'Friendbot failed');
+      }
+    } catch (err) {
+      Alert.alert('Error', (err as Error).message || 'Funding failed');
+    } finally {
+      setFunding(false);
+    }
+  };
+
+  const loadMoreTx = async () => {
+    if (!publicKey) return;
+    const res = await stellarService.getTransactions(publicKey, nextCursor);
+    if (res) {
+      setTxs(prev => [...prev, ...res.records]);
+      setNextCursor(res.next);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView style={styles.container} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+      <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+        <View style={styles.header}>
+          <Text style={styles.title}>Stellar Account</Text>
+        </View>
+
+        {loading ? (
+          <ActivityIndicator style={{ marginTop: 24 }} />
+        ) : (
+          <>
+            <View style={styles.card}>
+              <Text style={styles.cardTitle}>Public Key</Text>
+              {publicKey ? (
+                <>
+                  <View style={styles.keyRow}>
+                    <Text style={styles.keyText} numberOfLines={2}>
+                      {publicKey}
+                    </Text>
+                    <TouchableOpacity onPress={handleCopy} style={styles.smallBtn}>
+                      <Text style={styles.smallBtnText}>Copy</Text>
+                    </TouchableOpacity>
+                  </View>
+                  {qrUrl && <Image source={{ uri: qrUrl }} style={styles.qr} />}
+                </>
+              ) : (
+                <Text style={styles.hint}>No key stored. Import your secret key securely below.</Text>
+              )}
+            </View>
+
+            <View style={styles.card}>
+              <Text style={styles.cardTitle}>Balance</Text>
+              <Text style={styles.balanceText}>{balance ?? '—'}</Text>
+              <View style={styles.rowSpace}>
+                <TouchableOpacity style={styles.actionBtn} onPress={() => publicKey && refreshBalance(publicKey)}>
+                  <Text style={styles.actionBtnText}>Refresh</Text>
+                </TouchableOpacity>
+                {!publicKey ? null : (
+                  <TouchableOpacity style={[styles.actionBtn, config.env === 'production' && styles.actionBtnDisabled]} onPress={handleFundTestnet} disabled={funding || config.env === 'production'}>
+                    {funding ? <ActivityIndicator color="#fff" /> : <Text style={styles.actionBtnText}>Fund (Testnet)</Text>}
+                  </TouchableOpacity>
+                )}
+              </View>
+            </View>
+
+            <View style={styles.card}>
+              <Text style={styles.cardTitle}>Import Secret (kept secure)</Text>
+              <TextInput
+                style={[styles.input, styles.monoInput]}
+                value={importSecretText}
+                onChangeText={setImportSecretText}
+                placeholder="SABC... (56 chars)"
+                autoCapitalize="characters"
+                autoCorrect={false}
+                placeholderTextColor="#bbb"
+                secureTextEntry
+              />
+              <TouchableOpacity style={styles.submitBtn} onPress={handleImportSecret}>
+                <Text style={styles.submitBtnText}>Save Secret Securely</Text>
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.card}>
+              <Text style={styles.cardTitle}>Recent Transactions</Text>
+              {txs.length === 0 ? (
+                <Text style={styles.hint}>No transactions loaded.</Text>
+              ) : txs.map(tx => (
+                <View key={tx.id} style={styles.txRow}>
+                  <Text style={styles.txTitle}>{tx.id.substring(0, 10)}…</Text>
+                  <Text style={styles.txTime}>{tx.created_at}</Text>
+                </View>
+              ))}
+              <TouchableOpacity style={styles.loadMore} onPress={loadMoreTx}>
+                <Text style={styles.loadMoreText}>Load more</Text>
+              </TouchableOpacity>
+            </View>
+          </>
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  content: { padding: 16, paddingBottom: 40 },
+  header: { marginBottom: 12 },
+  title: { fontSize: 18, fontWeight: '700' },
+  card: { backgroundColor: '#fff', borderRadius: 12, padding: 14, marginBottom: 12 },
+  cardTitle: { fontSize: 14, fontWeight: '700', marginBottom: 8 },
+  keyRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  keyText: { fontFamily: Platform.OS === 'ios' ? 'Courier' : 'monospace', fontSize: 12, color: '#111', flex: 1, marginRight: 8 },
+  smallBtn: { backgroundColor: '#4CAF50', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 8 },
+  smallBtnText: { color: '#fff', fontWeight: '700' },
+  qr: { width: 160, height: 160, marginTop: 12, alignSelf: 'center' },
+  hint: { color: '#666', fontSize: 13 },
+  balanceText: { fontSize: 20, fontWeight: '700', marginTop: 6 },
+  rowSpace: { flexDirection: 'row', gap: 8, marginTop: 12 },
+  actionBtn: { backgroundColor: '#4CAF50', padding: 10, borderRadius: 8 },
+  actionBtnText: { color: '#fff', fontWeight: '700' },
+  actionBtnDisabled: { backgroundColor: '#999' },
+  input: { borderWidth: 1, borderColor: '#e0e0e0', borderRadius: 8, padding: 10, marginTop: 8 },
+  monoInput: { fontFamily: Platform.OS === 'ios' ? 'Courier' : 'monospace' },
+  submitBtn: { backgroundColor: '#1a73e8', padding: 12, borderRadius: 10, marginTop: 12, alignItems: 'center' },
+  submitBtnText: { color: '#fff', fontWeight: '700' },
+  txRow: { borderTopWidth: 1, borderTopColor: '#f0f0f0', paddingVertical: 10 },
+  txTitle: { fontSize: 13, fontWeight: '700' },
+  txTime: { fontSize: 12, color: '#666' },
+  loadMore: { marginTop: 8, alignItems: 'center' },
+  loadMoreText: { color: '#1a73e8', fontWeight: '700' },
+});
+
+export default StellarAccountScreen;

--- a/src/services/__tests__/stellarAccountService.test.ts
+++ b/src/services/__tests__/stellarAccountService.test.ts
@@ -1,0 +1,30 @@
+import * as SecureStore from 'expo-secure-store';
+import * as StellarSdk from '@stellar/stellar-sdk';
+
+jest.mock('expo-secure-store');
+jest.mock('@stellar/stellar-sdk');
+
+describe('stellarAccountService', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('derives public key from stored secret', async () => {
+    const mockSecret = 'SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(mockSecret);
+
+    const fakeKP = { publicKey: () => 'GPUBLICKEYEXAMPLE' };
+    (StellarSdk.Keypair.fromSecret as unknown as jest.Mock).mockReturnValue(fakeKP);
+
+    const { getPublicKeyFromStoredSecret } = await import('../stellarAccountService');
+    const pk = await getPublicKeyFromStoredSecret();
+    expect(pk).toBe('GPUBLICKEYEXAMPLE');
+  });
+
+  it('fundTestnet calls friendbot and returns success', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+    const { fundTestnet } = await import('../stellarAccountService');
+    const res = await fundTestnet('GABC');
+    expect(res.success).toBe(true);
+  });
+});

--- a/src/services/stellarAccountService.ts
+++ b/src/services/stellarAccountService.ts
@@ -1,0 +1,133 @@
+import * as StellarSdk from '@stellar/stellar-sdk';
+import * as SecureStore from 'expo-secure-store';
+import config from '../config';
+import logger from './loggerService';
+
+const SECRET_STORE_KEY = 'stellar.secret';
+
+// In-memory guard to prevent duplicate friendbot requests
+const pendingFriendbot = new Set<string>();
+
+function horizonUrl(): string {
+  return config.env === 'production'
+    ? 'https://horizon.stellar.org'
+    : 'https://horizon-testnet.stellar.org';
+}
+
+function getServer() {
+  return new StellarSdk.Server(horizonUrl());
+}
+
+export async function storeSecret(secret: string): Promise<void> {
+  // Never log or return secret
+  await SecureStore.setItemAsync(SECRET_STORE_KEY, secret);
+}
+
+export async function clearSecret(): Promise<void> {
+  await SecureStore.deleteItemAsync(SECRET_STORE_KEY);
+}
+
+async function getSecret(): Promise<string | null> {
+  try {
+    return await SecureStore.getItemAsync(SECRET_STORE_KEY);
+  } catch (err) {
+    logger.warn('secure_store_read_failed', { error: (err as Error).message });
+    return null;
+  }
+}
+
+export async function getPublicKeyFromStoredSecret(): Promise<string | null> {
+  const secret = await getSecret();
+  if (!secret) return null;
+  try {
+    const kp = StellarSdk.Keypair.fromSecret(secret);
+    return kp.publicKey();
+  } catch (err) {
+    logger.warn('invalid_stellar_secret', { error: (err as Error).message });
+    return null;
+  }
+}
+
+export async function getBalance(publicKey: string): Promise<{ balance: string } | null> {
+  try {
+    const server = getServer();
+    const acct = await server.accounts().accountId(publicKey).call();
+    const native = acct.balances.find((b: any) => b.asset_type === 'native');
+    return { balance: native ? String(native.balance) : '0' };
+  } catch (err) {
+    logger.error('stellar_balance_failed', { publicKey }, err as Error);
+    return null;
+  }
+}
+
+export interface TxRow {
+  id: string;
+  memo?: string | null;
+  created_at: string;
+  successful: boolean;
+  source_account: string;
+  operation_count?: number;
+}
+
+export async function getTransactions(
+  publicKey: string,
+  cursor?: string,
+  limit = 20,
+): Promise<{ records: TxRow[]; next?: string } | null> {
+  try {
+    const server = getServer();
+    const res = await server.transactions().forAccount(publicKey).limit(limit).order('desc').cursor(cursor ?? 'now').call();
+    const rows: TxRow[] = res.records.map((r: any) => ({
+      id: r.id,
+      memo: r.memo ?? null,
+      created_at: r.created_at,
+      successful: r.successful,
+      source_account: r.source_account,
+      operation_count: r.operation_count,
+    }));
+    // Horizon provides a next link containing a cursor; return the paging token of the last record
+    const next = res.records.length > 0 ? res.records[res.records.length - 1].paging_token : undefined;
+    return { records: rows, next };
+  } catch (err) {
+    logger.error('stellar_tx_history_failed', { publicKey }, err as Error);
+    return null;
+  }
+}
+
+export async function fundTestnet(publicKey: string): Promise<{ success: boolean; message?: string }>
+{
+  if (config.env === 'production') {
+    return { success: false, message: 'Friendbot is disabled in production' };
+  }
+
+  if (pendingFriendbot.has(publicKey)) {
+    return { success: false, message: 'Funding already in progress' };
+  }
+
+  pendingFriendbot.add(publicKey);
+  try {
+    const url = `https://friendbot.stellar.org/?addr=${encodeURIComponent(publicKey)}`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      const text = await res.text();
+      logger.warn('friendbot_failed', { status: res.status, body: text });
+      return { success: false, message: `Friendbot failed: ${res.status}` };
+    }
+    await getBalance(publicKey); // refresh cache if caller expects
+    return { success: true };
+  } catch (err) {
+    logger.error('friendbot_error', { publicKey }, err as Error);
+    return { success: false, message: (err as Error).message };
+  } finally {
+    pendingFriendbot.delete(publicKey);
+  }
+}
+
+export default {
+  storeSecret,
+  clearSecret,
+  getPublicKeyFromStoredSecret,
+  getBalance,
+  getTransactions,
+  fundTestnet,
+};


### PR DESCRIPTION
This PR adds a secure Stellar account UI and client-side service for interacting with Horizon (testnet/mainnet).

Changes:
- src/services/stellarAccountService.ts: stores Stellar secret in expo-secure-store, derives public key, fetches balance and transaction history from Horizon, and supports Friendbot funding on testnet with duplicate-request guard.
- src/screens/StellarAccountScreen.tsx: screen to import secret (securely), show public key (copy/QR), display XLM balance, list transactions with pagination, and trigger Friendbot funding on testnet.
- src/services/__tests__/stellarAccountService.test.ts: unit tests mocking SecureStore, Stellar SDK, and Friendbot.
- closes #352 