### PR TITLE
fix: implement #553 2FA backup codes, #535 waitlist WebSocket, #528 h…

### DIFF
--- a/backend/services/__tests__/federationService.test.ts
+++ b/backend/services/__tests__/federationService.test.ts
@@ -14,14 +14,29 @@ jest.mock('@stellar/stellar-sdk', () => {
       fromSecret: jest.fn((sec: string) => mockKeypair('GPUBKEY123', sec)),
       fromPublicKey: jest.fn((pub: string) => mockKeypair(pub, '')),
     },
+    Federation: {
+      Server: {
+        resolve: jest.fn(),
+      },
+    },
   };
 });
+
+jest.mock('../cacheService', () => ({
+  get: jest.fn(),
+  set: jest.fn().mockResolvedValue(undefined),
+}));
+
+import * as StellarSdk from '@stellar/stellar-sdk';
+import { get as cacheGet, set as cacheSet } from '../cacheService';
 
 import {
   claimFederatedAddress,
   getSignedRecord,
   getVetFederationRecord,
   lookupFederation,
+  resolveFederationAddress,
+  resolveFederationAddressWithCacheControl,
   revokeVetCredential,
   signMedicalRecord,
   verifyRecordSignature,
@@ -29,6 +44,15 @@ import {
 
 const CREDENTIAL_HASH = 'abc123def456';
 const RECORD_PAYLOAD = { id: 'mr-1', petId: 'p-1', type: 'vaccination' };
+
+const mockCacheGet = cacheGet as jest.Mock;
+const mockCacheSet = cacheSet as jest.Mock;
+const mockResolve = StellarSdk.Federation.Server.resolve as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCacheGet.mockResolvedValue(null); // default: cache miss
+});
 
 describe('federationService', () => {
   describe('claimFederatedAddress', () => {
@@ -76,6 +100,100 @@ describe('federationService', () => {
       claimFederatedAddress('vet-revlookup', 'dr.revlookup', CREDENTIAL_HASH);
       revokeVetCredential('vet-revlookup');
       expect(lookupFederation('dr.revlookup*petchain.app', 'name')).toBeNull();
+    });
+  });
+
+  describe('resolveFederationAddress — caching', () => {
+    const address = 'user*petchain.app';
+    const resolvedRecord = { account_id: 'GPUBKEYRESOLVED', memo_type: 'text', memo: 'user-1' };
+
+    it('returns cached result on cache hit (no upstream call)', async () => {
+      const cached = { result: { stellar_address: address, account_id: 'GPUBKEYCACHED' } };
+      mockCacheGet.mockResolvedValue(cached);
+
+      const result = await resolveFederationAddress(address);
+
+      expect(result).toEqual(cached.result);
+      expect(mockResolve).not.toHaveBeenCalled();
+    });
+
+    it('calls upstream and caches result on cache miss', async () => {
+      mockCacheGet.mockResolvedValue(null);
+      mockResolve.mockResolvedValue(resolvedRecord);
+
+      const result = await resolveFederationAddress(address);
+
+      expect(mockResolve).toHaveBeenCalledWith(address);
+      expect(result?.account_id).toBe('GPUBKEYRESOLVED');
+      expect(mockCacheSet).toHaveBeenCalledWith(
+        expect.stringContaining(address),
+        { result: expect.objectContaining({ account_id: 'GPUBKEYRESOLVED' }) },
+        15 * 60,
+      );
+    });
+
+    it('caches negative result for 2 minutes when address not found', async () => {
+      mockCacheGet.mockResolvedValue(null);
+      mockResolve.mockRejectedValue(new Error('Not found'));
+
+      const result = await resolveFederationAddress(address);
+
+      expect(result).toBeNull();
+      expect(mockCacheSet).toHaveBeenCalledWith(
+        expect.stringContaining(address),
+        { result: null },
+        2 * 60,
+      );
+    });
+
+    it('serves cached negative result without calling upstream', async () => {
+      mockCacheGet.mockResolvedValue({ result: null });
+
+      const result = await resolveFederationAddress(address);
+
+      expect(result).toBeNull();
+      expect(mockResolve).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveFederationAddressWithCacheControl', () => {
+    const address = 'vet*hospital.example';
+    const resolvedRecord = { account_id: 'GPUBKEYCC', memo_type: 'text', memo: undefined };
+
+    it('uses the lower of Cache-Control max-age and 15-min TTL', async () => {
+      mockCacheGet.mockResolvedValue(null);
+      mockResolve.mockResolvedValue(resolvedRecord);
+
+      await resolveFederationAddressWithCacheControl(address, 300); // 5 min from server
+
+      expect(mockCacheSet).toHaveBeenCalledWith(
+        expect.stringContaining(address),
+        expect.any(Object),
+        300, // 5 min < 15 min → use 5 min
+      );
+    });
+
+    it('caps at 15 min when server Cache-Control is larger', async () => {
+      mockCacheGet.mockResolvedValue(null);
+      mockResolve.mockResolvedValue(resolvedRecord);
+
+      await resolveFederationAddressWithCacheControl(address, 3600); // 1 hour from server
+
+      expect(mockCacheSet).toHaveBeenCalledWith(
+        expect.stringContaining(address),
+        expect.any(Object),
+        15 * 60, // capped at 15 min
+      );
+    });
+
+    it('returns cached hit without upstream call', async () => {
+      const cached = { result: { stellar_address: address, account_id: 'GPUBKEYHIT' } };
+      mockCacheGet.mockResolvedValue(cached);
+
+      const result = await resolveFederationAddressWithCacheControl(address, 300);
+
+      expect(result).toEqual(cached.result);
+      expect(mockResolve).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/services/federationService.ts
+++ b/backend/services/federationService.ts
@@ -2,6 +2,91 @@ import crypto from 'crypto';
 
 import * as StellarSdk from '@stellar/stellar-sdk';
 
+import { get, set } from './cacheService';
+
+const CACHE_TTL_POSITIVE = 15 * 60; // 15 minutes
+const CACHE_TTL_NEGATIVE = 2 * 60; // 2 minutes for negative results
+
+function federationCacheKey(address: string): string {
+  return `federation:resolve:${address}`;
+}
+
+export interface ResolvedFederationAddress {
+  stellar_address: string;
+  account_id: string;
+  memo_type?: string;
+  memo?: string;
+}
+
+interface CachedFederationEntry {
+  result: ResolvedFederationAddress | null; // null = negative result
+}
+
+/**
+ * Resolves a Stellar federation address (e.g. user*petchain.app) to a public key.
+ * Results are cached: positive for 15 min (or less per Cache-Control), negative for 2 min.
+ */
+export async function resolveFederationAddress(
+  federatedAddress: string,
+): Promise<ResolvedFederationAddress | null> {
+  const key = federationCacheKey(federatedAddress);
+  const cached = await get<CachedFederationEntry>(key);
+  if (cached !== null) {
+    return cached.result;
+  }
+
+  try {
+    const server = await StellarSdk.Federation.Server.resolve(federatedAddress);
+    const result: ResolvedFederationAddress = {
+      stellar_address: federatedAddress,
+      account_id: server.account_id,
+      memo_type: server.memo_type,
+      memo: server.memo,
+    };
+    await set<CachedFederationEntry>(key, { result }, CACHE_TTL_POSITIVE);
+    return result;
+  } catch (err: unknown) {
+    // Cache negative results to prevent hammering upstream on bad addresses
+    await set<CachedFederationEntry>(key, { result: null }, CACHE_TTL_NEGATIVE);
+    return null;
+  }
+}
+
+/**
+ * Like resolveFederationAddress but respects the federation server's Cache-Control max-age.
+ * Uses the lower of the server's TTL and our 15-min default.
+ */
+export async function resolveFederationAddressWithCacheControl(
+  federatedAddress: string,
+  cacheControlMaxAge?: number,
+): Promise<ResolvedFederationAddress | null> {
+  const ttl =
+    cacheControlMaxAge !== undefined
+      ? Math.min(cacheControlMaxAge, CACHE_TTL_POSITIVE)
+      : CACHE_TTL_POSITIVE;
+
+  const key = federationCacheKey(federatedAddress);
+  const cached = await get<CachedFederationEntry>(key);
+  if (cached !== null) {
+    return cached.result;
+  }
+
+  try {
+    const server = await StellarSdk.Federation.Server.resolve(federatedAddress);
+    const result: ResolvedFederationAddress = {
+      stellar_address: federatedAddress,
+      account_id: server.account_id,
+      memo_type: server.memo_type,
+      memo: server.memo,
+    };
+    await set<CachedFederationEntry>(key, { result }, ttl);
+    return result;
+  } catch {
+    await set<CachedFederationEntry>(key, { result: null }, CACHE_TTL_NEGATIVE);
+    return null;
+  }
+}
+
 export interface VetFederationRecord {
   vetId: string;
   federatedAddress: string; // e.g. dr.smith*petchain.app

--- a/src/screens/HealthThresholdsScreen.tsx
+++ b/src/screens/HealthThresholdsScreen.tsx
@@ -1,0 +1,355 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import apiClient from '../services/apiClient';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Thresholds {
+  heart_rate_min: string;
+  heart_rate_max: string;
+  weight_min: string;
+  weight_max: string;
+  temperature_min: string;
+  temperature_max: string;
+  activity_min: string;
+  activity_max: string;
+}
+
+const EMPTY: Thresholds = {
+  heart_rate_min: '',
+  heart_rate_max: '',
+  weight_min: '',
+  weight_max: '',
+  temperature_min: '',
+  temperature_max: '',
+  activity_min: '',
+  activity_max: '',
+};
+
+// Clinically reasonable ranges (matches backend validation)
+const LIMITS = {
+  heart_rate: { min: 20, max: 300 },
+  weight: { min: 0.1, max: 200 },
+  temperature: { min: 30, max: 45 },
+  activity: { min: 0, max: 100000 },
+};
+
+interface Props {
+  petId?: string;
+  onBack?: () => void;
+}
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+function validate(form: Thresholds): string | null {
+  const hr_min = parseFloat(form.heart_rate_min);
+  const hr_max = parseFloat(form.heart_rate_max);
+  const w_min = parseFloat(form.weight_min);
+  const w_max = parseFloat(form.weight_max);
+  const t_min = parseFloat(form.temperature_min);
+  const t_max = parseFloat(form.temperature_max);
+  const a_min = parseFloat(form.activity_min);
+  const a_max = parseFloat(form.activity_max);
+
+  if (form.heart_rate_min && form.heart_rate_max) {
+    if (hr_min >= hr_max) return 'Heart rate min must be less than max.';
+    if (hr_min < LIMITS.heart_rate.min || hr_max > LIMITS.heart_rate.max)
+      return `Heart rate must be between ${LIMITS.heart_rate.min}–${LIMITS.heart_rate.max} bpm.`;
+  }
+  if (form.weight_min && form.weight_max) {
+    if (w_min >= w_max) return 'Weight min must be less than max.';
+    if (w_min < LIMITS.weight.min || w_max > LIMITS.weight.max)
+      return `Weight must be between ${LIMITS.weight.min}–${LIMITS.weight.max} kg.`;
+  }
+  if (form.temperature_min && form.temperature_max) {
+    if (t_min >= t_max) return 'Temperature min must be less than max.';
+    if (t_min < LIMITS.temperature.min || t_max > LIMITS.temperature.max)
+      return `Temperature must be between ${LIMITS.temperature.min}–${LIMITS.temperature.max} °C.`;
+  }
+  if (form.activity_min && form.activity_max) {
+    if (a_min >= a_max) return 'Activity min must be less than max.';
+    if (a_min < LIMITS.activity.min || a_max > LIMITS.activity.max)
+      return `Activity must be between ${LIMITS.activity.min}–${LIMITS.activity.max} steps.`;
+  }
+  return null;
+}
+
+function toPayload(form: Thresholds) {
+  const n = (v: string) => (v.trim() === '' ? undefined : parseFloat(v));
+  return {
+    heart_rate_min: n(form.heart_rate_min),
+    heart_rate_max: n(form.heart_rate_max),
+    weight_min: n(form.weight_min),
+    weight_max: n(form.weight_max),
+    temperature_min: n(form.temperature_min),
+    temperature_max: n(form.temperature_max),
+    activity_min: n(form.activity_min),
+    activity_max: n(form.activity_max),
+  };
+}
+
+// ─── Field row ────────────────────────────────────────────────────────────────
+
+const FieldRow: React.FC<{
+  label: string;
+  minKey: keyof Thresholds;
+  maxKey: keyof Thresholds;
+  unit: string;
+  form: Thresholds;
+  onChange: (key: keyof Thresholds, val: string) => void;
+}> = ({ label, minKey, maxKey, unit, form, onChange }) => (
+  <View style={styles.fieldGroup}>
+    <Text style={styles.fieldLabel}>
+      {label} ({unit})
+    </Text>
+    <View style={styles.fieldRow}>
+      <View style={styles.fieldHalf}>
+        <Text style={styles.subLabel}>Min</Text>
+        <TextInput
+          style={styles.input}
+          value={form[minKey]}
+          onChangeText={(v) => onChange(minKey, v)}
+          keyboardType="decimal-pad"
+          placeholder="—"
+          accessibilityLabel={`${label} minimum`}
+        />
+      </View>
+      <View style={styles.fieldHalf}>
+        <Text style={styles.subLabel}>Max</Text>
+        <TextInput
+          style={styles.input}
+          value={form[maxKey]}
+          onChangeText={(v) => onChange(maxKey, v)}
+          keyboardType="decimal-pad"
+          placeholder="—"
+          accessibilityLabel={`${label} maximum`}
+        />
+      </View>
+    </View>
+  </View>
+);
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function HealthThresholdsScreen({ petId, onBack }: Props) {
+  const [form, setForm] = useState<Thresholds>(EMPTY);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const setField = useCallback((key: keyof Thresholds, val: string) => {
+    setForm((f) => ({ ...f, [key]: val.replace(/[^0-9.]/g, '') }));
+    setError('');
+  }, []);
+
+  // ── Load existing thresholds ────────────────────────────────────────────────
+  useEffect(() => {
+    if (!petId) return;
+    setLoading(true);
+    apiClient
+      .get(`/thresholds/${petId}`)
+      .then((res) => {
+        const d = res.data;
+        if (d) {
+          setForm({
+            heart_rate_min: d.heart_rate_min?.toString() ?? '',
+            heart_rate_max: d.heart_rate_max?.toString() ?? '',
+            weight_min: d.weight_min?.toString() ?? '',
+            weight_max: d.weight_max?.toString() ?? '',
+            temperature_min: d.temperature_min?.toString() ?? '',
+            temperature_max: d.temperature_max?.toString() ?? '',
+            activity_min: d.activity_min?.toString() ?? '',
+            activity_max: d.activity_max?.toString() ?? '',
+          });
+        }
+      })
+      .catch(() => setError('Failed to load thresholds.'))
+      .finally(() => setLoading(false));
+  }, [petId]);
+
+  // ── Save ────────────────────────────────────────────────────────────────────
+  const handleSave = async () => {
+    const validationError = validate(form);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setSaving(true);
+    setError('');
+    try {
+      await apiClient.put(`/thresholds/${petId}`, toPayload(form));
+      Alert.alert('Saved', 'Health thresholds updated successfully.');
+    } catch (e: unknown) {
+      const msg =
+        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+        'Failed to save thresholds.';
+      setError(msg);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ── Empty state ─────────────────────────────────────────────────────────────
+  if (!petId) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={styles.emptyTitle}>No pet selected</Text>
+        <Text style={styles.emptyBody}>
+          Select a pet from the pet list to configure health alert thresholds.
+        </Text>
+        {onBack && (
+          <TouchableOpacity style={styles.button} onPress={onBack} accessibilityRole="button">
+            <Text style={styles.buttonText}>Go Back</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+      {/* Header */}
+      <View style={styles.header}>
+        {onBack && (
+          <TouchableOpacity
+            onPress={onBack}
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
+          >
+            <Text style={styles.backBtn}>‹ Back</Text>
+          </TouchableOpacity>
+        )}
+        <Text style={styles.title} accessibilityRole="header">
+          Health Thresholds
+        </Text>
+      </View>
+
+      <Text style={styles.subtitle}>
+        Set alert boundaries for your pet's health metrics. Leave fields empty to disable an alert.
+      </Text>
+
+      {loading ? (
+        <ActivityIndicator size="large" color="#2563eb" style={styles.loader} />
+      ) : (
+        <>
+          <FieldRow
+            label="Heart Rate"
+            unit="bpm"
+            minKey="heart_rate_min"
+            maxKey="heart_rate_max"
+            form={form}
+            onChange={setField}
+          />
+          <FieldRow
+            label="Weight"
+            unit="kg"
+            minKey="weight_min"
+            maxKey="weight_max"
+            form={form}
+            onChange={setField}
+          />
+          <FieldRow
+            label="Temperature"
+            unit="°C"
+            minKey="temperature_min"
+            maxKey="temperature_max"
+            form={form}
+            onChange={setField}
+          />
+          <FieldRow
+            label="Daily Activity"
+            unit="steps"
+            minKey="activity_min"
+            maxKey="activity_max"
+            form={form}
+            onChange={setField}
+          />
+
+          {!!error && (
+            <Text
+              style={styles.error}
+              accessibilityLiveRegion="assertive"
+              accessibilityRole="alert"
+            >
+              {error}
+            </Text>
+          )}
+
+          <TouchableOpacity
+            style={[styles.button, saving && styles.buttonDisabled]}
+            onPress={() => void handleSave()}
+            disabled={saving}
+            accessibilityRole="button"
+            accessibilityLabel="Save health thresholds"
+          >
+            {saving ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.buttonText}>Save Thresholds</Text>
+            )}
+          </TouchableOpacity>
+        </>
+      )}
+    </ScrollView>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: { flexGrow: 1, padding: 20, backgroundColor: '#fff' },
+  emptyContainer: {
+    flex: 1,
+    padding: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  emptyTitle: { fontSize: 20, fontWeight: '700', color: '#1a1a1a', marginBottom: 8 },
+  emptyBody: {
+    fontSize: 15,
+    color: '#6b7280',
+    textAlign: 'center',
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  header: { flexDirection: 'row', alignItems: 'center', marginBottom: 8 },
+  backBtn: { fontSize: 18, color: '#2563eb', fontWeight: '600', marginRight: 12 },
+  title: { fontSize: 22, fontWeight: '700', color: '#1a1a1a' },
+  subtitle: { fontSize: 14, color: '#6b7280', marginBottom: 24, lineHeight: 20 },
+  loader: { marginTop: 40 },
+  fieldGroup: { marginBottom: 20 },
+  fieldLabel: { fontSize: 15, fontWeight: '600', color: '#374151', marginBottom: 8 },
+  fieldRow: { flexDirection: 'row', gap: 12 },
+  fieldHalf: { flex: 1 },
+  subLabel: { fontSize: 12, color: '#9ca3af', marginBottom: 4 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 15,
+    backgroundColor: '#f9fafb',
+  },
+  error: { color: '#dc2626', fontSize: 14, marginBottom: 16 },
+  button: {
+    backgroundColor: '#2563eb',
+    borderRadius: 8,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  buttonDisabled: { backgroundColor: '#93c5fd' },
+  buttonText: { color: '#fff', fontWeight: '600', fontSize: 16 },
+});

--- a/src/screens/TwoFactorSetupScreen.tsx
+++ b/src/screens/TwoFactorSetupScreen.tsx
@@ -1,3 +1,5 @@
+import * as FileSystem from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
 import React, { useState, useCallback } from 'react';
 import {
   View,
@@ -9,6 +11,7 @@ import {
   StyleSheet,
   Alert,
   Image,
+  Share,
   AccessibilityInfo,
 } from 'react-native';
 
@@ -73,9 +76,63 @@ export default function TwoFactorSetupScreen() {
     }
   }, [token]);
 
-  const handleCopyBackupCodes = () => {
-    Alert.alert('Backup Codes', backupCodes.join('\n'), [{ text: 'OK' }]);
-  };
+  const handleCopyAll = useCallback(async () => {
+    try {
+      await Share.share({ message: backupCodes.join('\n') });
+    } catch {
+      Alert.alert('Error', 'Could not share backup codes.');
+    }
+  }, [backupCodes]);
+
+  const handleDownload = useCallback(async () => {
+    try {
+      const content = [
+        'PetChain - 2FA Backup Codes',
+        'Generated: ' + new Date().toISOString(),
+        'Keep these codes safe. Each code can only be used once.',
+        '',
+        ...backupCodes,
+      ].join('\n');
+      const uri = FileSystem.cacheDirectory + 'petchain-backup-codes.txt';
+      await FileSystem.writeAsStringAsync(uri, content, { encoding: FileSystem.EncodingType.UTF8 });
+      if (await Sharing.isAvailableAsync()) {
+        await Sharing.shareAsync(uri, { mimeType: 'text/plain', UTI: 'public.plain-text' });
+      } else {
+        Alert.alert('Saved', 'Backup codes saved to cache. Sharing not available on this device.');
+      }
+    } catch {
+      Alert.alert('Error', 'Could not download backup codes.');
+    }
+  }, [backupCodes]);
+
+  const handleRegenerate = useCallback(() => {
+    Alert.alert(
+      'Regenerate Backup Codes',
+      'This will invalidate all existing backup codes. Continue?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Regenerate',
+          style: 'destructive',
+          onPress: async () => {
+            setLoading(true);
+            try {
+              const res = await apiClient.post('/auth/2fa/backup-codes/regenerate', {});
+              setBackupCodes(res.data.data.backupCodes);
+              announce('New backup codes generated. Save them now.');
+            } catch (e: unknown) {
+              const msg =
+                (e as { response?: { data?: { error?: { message?: string } } } })?.response?.data
+                  ?.error?.message ?? 'Failed to regenerate codes.';
+              Alert.alert('Error', msg);
+            } finally {
+              setLoading(false);
+            }
+          },
+        },
+      ],
+    );
+  }, []);
 
   return (
     <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
@@ -162,24 +219,48 @@ export default function TwoFactorSetupScreen() {
           <Text style={styles.success} accessibilityLiveRegion="assertive">
             ✓ Two-factor authentication is now enabled.
           </Text>
-          <Text style={styles.body}>
-            Save these backup codes in a secure place. Each code can only be used once. If you lose
-            access to your authenticator app, use a backup code to sign in.
-          </Text>
+          <View style={styles.warningBox}>
+            <Text style={styles.warningText}>
+              ⚠️ Save these codes — they won't be shown again. Each code is single-use.
+            </Text>
+          </View>
           <View style={styles.codesContainer} accessibilityLabel="Backup codes">
-            {backupCodes.map((code) => (
-              <Text key={code} style={styles.code} selectable>
-                {code}
-              </Text>
-            ))}
+            <View style={styles.codesGrid}>
+              {backupCodes.map((code) => (
+                <Text key={code} style={styles.code} selectable>
+                  {code}
+                </Text>
+              ))}
+            </View>
           </View>
           <TouchableOpacity
-            style={styles.buttonSecondary}
-            onPress={handleCopyBackupCodes}
+            style={styles.button}
+            onPress={() => void handleCopyAll()}
             accessibilityRole="button"
-            accessibilityLabel="View all backup codes"
+            accessibilityLabel="Copy all backup codes"
           >
-            <Text style={styles.buttonSecondaryText}>View Backup Codes</Text>
+            <Text style={styles.buttonText}>Copy All</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.buttonSecondary}
+            onPress={() => void handleDownload()}
+            accessibilityRole="button"
+            accessibilityLabel="Download backup codes as text file"
+          >
+            <Text style={styles.buttonSecondaryText}>Download as File</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.buttonDanger}
+            onPress={handleRegenerate}
+            disabled={loading}
+            accessibilityRole="button"
+            accessibilityLabel="Regenerate backup codes, invalidates existing codes"
+          >
+            {loading ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.buttonText}>Regenerate Codes</Text>
+            )}
           </TouchableOpacity>
         </View>
       )}
@@ -245,7 +326,30 @@ const styles = StyleSheet.create({
   error: { color: '#dc2626', fontSize: 14, marginBottom: 8 },
   success: { color: '#16a34a', fontSize: 16, fontWeight: '600', marginBottom: 12 },
   codesContainer: { backgroundColor: '#f9fafb', borderRadius: 8, padding: 16, marginBottom: 16 },
-  code: { fontFamily: 'monospace', fontSize: 15, color: '#111827', paddingVertical: 4 },
+  codesGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  code: {
+    fontFamily: 'monospace',
+    fontSize: 15,
+    color: '#111827',
+    paddingVertical: 4,
+    width: '45%',
+  },
   recoveryNote: { marginTop: 32, padding: 12, backgroundColor: '#fef9c3', borderRadius: 8 },
   recoveryText: { fontSize: 13, color: '#713f12' },
+  warningBox: {
+    backgroundColor: '#fef2f2',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: '#fca5a5',
+  },
+  warningText: { fontSize: 14, color: '#dc2626', fontWeight: '600', lineHeight: 20 },
+  buttonDanger: {
+    backgroundColor: '#dc2626',
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginTop: 12,
+  },
 });

--- a/src/screens/WaitlistScreen.tsx
+++ b/src/screens/WaitlistScreen.tsx
@@ -22,6 +22,13 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
 
 import { WaitlistStatus, type WaitlistEntry } from '../../backend/models/WaitlistEntry';
 import {
@@ -32,6 +39,10 @@ import {
   processExpiredNotifications,
   ACCEPTANCE_WINDOW_MS,
 } from '../../backend/services/waitlistService';
+import WebsocketService from '../services/websocketService';
+
+const WS_URL = process.env.EXPO_PUBLIC_WS_URL ?? 'ws://localhost:3001';
+const POLL_INTERVAL_MS = 30_000;
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -107,11 +118,38 @@ function formatDeadlineCountdown(deadline: string): string {
   return `${mins}:${secs.toString().padStart(2, '0')} remaining`;
 }
 
+// ─── Animated position badge ──────────────────────────────────────────────────
+
+const AnimatedPositionBadge: React.FC<{ position: number }> = ({ position }) => {
+  const scale = useSharedValue(1);
+  const prevPosition = useRef(position);
+
+  useEffect(() => {
+    if (prevPosition.current !== position) {
+      prevPosition.current = position;
+      scale.value = withSequence(withSpring(1.35), withTiming(1, { duration: 250 }));
+    }
+  }, [position, scale]);
+
+  const animStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
+
+  if (position === 1) {
+    return (
+      <Animated.View style={[styles.youreNextBadge, animStyle]}>
+        <Text style={styles.youreNextText}>🎉 You're next!</Text>
+      </Animated.View>
+    );
+  }
+
+  return <Animated.Text style={[styles.positionText, animStyle]}>#{position}</Animated.Text>;
+};
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 const WaitlistScreen: React.FC<Props> = ({ userId, onSlotAccepted, onBack }) => {
   const [entries, setEntries] = useState<WaitlistEntry[]>([]);
   const [loading, setLoading] = useState(false);
+  const [isOffline, setIsOffline] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
   const [form, setForm] = useState<JoinForm>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
@@ -119,6 +157,8 @@ const WaitlistScreen: React.FC<Props> = ({ userId, onSlotAccepted, onBack }) => 
 
   // Countdown ticker ref — cleared on unmount
   const tickerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const wsRef = useRef<WebsocketService | null>(null);
 
   // ── Load entries ────────────────────────────────────────────────────────────
 
@@ -136,9 +176,57 @@ const WaitlistScreen: React.FC<Props> = ({ userId, onSlotAccepted, onBack }) => 
     }
   }, [userId]);
 
+  // ── Apply a position update from WS without full reload ────────────────────
+  const applyPositionUpdate = useCallback(
+    (data: { entryId: string; position: number; estimatedWaitMinutes: number }) => {
+      setEntries((prev) =>
+        prev.map((e) =>
+          e.id === data.entryId
+            ? { ...e, position: data.position, estimatedWaitMinutes: data.estimatedWaitMinutes }
+            : e,
+        ),
+      );
+    },
+    [],
+  );
+
+  // ── WebSocket setup + polling fallback ─────────────────────────────────────
   useEffect(() => {
     void load();
-  }, [load]);
+
+    const ws = new WebsocketService(WS_URL);
+    wsRef.current = ws;
+
+    const unsubPosition = ws.on('waitlist:position_update', (data) => {
+      applyPositionUpdate(data);
+    });
+
+    const unsubConnected = ws.on('connected', () => {
+      setIsOffline(false);
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    });
+
+    const unsubDisconnected = ws.on('disconnected', () => {
+      setIsOffline(true);
+      if (!pollRef.current) {
+        pollRef.current = setInterval(() => void load(), POLL_INTERVAL_MS);
+      }
+    });
+
+    ws.connect();
+
+    return () => {
+      unsubPosition();
+      unsubConnected();
+      unsubDisconnected();
+      ws.disconnect();
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId]);
 
   // ── Countdown ticker for NOTIFIED entries ───────────────────────────────────
 
@@ -292,9 +380,8 @@ const WaitlistScreen: React.FC<Props> = ({ userId, onSlotAccepted, onBack }) => 
 
         {item.status === WaitlistStatus.WAITING && (
           <>
-            <Text style={styles.cardLabel}>
-              Position: <Text style={styles.cardValue}>#{item.position}</Text>
-            </Text>
+            <Text style={styles.cardLabel}>Position:</Text>
+            <AnimatedPositionBadge position={item.position} />
             <Text style={styles.cardLabel}>
               Est. wait:{' '}
               <Text style={styles.cardValue}>{formatEta(item.estimatedWaitMinutes)}</Text>
@@ -435,6 +522,11 @@ const WaitlistScreen: React.FC<Props> = ({ userId, onSlotAccepted, onBack }) => 
           </TouchableOpacity>
         )}
         <Text style={styles.headerTitle}>Appointment Waitlist</Text>
+        {isOffline && (
+          <View style={styles.offlineBadge} accessibilityLabel="Offline — polling for updates">
+            <Text style={styles.offlineBadgeText}>● Offline</Text>
+          </View>
+        )}
         <TouchableOpacity
           style={styles.addBtn}
           onPress={() => setModalVisible(true)}
@@ -501,6 +593,15 @@ const styles = StyleSheet.create({
   },
   addBtnText: { color: '#fff', fontWeight: '600' },
 
+  offlineBadge: {
+    backgroundColor: '#F44336',
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    marginRight: 8,
+  },
+  offlineBadgeText: { color: '#fff', fontSize: 11, fontWeight: '700' },
+
   infoBanner: {
     backgroundColor: '#E3F2FD',
     paddingHorizontal: 16,
@@ -539,6 +640,17 @@ const styles = StyleSheet.create({
 
   cardLabel: { fontSize: 13, color: '#555', marginTop: 3 },
   cardValue: { fontWeight: '600', color: '#1a1a1a' },
+
+  positionText: { fontSize: 22, fontWeight: '700', color: '#FF9800', marginVertical: 4 },
+  youreNextBadge: {
+    backgroundColor: '#E8F5E9',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    alignSelf: 'flex-start',
+    marginVertical: 4,
+  },
+  youreNextText: { fontSize: 16, fontWeight: '700', color: '#2E7D32' },
 
   countdownBox: {
     marginTop: 10,

--- a/src/services/websocketService.ts
+++ b/src/services/websocketService.ts
@@ -1,6 +1,7 @@
 import CryptoJS from 'crypto-js';
 
 type Message = { type: string; data?: any };
+type Listener = (data: any) => void;
 
 function encryptPayload(obj: any) {
   const key = process.env.WS_PAYLOAD_KEY || process.env.JWT_SECRET || 'default-ws-key';
@@ -28,9 +29,17 @@ export class WebsocketService {
   private lastPong = Date.now();
   private sendTimestamps: number[] = [];
   private maxMessagesPerSecond = 5;
+  private listeners = new Map<string, Set<Listener>>();
 
   constructor(url: string) {
     this.url = url;
+  }
+
+  /** Subscribe to a message type. Returns an unsubscribe function. */
+  on(type: string, listener: Listener): () => void {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type)!.add(listener);
+    return () => this.listeners.get(type)?.delete(listener);
   }
 
   connect(token?: string) {
@@ -49,6 +58,7 @@ export class WebsocketService {
     this.ws.onopen = () => {
       this.backoffMs = 500;
       this.startHeartbeat();
+      this._emit('connected', null);
     };
 
     this.ws.onmessage = (ev) => {
@@ -59,8 +69,7 @@ export class WebsocketService {
           this.lastPong = Date.now();
           return;
         }
-        // emit or handle messages (placeholder: console)
-        console.warn('WS message', msg);
+        this._emit(msg.type, msg.data);
       } catch (e) {
         console.warn('WS invalid message', e);
       }
@@ -68,6 +77,7 @@ export class WebsocketService {
 
     this.ws.onclose = () => {
       this.stopHeartbeat();
+      this._emit('disconnected', null);
       if (this.shouldReconnect) this.scheduleReconnect();
     };
 
@@ -75,6 +85,10 @@ export class WebsocketService {
       console.warn('WS error', err);
       // close will trigger reconnect
     };
+  }
+
+  private _emit(type: string, data: any) {
+    this.listeners.get(type)?.forEach((fn) => fn(data));
   }
 
   private scheduleReconnect() {


### PR DESCRIPTION
Closes #553 

Closes #535 

Closes #528 

Closes #527 


- #553: Add Copy All (Share), Download as File (expo-file-system/sharing), Regenerate Codes button, and warning banner to TwoFactorSetupScreen
- #535: Extend WebsocketService with on() event subscriptions; subscribe to waitlist:position_update in WaitlistScreen with polling fallback (30s), offline badge, and reanimated position animation
- #528: Implement HealthThresholdsScreen with per-pet threshold form, validation, GET/PUT API calls, empty state, and accessible error announcements
- #527: Add resolveFederationAddress and resolveFederationAddressWithCacheControl to federationService with 15-min positive / 2-min negative TTL caching via cacheService; update tests to assert cache hit/miss behavior