### PR TITLE
feat(ci/infra/docs): migration rollback testing, Stellar setup, staging profile, Sentry release tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ API_TIMEOUT=10000
 SENTRY_DSN=
 SENTRY_ENABLE_IN_DEV=false
 
+# Sentry CI — required for source map upload (sentry-sourcemaps workflow)
+# Generate SENTRY_AUTH_TOKEN at https://sentry.io/settings/account/api/auth-tokens/
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=petchain
+SENTRY_PROJECT=mobile-app
+
 # Update Mechanism
 IOS_STORE_URL=https://apps.apple.com/app/petchain/id000000000
 ANDROID_STORE_URL=https://play.google.com/store/apps/details?id=app.petchain.mobile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,38 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+  # ─── Migration rollback testing ───────────────────────────────────────────
+  migration-rollback:
+    name: Migration Rollback Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run migration rollback tests
+        run: npm run test:migrations
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+
   # ─── Unit + Integration tests ─────────────────────────────────────────────
   test:
     name: Unit & Integration Tests

--- a/.github/workflows/sentry-sourcemaps.yml
+++ b/.github/workflows/sentry-sourcemaps.yml
@@ -48,11 +48,18 @@ jobs:
         continue-on-error: true
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          RELEASE="petchain-mobile@${VERSION}"
+          GIT_SHA=$(echo "${{ github.event.workflow_run.head_sha }}" | cut -c1-8)
+          BUILD_NUMBER="${{ github.run_number }}"
+          RELEASE="petchain-mobile@${VERSION}+${BUILD_NUMBER}.${GIT_SHA}"
 
           npx sentry-cli releases new "$RELEASE" \
             --org "$SENTRY_ORG" \
             --project "$SENTRY_PROJECT"
+
+          npx sentry-cli releases set-commits "$RELEASE" \
+            --auto \
+            --org "$SENTRY_ORG" \
+            --project "$SENTRY_PROJECT" || true
 
           npx sentry-cli releases files "$RELEASE" upload-sourcemaps dist \
             --org "$SENTRY_ORG" \
@@ -70,5 +77,5 @@ jobs:
             --project "$SENTRY_PROJECT"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: petchain
-          SENTRY_PROJECT: mobile-app
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -110,6 +110,104 @@ For new features, provide:
 
 Thank you for contributing to PetChain-MobileApp!
 
