### PR TITLE
fix: resolve issues #525, #536, #547, #549

### DIFF
--- a/backend/server/routes/medicalRecords.ts
+++ b/backend/server/routes/medicalRecords.ts
@@ -35,6 +35,50 @@ function toApiRecord(r: StoredMedicalRecord) {
 // All medical record routes require authentication
 router.use(authenticateJWT);
 
+/**
+ * GET /medical-records/search?q=&petId=
+ * Full-text search with ts_rank-style scoring (Issue #536).
+ */
+router.get('/search', (req: AuthenticatedRequest, res) => {
+  const { petId, q } = req.query as { petId?: string; q?: string };
+  if (!q?.trim()) return sendError(res, 400, 'VALIDATION_ERROR', 'Query parameter q is required');
+
+  const terms = q.trim().toLowerCase().split(/\s+/);
+
+  function tsRank(r: StoredMedicalRecord): number {
+    const haystack = [r.notes, r.diagnosis, r.treatment, r.type]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+    return terms.reduce((score, t) => score + (haystack.includes(t) ? 1 : 0), 0);
+  }
+
+  let list = [...store.medicalRecords.values()];
+
+  if (petId) {
+    if (req.user!.role === UserRole.OWNER) {
+      const pet = store.pets.get(petId);
+      if (!pet || pet.ownerId !== req.user!.id)
+        return sendError(res, 403, 'FORBIDDEN', 'No permission to view these records');
+    }
+    list = list.filter((r) => r.petId === petId);
+  } else if (req.user!.role === UserRole.OWNER) {
+    return sendError(res, 403, 'FORBIDDEN', 'petId is required for pet owners');
+  }
+
+  const results = list
+    .map((r) => ({ record: r, rank: tsRank(r) }))
+    .filter(({ rank }) => rank > 0)
+    .sort(
+      (a, b) =>
+        b.rank - a.rank ||
+        new Date(b.record.visitDate).getTime() - new Date(a.record.visitDate).getTime(),
+    )
+    .map(({ record }) => toApiRecord(record));
+
+  return res.json(ok(results));
+});
+
 router.get('/pet/:petId', (req: AuthenticatedRequest, res) => {
   const petId = req.params.petId as string;
   const pet = store.pets.get(petId);

--- a/backend/utils/__tests__/cryptoUtils.test.ts
+++ b/backend/utils/__tests__/cryptoUtils.test.ts
@@ -1,0 +1,83 @@
+import {
+  decryptTOTPSeed,
+  encryptTOTPSeed,
+  isEncryptedPayload,
+  type EncryptedPayload,
+} from '../cryptoUtils';
+
+const VALID_KEY = 'a'.repeat(64); // 32 bytes as hex
+
+beforeEach(() => {
+  process.env.TOTP_ENCRYPTION_KEY = VALID_KEY;
+});
+
+afterEach(() => {
+  delete process.env.TOTP_ENCRYPTION_KEY;
+});
+
+describe('encrypt/decrypt round-trip', () => {
+  it('decrypts back to the original plaintext', () => {
+    const secret = 'JBSWY3DPEHPK3PXP';
+    const payload = encryptTOTPSeed(secret);
+    expect(decryptTOTPSeed(payload)).toBe(secret);
+  });
+
+  it('produces different ciphertexts on each call (random IV)', () => {
+    const secret = 'TESTSECRET123456';
+    const a = encryptTOTPSeed(secret);
+    const b = encryptTOTPSeed(secret);
+    expect(a.iv).not.toBe(b.iv);
+    expect(a.ciphertext).not.toBe(b.ciphertext);
+  });
+
+  it('payload contains iv, authTag, and ciphertext fields', () => {
+    const payload = encryptTOTPSeed('mysecret');
+    expect(typeof payload.iv).toBe('string');
+    expect(typeof payload.authTag).toBe('string');
+    expect(typeof payload.ciphertext).toBe('string');
+  });
+});
+
+describe('tampered authTag rejected', () => {
+  it('throws when authTag is modified', () => {
+    const payload = encryptTOTPSeed('JBSWY3DPEHPK3PXP');
+    const tampered: EncryptedPayload = { ...payload, authTag: 'ff'.repeat(16) };
+    expect(() => decryptTOTPSeed(tampered)).toThrow();
+  });
+
+  it('throws when ciphertext is modified', () => {
+    const payload = encryptTOTPSeed('JBSWY3DPEHPK3PXP');
+    const tampered: EncryptedPayload = {
+      ...payload,
+      ciphertext: 'deadbeef' + payload.ciphertext.slice(8),
+    };
+    expect(() => decryptTOTPSeed(tampered)).toThrow();
+  });
+});
+
+describe('missing key throws on startup', () => {
+  it('throws when TOTP_ENCRYPTION_KEY is not set', () => {
+    delete process.env.TOTP_ENCRYPTION_KEY;
+    expect(() => encryptTOTPSeed('secret')).toThrow('TOTP_ENCRYPTION_KEY');
+  });
+
+  it('throws when TOTP_ENCRYPTION_KEY is wrong length', () => {
+    process.env.TOTP_ENCRYPTION_KEY = 'tooshort';
+    expect(() => encryptTOTPSeed('secret')).toThrow('TOTP_ENCRYPTION_KEY');
+  });
+});
+
+describe('isEncryptedPayload', () => {
+  it('returns true for a valid encrypted JSON payload', () => {
+    const payload = encryptTOTPSeed('test');
+    expect(isEncryptedPayload(JSON.stringify(payload))).toBe(true);
+  });
+
+  it('returns false for a plaintext secret', () => {
+    expect(isEncryptedPayload('JBSWY3DPEHPK3PXP')).toBe(false);
+  });
+
+  it('returns false for arbitrary JSON without required fields', () => {
+    expect(isEncryptedPayload(JSON.stringify({ foo: 'bar' }))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #525
Closes #536
Closes #547
Closes #549

### #525 — TOTP seed encryption at rest
Adds missing unit tests for `cryptoUtils.ts` (AES-256-GCM already implemented):
- encrypt/decrypt round-trip
- tampered `authTag` rejected
- missing/wrong-length `TOTP_ENCRYPTION_KEY` throws on startup
- `isEncryptedPayload` detection (plaintext vs encrypted)

**File:** `backend/utils/__tests__/cryptoUtils.test.ts` (new, 10 tests)

### #536 — Full-text search for medical records
Adds missing backend search route (migration + frontend `searchRecords()` already existed):
- `GET /medical-records/search?q=&petId=`
- ts_rank-style scoring across `notes`, `diagnosis`, `treatment`, `type`
- Ranked by relevance then date; owner auth enforced

**File:** `backend/server/routes/medicalRecords.ts` (+44 lines)

### #547 — Token refresh race condition
Already fully implemented via `singleFlightRefresh()` in `apiClient.ts`. No code changes.

### #549 — Privacy Dashboard workflows
Already fully implemented in `PrivacyDashboardScreen.tsx`. No code changes.