### PR TITLE
feat(#571): distance sorting, filter drawer, and location fallback in VetDirectoryScreen

### DIFF
--- a/src/screens/VetDirectoryScreen.tsx
+++ b/src/screens/VetDirectoryScreen.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
   FlatList,
   KeyboardAvoidingView,
   Modal,
+  PanResponder,
   Platform,
   ScrollView,
   StyleSheet,
@@ -16,6 +17,7 @@ import {
 
 import { SkeletonCard } from '../components/SkeletonCard';
 import { useMinimumLoadingTime } from '../hooks/useMinimumLoadingTime';
+import mapService from '../services/mapService';
 import {
   getMessages,
   getVetProfile,
@@ -25,7 +27,116 @@ import {
   type VetProfile,
 } from '../services/vetService';
 
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const RADIUS_MIN = 1;
+const RADIUS_MAX = 50;
+const DEBOUNCE_MS = 300;
+
+const SPECIALTY_OPTIONS = [
+  'General',
+  'Dermatology',
+  'Cardiology',
+  'Oncology',
+  'Surgery',
+  'Dentistry',
+  'Neurology',
+  'Ophthalmology',
+];
+
 type Screen = 'directory' | 'profile' | 'chat';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+// ─── RadiusSlider ─────────────────────────────────────────────────────────────
+
+interface RadiusSliderProps {
+  value: number;
+  onChange: (v: number) => void;
+}
+
+const RadiusSlider: React.FC<RadiusSliderProps> = ({ value, onChange }) => {
+  const trackWidth = useRef(0);
+  const ratio = (value - RADIUS_MIN) / (RADIUS_MAX - RADIUS_MIN);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onPanResponderGrant: (e) => {
+        const x = e.nativeEvent.locationX;
+        const r = Math.max(0, Math.min(1, x / (trackWidth.current || 1)));
+        onChange(Math.round(RADIUS_MIN + r * (RADIUS_MAX - RADIUS_MIN)));
+      },
+      onPanResponderMove: (e) => {
+        const x = e.nativeEvent.locationX;
+        const r = Math.max(0, Math.min(1, x / (trackWidth.current || 1)));
+        onChange(Math.round(RADIUS_MIN + r * (RADIUS_MAX - RADIUS_MIN)));
+      },
+    }),
+  ).current;
+
+  return (
+    <View style={sliderStyles.wrapper}>
+      <View
+        style={sliderStyles.track}
+        onLayout={(e) => {
+          trackWidth.current = e.nativeEvent.layout.width;
+        }}
+        {...panResponder.panHandlers}
+      >
+        <View style={[sliderStyles.fill, { width: `${ratio * 100}%` }]} />
+        <View style={[sliderStyles.thumb, { left: `${ratio * 100}%` }]} />
+      </View>
+      <View style={sliderStyles.labels}>
+        <Text style={sliderStyles.labelText}>{RADIUS_MIN} km</Text>
+        <Text style={sliderStyles.labelText}>{RADIUS_MAX} km</Text>
+      </View>
+    </View>
+  );
+};
+
+const sliderStyles = StyleSheet.create({
+  wrapper: { marginVertical: 8 },
+  track: {
+    height: 6,
+    backgroundColor: '#E2E8F0',
+    borderRadius: 3,
+    justifyContent: 'center',
+    marginHorizontal: 8,
+  },
+  fill: { height: 6, backgroundColor: '#4299e1', borderRadius: 3 },
+  thumb: {
+    position: 'absolute',
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: '#fff',
+    borderWidth: 2,
+    borderColor: '#4299e1',
+    top: -7,
+    marginLeft: -10,
+  },
+  labels: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 4,
+    paddingHorizontal: 8,
+  },
+  labelText: { fontSize: 11, color: '#718096' },
+});
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 const VetDirectoryScreen: React.FC = () => {
   const [screen, setScreen] = useState<Screen>('directory');
@@ -33,13 +144,23 @@ const VetDirectoryScreen: React.FC = () => {
   const [selectedVet, setSelectedVet] = useState<VetProfile | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // Enforce minimum 300ms display for skeleton
   const displayLoading = useMinimumLoadingTime(loading, { minLoadingTime: 300 });
 
-  // Search filters
-  const [specialty, setSpecialty] = useState('');
-  const [radius, setRadius] = useState('25');
+  // Location
+  const [userLat, setUserLat] = useState<number | null>(null);
+  const [userLng, setUserLng] = useState<number | null>(null);
+  const [locationDenied, setLocationDenied] = useState(false);
+
+  // Filters
+  const [radius, setRadius] = useState(25);
+  const [selectedSpecialties, setSelectedSpecialties] = useState<string[]>([]);
   const [availableOnly, setAvailableOnly] = useState(false);
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+
+  // Draft filter state (inside drawer, not applied until confirmed)
+  const [draftRadius, setDraftRadius] = useState(25);
+  const [draftSpecialties, setDraftSpecialties] = useState<string[]>([]);
+  const [draftAvailableOnly, setDraftAvailableOnly] = useState(false);
 
   // Chat
   const [messages, setMessages] = useState<VetMessage[]>([]);
@@ -47,25 +168,122 @@ const VetDirectoryScreen: React.FC = () => {
   const [chatLoading, setChatLoading] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
 
-  const doSearch = useCallback(async () => {
-    setLoading(true);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ── Location ───────────────────────────────────────────────────────────────
+
+  const requestLocation = useCallback(async () => {
     try {
-      const results = await searchVets({
-        specialty: specialty || undefined,
-        radius: parseFloat(radius) || 25,
-        available: availableOnly || undefined,
-      });
-      setVets(results);
+      const granted = await mapService.requestLocationPermission();
+      if (!granted) {
+        setLocationDenied(true);
+        return;
+      }
+      setLocationDenied(false);
+      const loc = await mapService.getCurrentLocation();
+      setUserLat(loc.latitude);
+      setUserLng(loc.longitude);
     } catch {
-      Alert.alert('Error', 'Failed to search vets');
-    } finally {
-      setLoading(false);
+      setLocationDenied(true);
     }
-  }, [specialty, radius, availableOnly]);
+  }, []);
 
   useEffect(() => {
-    void doSearch();
-  }, [doSearch]);
+    void requestLocation();
+  }, [requestLocation]);
+
+  // ── Search ─────────────────────────────────────────────────────────────────
+
+  const doSearch = useCallback(
+    async (
+      lat: number | null,
+      lng: number | null,
+      r: number,
+      specialties: string[],
+      availOnly: boolean,
+    ) => {
+      setLoading(true);
+      try {
+        const specialtyParam = specialties.length === 1 ? specialties[0] : undefined;
+        const results = await searchVets({
+          lat: lat ?? undefined,
+          lng: lng ?? undefined,
+          radius: r,
+          specialty: specialtyParam,
+          available: availOnly || undefined,
+        });
+
+        // Attach distance client-side and sort
+        const withDist = results.map((v) => {
+          if (lat !== null && lng !== null && v.lat && v.lng) {
+            return { ...v, distance: haversineKm(lat, lng, v.lat, v.lng) };
+          }
+          return v;
+        });
+
+        // Client-side multi-specialty filter when more than one selected
+        const filtered =
+          specialties.length > 1
+            ? withDist.filter((v) =>
+                specialties.some((s) => v.specialty.toLowerCase().includes(s.toLowerCase())),
+              )
+            : withDist;
+
+        const sorted =
+          lat !== null
+            ? [...filtered].sort((a, b) => (a.distance ?? Infinity) - (b.distance ?? Infinity))
+            : [...filtered].sort((a, b) => a.name.localeCompare(b.name));
+
+        setVets(sorted);
+      } catch {
+        Alert.alert('Error', 'Failed to search vets');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  // Debounced re-search when filters change
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void doSearch(userLat, userLng, radius, selectedSpecialties, availableOnly);
+    }, DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [userLat, userLng, radius, selectedSpecialties, availableOnly, doSearch]);
+
+  // ── Filter drawer ──────────────────────────────────────────────────────────
+
+  const openDrawer = () => {
+    setDraftRadius(radius);
+    setDraftSpecialties(selectedSpecialties);
+    setDraftAvailableOnly(availableOnly);
+    setFilterDrawerOpen(true);
+  };
+
+  const applyFilters = () => {
+    setRadius(draftRadius);
+    setSelectedSpecialties(draftSpecialties);
+    setAvailableOnly(draftAvailableOnly);
+    setFilterDrawerOpen(false);
+  };
+
+  const toggleDraftSpecialty = (s: string) => {
+    setDraftSpecialties((prev) => (prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]));
+  };
+
+  const activeFilterCount = useMemo(() => {
+    let n = 0;
+    if (radius !== 25) n++;
+    if (selectedSpecialties.length) n++;
+    if (availableOnly) n++;
+    return n;
+  }, [radius, selectedSpecialties, availableOnly]);
+
+  // ── Profile / Chat ─────────────────────────────────────────────────────────
 
   const openProfile = useCallback(async (vet: VetProfile) => {
     try {
@@ -103,48 +321,51 @@ const VetDirectoryScreen: React.FC = () => {
     }
   }, [msgInput, selectedVet]);
 
-  // ─── Directory ───────────────────────────────────────────────────────────────
+  // ── Directory screen ───────────────────────────────────────────────────────
+
   if (screen === 'directory') {
     return (
       <View style={styles.container}>
-        <Text style={styles.title}>Vet Directory</Text>
+        {/* Location denied banner */}
+        {locationDenied && (
+          <TouchableOpacity
+            style={styles.locationBanner}
+            onPress={() => void requestLocation()}
+            accessibilityLabel="Enable location for nearest results"
+          >
+            <Text style={styles.locationBannerText}>
+              📍 Enable location for nearest results — tap to retry
+            </Text>
+          </TouchableOpacity>
+        )}
 
-        <View style={styles.filters}>
-          <TextInput
-            style={styles.input}
-            placeholder="Specialty (e.g. Dermatology)"
-            value={specialty}
-            onChangeText={setSpecialty}
-            returnKeyType="search"
-            onSubmitEditing={() => void doSearch()}
-          />
-          <View style={styles.row}>
-            <TextInput
-              style={[styles.input, { flex: 1, marginRight: 8 }]}
-              placeholder="Radius (km)"
-              value={radius}
-              onChangeText={setRadius}
-              keyboardType="numeric"
-            />
-            <TouchableOpacity
-              style={[styles.toggleBtn, availableOnly && styles.toggleActive]}
-              onPress={() => setAvailableOnly((v) => !v)}
-              accessibilityLabel="Toggle available only"
+        {/* Header row */}
+        <View style={styles.headerRow}>
+          <Text style={styles.title}>Vet Directory</Text>
+          <TouchableOpacity
+            style={[styles.filterBtn, activeFilterCount > 0 && styles.filterBtnActive]}
+            onPress={openDrawer}
+            accessibilityLabel="Open filter drawer"
+          >
+            <Text
+              style={[styles.filterBtnText, activeFilterCount > 0 && styles.filterBtnTextActive]}
             >
-              <Text style={availableOnly ? styles.toggleTextActive : styles.toggleText}>
-                Available only
-              </Text>
-            </TouchableOpacity>
-          </View>
-          <TouchableOpacity style={styles.searchBtn} onPress={() => void doSearch()}>
-            <Text style={styles.searchBtnText}>Search</Text>
+              Filters{activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
+            </Text>
           </TouchableOpacity>
         </View>
 
+        {/* Sort / status bar */}
+        <Text style={styles.sortLabel}>
+          {userLat !== null ? `Sorted by distance · ${radius} km radius` : 'Sorted alphabetically'}
+          {selectedSpecialties.length > 0 ? ` · ${selectedSpecialties.join(', ')}` : ''}
+          {availableOnly ? ' · Available only' : ''}
+        </Text>
+
         {displayLoading ? (
           <View style={styles.list}>
-            {Array.from({ length: 5 }).map((_, index) => (
-              <SkeletonCard key={`skeleton-${index}`} />
+            {Array.from({ length: 5 }).map((_, i) => (
+              <SkeletonCard key={`sk-${i}`} />
             ))}
           </View>
         ) : (
@@ -162,8 +383,10 @@ const VetDirectoryScreen: React.FC = () => {
                   <Text style={styles.vetSub}>{item.specialty}</Text>
                   <Text style={styles.vetSub}>
                     ⭐ {item.rating.toFixed(1)} · {item.reviewCount} reviews
-                    {item.distance !== undefined ? ` · ${item.distance.toFixed(1)} km` : ''}
                   </Text>
+                  {item.distance !== undefined && (
+                    <Text style={styles.distanceText}>📍 {item.distance.toFixed(1)} km away</Text>
+                  )}
                 </View>
                 <View style={[styles.badge, item.available ? styles.badgeGreen : styles.badgeGray]}>
                   <Text style={styles.badgeText}>{item.available ? 'Available' : 'Busy'}</Text>
@@ -174,11 +397,93 @@ const VetDirectoryScreen: React.FC = () => {
             contentContainerStyle={styles.list}
           />
         )}
+
+        {/* Filter drawer modal */}
+        <Modal
+          visible={filterDrawerOpen}
+          animationType="slide"
+          transparent
+          onRequestClose={() => setFilterDrawerOpen(false)}
+        >
+          <View style={styles.drawerOverlay}>
+            <View style={styles.drawer}>
+              <View style={styles.drawerHeader}>
+                <Text style={styles.drawerTitle}>Filters</Text>
+                <TouchableOpacity onPress={() => setFilterDrawerOpen(false)}>
+                  <Text style={styles.drawerClose}>✕</Text>
+                </TouchableOpacity>
+              </View>
+
+              <ScrollView contentContainerStyle={styles.drawerBody}>
+                {/* Radius */}
+                <Text style={styles.drawerLabel}>Distance radius: {draftRadius} km</Text>
+                <RadiusSlider value={draftRadius} onChange={setDraftRadius} />
+
+                {/* Specialty multi-select */}
+                <Text style={styles.drawerLabel}>Specialty</Text>
+                <View style={styles.specialtyGrid}>
+                  {SPECIALTY_OPTIONS.map((s) => {
+                    const active = draftSpecialties.includes(s);
+                    return (
+                      <TouchableOpacity
+                        key={s}
+                        style={[styles.specialtyChip, active && styles.specialtyChipActive]}
+                        onPress={() => toggleDraftSpecialty(s)}
+                        accessibilityLabel={`Toggle ${s} specialty`}
+                        accessibilityState={{ selected: active }}
+                      >
+                        <Text
+                          style={[
+                            styles.specialtyChipText,
+                            active && styles.specialtyChipTextActive,
+                          ]}
+                        >
+                          {s}
+                        </Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+
+                {/* Available only */}
+                <TouchableOpacity
+                  style={styles.drawerToggleRow}
+                  onPress={() => setDraftAvailableOnly((v) => !v)}
+                  accessibilityLabel="Toggle accepts new patients"
+                >
+                  <Text style={styles.drawerToggleLabel}>Accepts new patients</Text>
+                  <View style={[styles.togglePill, draftAvailableOnly && styles.togglePillActive]}>
+                    <View
+                      style={[styles.toggleDot, draftAvailableOnly && styles.toggleDotActive]}
+                    />
+                  </View>
+                </TouchableOpacity>
+              </ScrollView>
+
+              <View style={styles.drawerFooter}>
+                <TouchableOpacity
+                  style={styles.drawerResetBtn}
+                  onPress={() => {
+                    setDraftRadius(25);
+                    setDraftSpecialties([]);
+                    setDraftAvailableOnly(false);
+                  }}
+                >
+                  <Text style={styles.drawerResetText}>Reset</Text>
+                </TouchableOpacity>
+                <TouchableOpacity style={styles.drawerApplyBtn} onPress={applyFilters}>
+                  <Text style={styles.drawerApplyText}>Apply Filters</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        </Modal>
       </View>
     );
   }
 
-  // ─── Profile ─────────────────────────────────────────────────────────────────
+  // ── Profile screen ─────────────────────────────────────────────────────────
+
   if (screen === 'profile' && selectedVet) {
     return (
       <ScrollView style={styles.container} contentContainerStyle={styles.profileContent}>
@@ -198,6 +503,12 @@ const VetDirectoryScreen: React.FC = () => {
         <Text style={styles.value}>
           ⭐ {selectedVet.rating.toFixed(1)} ({selectedVet.reviewCount} reviews)
         </Text>
+        {selectedVet.distance !== undefined && (
+          <>
+            <Text style={styles.label}>Distance</Text>
+            <Text style={styles.value}>📍 {selectedVet.distance.toFixed(1)} km away</Text>
+          </>
+        )}
         <Text style={styles.label}>Address</Text>
         <Text style={styles.value}>{selectedVet.address || '—'}</Text>
         <Text style={styles.label}>Phone</Text>
@@ -214,7 +525,8 @@ const VetDirectoryScreen: React.FC = () => {
     );
   }
 
-  // ─── Chat ─────────────────────────────────────────────────────────────────────
+  // ── Chat screen ────────────────────────────────────────────────────────────
+
   if (screen === 'chat' && selectedVet) {
     return (
       <KeyboardAvoidingView
@@ -284,38 +596,45 @@ const VetDirectoryScreen: React.FC = () => {
   return null;
 };
 
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#fff' },
-  title: { fontSize: 20, fontWeight: '700', color: '#1a202c', padding: 16, paddingBottom: 8 },
-  filters: { paddingHorizontal: 16, paddingBottom: 8 },
-  input: {
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    marginBottom: 8,
-    fontSize: 14,
-    color: '#1a202c',
-  },
-  row: { flexDirection: 'row', alignItems: 'center', marginBottom: 8 },
-  toggleBtn: {
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-  },
-  toggleActive: { backgroundColor: '#4299e1', borderColor: '#4299e1' },
-  toggleText: { color: '#718096', fontSize: 13 },
-  toggleTextActive: { color: '#fff', fontSize: 13 },
-  searchBtn: {
-    backgroundColor: '#4299e1',
-    borderRadius: 8,
+
+  // Location banner
+  locationBanner: {
+    backgroundColor: '#EBF8FF',
+    borderBottomWidth: 1,
+    borderBottomColor: '#BEE3F8',
+    paddingHorizontal: 16,
     paddingVertical: 10,
-    alignItems: 'center',
   },
-  searchBtnText: { color: '#fff', fontWeight: '600', fontSize: 15 },
+  locationBannerText: { fontSize: 13, color: '#2B6CB0', fontWeight: '500' },
+
+  // Header
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 4,
+  },
+  title: { fontSize: 20, fontWeight: '700', color: '#1a202c' },
+  filterBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#CBD5E0',
+    backgroundColor: '#F7FAFC',
+  },
+  filterBtnActive: { backgroundColor: '#4299e1', borderColor: '#4299e1' },
+  filterBtnText: { fontSize: 13, color: '#4A5568', fontWeight: '600' },
+  filterBtnTextActive: { color: '#fff' },
+  sortLabel: { fontSize: 12, color: '#718096', paddingHorizontal: 16, paddingBottom: 8 },
+
+  // List
   loader: { marginTop: 40 },
   list: { padding: 12 },
   card: {
@@ -329,11 +648,111 @@ const styles = StyleSheet.create({
   cardInfo: { flex: 1 },
   vetName: { fontSize: 15, fontWeight: '600', color: '#1a202c' },
   vetSub: { fontSize: 13, color: '#718096', marginTop: 2 },
+  distanceText: { fontSize: 13, color: '#4299e1', fontWeight: '600', marginTop: 4 },
   badge: { paddingHorizontal: 8, paddingVertical: 4, borderRadius: 12 },
   badgeGreen: { backgroundColor: '#c6f6d5' },
   badgeGray: { backgroundColor: '#e2e8f0' },
   badgeText: { fontSize: 12, fontWeight: '600', color: '#2d3748' },
   empty: { textAlign: 'center', color: '#718096', marginTop: 40 },
+
+  // Filter drawer
+  drawerOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', justifyContent: 'flex-end' },
+  drawer: {
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    maxHeight: '80%',
+  },
+  drawerHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: '#EDF2F7',
+  },
+  drawerTitle: { fontSize: 18, fontWeight: '700', color: '#1a202c' },
+  drawerClose: { fontSize: 20, color: '#718096' },
+  drawerBody: { padding: 20, paddingBottom: 8 },
+  drawerLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#4A5568',
+    marginBottom: 8,
+    marginTop: 12,
+  },
+
+  // Specialty chips
+  specialtyGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 8 },
+  specialtyChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#CBD5E0',
+    backgroundColor: '#F7FAFC',
+  },
+  specialtyChipActive: { backgroundColor: '#4299e1', borderColor: '#4299e1' },
+  specialtyChipText: { fontSize: 13, color: '#4A5568' },
+  specialtyChipTextActive: { color: '#fff', fontWeight: '600' },
+
+  // Toggle row
+  drawerToggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 14,
+    borderTopWidth: 1,
+    borderTopColor: '#EDF2F7',
+    marginTop: 8,
+  },
+  drawerToggleLabel: { fontSize: 15, color: '#1a202c' },
+  togglePill: {
+    width: 44,
+    height: 26,
+    borderRadius: 13,
+    backgroundColor: '#CBD5E0',
+    justifyContent: 'center',
+    padding: 2,
+  },
+  togglePillActive: { backgroundColor: '#4299e1' },
+  toggleDot: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: '#fff',
+    alignSelf: 'flex-start',
+  },
+  toggleDotActive: { alignSelf: 'flex-end' },
+
+  // Drawer footer
+  drawerFooter: {
+    flexDirection: 'row',
+    gap: 12,
+    padding: 20,
+    paddingBottom: Platform.OS === 'ios' ? 36 : 20,
+    borderTopWidth: 1,
+    borderTopColor: '#EDF2F7',
+  },
+  drawerResetBtn: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#CBD5E0',
+    alignItems: 'center',
+  },
+  drawerResetText: { fontSize: 15, color: '#4A5568', fontWeight: '600' },
+  drawerApplyBtn: {
+    flex: 2,
+    paddingVertical: 12,
+    borderRadius: 10,
+    backgroundColor: '#4299e1',
+    alignItems: 'center',
+  },
+  drawerApplyText: { fontSize: 15, color: '#fff', fontWeight: '700' },
+
+  // Profile
   profileContent: { padding: 16 },
   back: { marginBottom: 8 },
   backText: { color: '#4299e1', fontSize: 16 },
@@ -345,6 +764,15 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   value: { fontSize: 15, color: '#1a202c', marginTop: 2 },
+  searchBtn: {
+    backgroundColor: '#4299e1',
+    borderRadius: 8,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  searchBtnText: { color: '#fff', fontWeight: '600', fontSize: 15 },
+
+  // Chat
   chatHeader: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -388,5 +816,8 @@ const styles = StyleSheet.create({
   },
   sendBtnText: { color: '#fff', fontWeight: '600' },
 });
+
+// suppress unused wsRef warning — kept for future WebSocket integration
+void wsRef;
 
 export default VetDirectoryScreen;


### PR DESCRIPTION
## Summary
- Location permission requested on mount via mapService; results sorted by distance when granted
- "📍 X.X km away" distance shown prominently on each card
- Filter drawer (bottom-sheet modal) with:
  - Custom PanResponder radius slider (1–50 km, no extra dependencies)
  - Specialty multi-select chips (General, Dermatology, Cardiology, Oncology, Surgery, Dentistry, Neurology, Ophthalmology)
  - Accepts new patients toggle
- Filters applied on "Apply Filters"; Reset clears all back to defaults
- Active filter count badge on the Filters button
- 300 ms debounce on every filter change — results update in real time
- When location is denied: alphabetical list shown + tappable blue banner to retry

## Test plan
- [ ] Grant location — list sorted by distance, "X.X km away" visible on cards
- [ ] Deny location — alphabetical list, blue banner shows "Enable location for nearest results"
- [ ] Tap banner — re-prompts for permission
- [ ] Open filter drawer, drag slider to 10 km — value updates live
- [ ] Select multiple specialties — chips highlight; results filter client-side
- [ ] Toggle "Accepts new patients" — list updates after 300 ms debounce
- [ ] Reset button — all draft filters cleared to defaults
closes #571 