+## Stellar Development Setup
+
+PetChain uses the [Stellar](https://stellar.org) network for blockchain-verified medical records.
+This section guides you through the testnet setup required to work on any feature under
+`src/services/stellar*` or `backend/src/stellar*`.
+
+### Prerequisites
+
+- Node.js 20+
+- The project dependencies installed (`npm install`)
+- A Stellar testnet account (steps below)
+
+### 1. Create a testnet account
+
+Use the Stellar Laboratory or the `stellar-sdk` CLI to generate a new keypair:
+
+```bash
+node -e "
+const { Keypair } = require('@stellar/stellar-sdk');
+const kp = Keypair.random();
+console.log('Public key:', kp.publicKey());
+console.log('Secret key:', kp.secret());
+"
+```
+
+Save the output — you will need both keys in the next steps.
+
+### 2. Fund the account via Friendbot
+
+Friendbot is a testnet-only faucet that credits 10 000 XLM to a new account:
+
+```bash
+curl "https://friendbot.stellar.org?addr=<YOUR_PUBLIC_KEY>"
+```
+
+Verify the account is funded:
+
+```bash
+curl "https://horizon-testnet.stellar.org/accounts/<YOUR_PUBLIC_KEY>" | \
+  node -e "const d=require('fs').readFileSync('/dev/stdin','utf8'); console.log(JSON.parse(d).balances)"
+```
+
+### 3. Point `.env.development` at testnet Horizon
+
+Add the following to your `.env.development` file (create it from `.env.example` if it does not
+exist):
+
+```bash
+STELLAR_NETWORK=testnet
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+STELLAR_SECRET_KEY=<YOUR_SECRET_KEY>
+STELLAR_PUBLIC_KEY=<YOUR_PUBLIC_KEY>
+```
+
+> **Never commit secret keys.** `.env.development` is gitignored; double-check with
+> `git status` before pushing.
+
+### 4. Run the local SEP-24 anchor mock
+
+PetChain uses [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md)
+for deposit/withdrawal flows. A mock anchor server is provided for local development:
+
+```bash
+# Start the mock anchor (runs on http://localhost:8000)
+npm run server:anchor:mock
+
+# Verify the TOML is reachable
+curl http://localhost:8000/.well-known/stellar.toml
+```
+
+The `TRANSFER_SERVER_SEP0024` key in the response confirms the mock is running. Configure your
+`.env.development` with:
+
+```bash
+STELLAR_ANCHOR_URL=http://localhost:8000
+```
+
+### Troubleshooting
+
+**`OperationError: op_underfunded` when submitting a transaction**
+
+Your testnet account has run out of XLM. Re-fund it with Friendbot (step 2 above). Testnet
+accounts reset periodically; bookmark the Friendbot URL and re-run it if you see this error after
+a testnet reset.
+
+**`NotFoundError: The resource at the url requested was not found`**
+
+The account does not exist on testnet yet. This happens when the public key has never been funded.
+Run the Friendbot curl command (step 2) before making any Horizon API calls.
+
+**`stellar-sdk` throws `TypeError: Cannot read properties of undefined (reading 'sequence')`**
+
+The `loadAccount` call failed silently. Ensure `STELLAR_HORIZON_URL` is set to
+`https://horizon-testnet.stellar.org` (not the mainnet URL) and that the account is funded. Add
+`console.log` around the `loadAccount` call to inspect the raw Horizon response.
+
+---
+
 ## End-to-End (E2E) Testing with Detox
 
 PetChain uses [Detox](https://wix.github.io/Detox/) for end-to-end testing on iOS Simulator and Android Emulator.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -105,7 +105,47 @@ Defined in [`eas.json`](../eas.json):
 |---|---|---|---|---|
 | `development` | — | Device build (dev client) | Device build (dev client) | Local development with `expo-dev-client` |
 | `preview` | `preview` | Simulator `.app` | `.apk` | QA testing, E2E CI, ad-hoc distribution |
+| `staging` | `staging` | `.ipa` (internal) | `.aab` (internal) | Pre-release validation against staging API |
 | `production` | `production` | `.ipa` (App Store) | `.aab` (Play Store) | Store releases |
+
+### Staging build process
+
+The `staging` profile produces **production-grade binaries** (Hermes engine, minification,
+release signing) distributed internally via EAS, pointed at the staging API
+(`https://staging.petchain.app/api`).
+
+**App identifiers for staging:**
+
+| Platform | Identifier |
+|---|---|
+| iOS | `app.petchain.mobile.staging` |
+| Android | `app.petchain.mobile.staging` |
+
+**Build and distribute:**
+
+```bash
+# Build for both platforms
+npm run eas:build:staging
+
+# Or target a single platform
+eas build --platform ios     --profile staging
+eas build --platform android --profile staging
+```
+
+Distributes to internal testers via the EAS dashboard. Share the build URL with QA before
+promoting to production.
+
+**Environment variables required** (set in `.env.staging` or as EAS secrets):
+
+```bash
+APP_ENV=staging
+STAGING_API_URL=https://staging.petchain.app/api
+SENTRY_DSN=<your-staging-sentry-dsn>
+```
+
+> [!IMPORTANT]
+> The `staging` profile uses `distribution: internal` — it does **not** submit to the App Store
+> or Play Store. Use `production` for store releases.
 
 ---
 

--- a/eas.json
+++ b/eas.json
@@ -23,8 +23,20 @@
         "simulator": true
       }
     },
+    "staging": {
+      "distribution": "internal",
+      "channel": "staging",
+      "jsEngine": "hermes",
+      "env": {
+        "APP_ENV": "staging"
+      },
+      "android": {
+        "buildType": "app-bundle"
+      }
+    },
     "production": {
       "channel": "production",
+      "jsEngine": "hermes",
       "env": {
         "APP_ENV": "production"
       },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "start:production": "APP_ENV=production expo start",
     "eas:build:dev": "eas build --platform all --profile development",
     "eas:build:preview": "eas build --platform all --profile preview",
+    "eas:build:staging": "eas build --platform all --profile staging",
     "eas:build:prod": "eas build --platform all --profile production",
     "test": "jest --runInBand",
     "test:ci": "jest --runInBand --ci --coverage",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "prepare": "husky",
     "codegen": "graphql-codegen --config codegen.ts",
     "migrations:validate": "tsx scripts/validate-migrations.ts",
+    "test:migrations": "tsx scripts/test-migrations.ts",
     "migrate": "ts-node backend/src/db/migrate.ts",
     "seed": "ts-node backend/seeds/index.ts",
     "seed:dev": "ts-node backend/seeds/index.ts --owners 5 --vets 3 --pets 2 --records 3 --appointments 2 --medications 1",

--- a/scripts/test-migrations.ts
+++ b/scripts/test-migrations.ts
@@ -1,0 +1,172 @@
+import fs from 'fs';
+import path from 'path';
+
+import { Client } from 'pg';
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..', 'backend', 'migrations', 'legacy');
+const ROLLBACK_DIR = path.resolve(MIGRATIONS_DIR, 'rollback');
+const DATABASE_URL =
+  process.env.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/postgres';
+
+async function waitForPostgres(retries = 30): Promise<void> {
+  for (let i = 0; i < retries; i++) {
+    const client = new Client({ connectionString: DATABASE_URL });
+    try {
+      await client.connect();
+      await client.query('SELECT 1');
+      await client.end();
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+  }
+  throw new Error('Postgres did not become ready in time');
+}
+
+async function runFile(client: Client, filePath: string): Promise<void> {
+  const sql = fs.readFileSync(filePath, 'utf-8');
+  await client.query(sql);
+}
+
+async function getSchemaFingerprint(client: Client): Promise<string> {
+  const res = await client.query<Record<string, string>>(`
+    SELECT
+      t.table_name,
+      c.column_name,
+      c.data_type,
+      c.is_nullable
+    FROM information_schema.tables t
+    JOIN information_schema.columns c
+      ON c.table_name = t.table_name
+     AND c.table_schema = t.table_schema
+    WHERE t.table_schema = 'public'
+      AND t.table_type = 'BASE TABLE'
+    ORDER BY t.table_name, c.ordinal_position
+  `);
+  return JSON.stringify(res.rows);
+}
+
+function numericPrefix(filename: string): string {
+  return filename.match(/^(\d+)/)?.[1] ?? '';
+}
+
+async function main(): Promise<void> {
+  console.log('[test:migrations] Waiting for Postgres...');
+  await waitForPostgres();
+
+  const baseClient = new Client({ connectionString: DATABASE_URL });
+  await baseClient.connect();
+  const testDbName = `petchain_rollback_test_${Date.now()}`;
+  console.log(`[test:migrations] Creating temporary DB: ${testDbName}`);
+  await baseClient.query(`CREATE DATABASE ${testDbName}`);
+  await baseClient.end();
+
+  const testDbUrl = (() => {
+    const u = new URL(DATABASE_URL);
+    u.pathname = `/${testDbName}`;
+    return u.toString();
+  })();
+
+  const testClient = new Client({ connectionString: testDbUrl });
+  await testClient.connect();
+
+  // Forward migration files in the legacy folder, sorted numerically
+  const migrationFiles = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql') && /^\d+_/.test(f))
+    .sort();
+
+  // Index rollback files by their numeric prefix
+  const rollbackByPrefix = new Map<string, string>();
+  for (const f of fs.readdirSync(ROLLBACK_DIR)) {
+    if (f.endsWith('.sql')) {
+      const prefix = numericPrefix(f);
+      if (prefix) rollbackByPrefix.set(prefix, path.join(ROLLBACK_DIR, f));
+    }
+  }
+
+  let passed = 0;
+  let warnings = 0;
+  let failed = 0;
+
+  for (const migFile of migrationFiles) {
+    const migPath = path.join(MIGRATIONS_DIR, migFile);
+    const prefix = numericPrefix(migFile);
+    const rollbackPath = rollbackByPrefix.get(prefix);
+
+    console.log(`\n[test:migrations] ── ${migFile}`);
+
+    try {
+      await runFile(testClient, migPath);
+      console.log('  ✓ Applied');
+    } catch (err) {
+      console.error(`  ✗ Failed to apply: ${err}`);
+      failed++;
+      continue;
+    }
+
+    if (!rollbackPath) {
+      console.warn(`  ⚠  No rollback file for prefix ${prefix} — skipping rollback test`);
+      warnings++;
+      continue;
+    }
+
+    const schemaAfterApply = await getSchemaFingerprint(testClient);
+
+    try {
+      await runFile(testClient, rollbackPath);
+      console.log('  ✓ Rolled back');
+    } catch (err) {
+      console.error(`  ✗ Failed to roll back: ${err}`);
+      failed++;
+      continue;
+    }
+
+    try {
+      await runFile(testClient, migPath);
+      console.log('  ✓ Re-applied');
+    } catch (err) {
+      console.error(`  ✗ Failed to re-apply: ${err}`);
+      failed++;
+      continue;
+    }
+
+    const schemaAfterReapply = await getSchemaFingerprint(testClient);
+    if (schemaAfterApply === schemaAfterReapply) {
+      console.log('  ✓ Schema verified');
+      passed++;
+    } else {
+      console.error('  ✗ Schema mismatch after rollback + re-apply');
+      failed++;
+    }
+  }
+
+  await testClient.end();
+
+  const cleanupClient = new Client({ connectionString: DATABASE_URL });
+  await cleanupClient.connect();
+  await cleanupClient.query(
+    `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${testDbName}'`,
+  );
+  await cleanupClient.query(`DROP DATABASE IF EXISTS ${testDbName}`);
+  await cleanupClient.end();
+
+  console.log(
+    `\n[test:migrations] Results: ${passed} passed, ${warnings} warnings (no rollback), ${failed} failed`,
+  );
+
+  if (warnings > 0) {
+    console.warn(
+      `[test:migrations] ${warnings} migration(s) have no rollback script and were not tested`,
+    );
+  }
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('[test:migrations] Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Resolves four independent infrastructure, documentation, and CI tasks in a single PR.

---

### #627 — Automated migration rollback testing in CI

- **`scripts/test-migrations.ts`** — new script that iterates every migration file in `backend/migrations/legacy/`, applies it to a temporary test database, runs its rollback script, re-applies the migration, then compares the schema fingerprint before and after to confirm idempotency.
- Migrations without a corresponding rollback file emit a **warning** to stdout but do **not** fail the job — not every migration is reversible by design.
- **`npm run test:migrations`** added to `package.json` so the check is runnable locally.
- New **`migration-rollback`** job added to `.github/workflows/ci.yml` with its own Postgres 15 service container; runs independently of the existing `quality` and `test` jobs.

---

### #626 — Stellar development setup in CONTRIBUTING.md

- New **"Stellar Development Setup"** section added to `docs/CONTRIBUTING.md`.
- Covers: generating a testnet keypair with `stellar-sdk`, funding via Friendbot, configuring `.env.development` to point at `horizon-testnet.stellar.org`, and starting the local SEP-24 anchor mock (`npm run server:anchor:mock`).
- All steps include copy-paste CLI commands.
- **Troubleshooting subsection** documents the three most common setup errors: `op_underfunded`, `NotFoundError` (unfunded account), and the `sequence` TypeError from a failed `loadAccount` call.

---

### #628 — EAS staging build profile

- **`eas.json`** — new `staging` profile with production-grade settings: Hermes JS engine, `app-bundle` Android output, `internal` distribution, and `staging` OTA update channel. App identifier resolves to `app.petchain.mobile.staging` via the existing `APP_ENV`-aware logic in `app.config.js`.
- `jsEngine: "hermes"` also explicitly set on the `production` profile for consistency.
- **`npm run eas:build:staging`** script added to `package.json`.
- **`docs/DEPLOYMENT.md`** updated: `staging` row added to the EAS Build Profiles table; new "Staging build process" subsection documents identifiers, build commands, required env vars, and a note clarifying that `staging` uses `internal` distribution (not a store submission).

---

### #625 — Sentry release tracking and source map upload

- **`.github/workflows/sentry-sourcemaps.yml`** — release name extended to `petchain-mobile@<version>+<build_number>.<git_sha_short>`, linking each Sentry release to the exact CI run and commit.
- `sentry-cli releases set-commits --auto` added to associate suspect commits with issues automatically.
- `SENTRY_ORG` and `SENTRY_PROJECT` moved from hardcoded strings to `${{ secrets.SENTRY_ORG }}` / `${{ secrets.SENTRY_PROJECT }}` so they are configurable without a code change.
- **`.env.example`** updated with `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` so contributors know which secrets must be set to run the workflow.

---

## Files changed

| File | Change |
|---|---|
| `scripts/test-migrations.ts` | New — migration rollback test runner |
| `.github/workflows/ci.yml` | New `migration-rollback` CI job |
| `.github/workflows/sentry-sourcemaps.yml` | Release tagged with build number + git SHA; secrets externalised |
| `docs/CONTRIBUTING.md` | New Stellar Development Setup section |
| `docs/DEPLOYMENT.md` | Staging profile table row + build process section |
| `eas.json` | New `staging` profile; explicit Hermes on `production` |
| `package.json` | `test:migrations` and `eas:build:staging` scripts |
| `.env.example` | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` |

Closes #625
Closes #626
Closes #627
Closes #628