### PR TITLE
[600] Create integration tests for the Stellar migration checkpoint reconciliation

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -297,6 +297,16 @@ When adding new features:
 - Add tests for uncovered branches
 - Use coverage report to identify gaps
 
+## Stellar Migration Integration Tests
+
+PostgreSQL-backed checkpoint reconciliation tests live in `backend/tests/integration/`. Run them separately:
+
+```bash
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres npm run test:integration
+```
+
+These tests set `RUN_INTEGRATION_TESTS=true` via `jest.integration.config.js` and are not part of the default `npm test` CI job.
+
 ## Resources
 
 - [Jest Documentation](https://jestjs.io/)

--- a/backend/tests/integration/__tests__/stellarMigrationReconciliation.integration.test.ts
+++ b/backend/tests/integration/__tests__/stellarMigrationReconciliation.integration.test.ts
@@ -1,0 +1,158 @@
+import * as StellarSdk from '@stellar/stellar-sdk';
+
+import { StellarMigrationService } from '../../../services/stellarMigrationService';
+import {
+  MAINNET_TX_ID,
+  VALID_HASH,
+  VALID_TX_ID,
+  cleanupRun,
+  ensureCheckpointTable,
+  getCheckpoint,
+  insertCheckpoint,
+  shouldRunIntegrationTests,
+  shutdownDatabase,
+} from '../helpers/migrationDb';
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Horizon: {
+    Server: jest.fn(),
+  },
+  Networks: {
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+    TESTNET: 'Test SDF Network ; September 2015',
+  },
+}));
+
+const mockTransactionCall = jest.fn();
+const mockOperationsCall = jest.fn();
+const mockHorizonServer = {
+  transactions: jest.fn(() => ({
+    transaction: jest.fn(() => ({ call: mockTransactionCall })),
+  })),
+  operations: jest.fn(() => ({
+    forTransaction: jest.fn(() => ({ call: mockOperationsCall })),
+  })),
+};
+
+const mockAnchorRecord = jest.fn();
+const mockHashPayload = jest.fn((payload: unknown) =>
+  typeof payload === 'string' ? payload : VALID_HASH,
+);
+
+const mockAnchorService = {
+  anchorRecord: mockAnchorRecord,
+  hashPayload: mockHashPayload,
+};
+
+const describeIntegration = shouldRunIntegrationTests() ? describe : describe.skip;
+
+function mockSuccessfulHorizon(hash = VALID_HASH) {
+  mockTransactionCall.mockResolvedValue({ successful: true });
+  mockOperationsCall.mockResolvedValue({
+    records: [
+      {
+        type: 'manage_data',
+        name: 'record:rec-integration-1',
+        value: Buffer.from(hash).toString('base64'),
+      },
+    ],
+  });
+}
+
+describeIntegration('Stellar migration checkpoint reconciliation integration', () => {
+  const runId = `integration-run-${Date.now()}`;
+  const userId = 'integration-user';
+  const recordId = 'rec-integration-1';
+
+  beforeAll(async () => {
+    (StellarSdk.Horizon.Server as jest.Mock).mockImplementation(() => mockHorizonServer);
+    await ensureCheckpointTable();
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.spyOn(StellarMigrationService.prototype, 'enumerateTestnetRecords').mockResolvedValue([]);
+    await cleanupRun(runId);
+  });
+
+  afterAll(async () => {
+    await cleanupRun(runId);
+    await shutdownDatabase();
+  });
+
+  it('persists a verified checkpoint when Stellar submission succeeds', async () => {
+    await insertCheckpoint({ runId, recordId, userId, status: 'pending' });
+    mockSuccessfulHorizon();
+    mockAnchorRecord.mockResolvedValueOnce({
+      recordId,
+      recordHash: VALID_HASH,
+      transactionId: MAINNET_TX_ID,
+      status: 'submitted',
+    });
+
+    const svc = new StellarMigrationService(mockAnchorService as never);
+    const result = await svc.migrateUser(userId, runId);
+
+    expect(result.migrated).toBe(1);
+    const checkpoint = await getCheckpoint(recordId, runId);
+    expect(checkpoint?.status).toBe('verified');
+    expect(checkpoint?.mainnet_tx_id).toBe(MAINNET_TX_ID);
+  });
+
+  it('rolls back checkpoint progress when Stellar submission fails', async () => {
+    await insertCheckpoint({ runId, recordId, userId, status: 'pending' });
+    mockSuccessfulHorizon();
+    mockAnchorRecord.mockRejectedValueOnce(new Error('Horizon submission failed'));
+
+    const svc = new StellarMigrationService(mockAnchorService as never);
+    const result = await svc.migrateUser(userId, runId);
+
+    expect(result.failed).toBe(1);
+    const checkpoint = await getCheckpoint(recordId, runId);
+    expect(checkpoint?.status).toBe('failed');
+    expect(checkpoint?.mainnet_tx_id).toBeNull();
+    expect(checkpoint?.error_message).toContain('Horizon submission failed');
+  });
+
+  it('detects diverged on-chain state during reconcile', async () => {
+    await insertCheckpoint({
+      runId,
+      recordId,
+      userId,
+      status: 'verified',
+      mainnetTxId: MAINNET_TX_ID,
+    });
+
+    mockSuccessfulHorizon('d'.repeat(64));
+
+    const svc = new StellarMigrationService(mockAnchorService as never);
+    const discrepancies = await svc.reconcile(runId);
+
+    expect(discrepancies).toHaveLength(1);
+    expect(discrepancies[0].reason).toBe('hash_mismatch');
+  });
+
+  it('reports no discrepancies after manual correction', async () => {
+    await insertCheckpoint({
+      runId,
+      recordId,
+      userId,
+      status: 'verified',
+      mainnetTxId: MAINNET_TX_ID,
+      testnetHash: VALID_HASH,
+    });
+
+    mockSuccessfulHorizon(VALID_HASH);
+
+    const svc = new StellarMigrationService(mockAnchorService as never);
+    const discrepancies = await svc.reconcile(runId);
+
+    expect(discrepancies).toEqual([]);
+  });
+});
+
+if (!shouldRunIntegrationTests()) {
+  it('skips integration suite unless RUN_INTEGRATION_TESTS=true and DATABASE_URL are set', () => {
+    expect(true).toBe(true);
+  });
+}

--- a/backend/tests/integration/helpers/migrationDb.ts
+++ b/backend/tests/integration/helpers/migrationDb.ts
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import path from 'path';
+
+import { closePool, query } from '../../../src/db';
+
+export const VALID_HASH = 'a'.repeat(64);
+export const VALID_TX_ID = 'b'.repeat(64);
+export const MAINNET_TX_ID = 'c'.repeat(64);
+
+export function shouldRunIntegrationTests(): boolean {
+  return process.env.RUN_INTEGRATION_TESTS === 'true' && Boolean(process.env.DATABASE_URL);
+}
+
+export async function ensureCheckpointTable(): Promise<void> {
+  const migrationPath = path.join(
+    __dirname,
+    '../../../migrations/009_stellar_migration_checkpoints.sql',
+  );
+  const sql = fs.readFileSync(migrationPath, 'utf8');
+  await query(sql);
+}
+
+export async function cleanupRun(runId: string): Promise<void> {
+  await query('DELETE FROM stellar_migration_checkpoints WHERE migration_run_id = $1', [runId]);
+}
+
+export async function insertCheckpoint(input: {
+  runId: string;
+  recordId: string;
+  userId: string;
+  status?: string;
+  mainnetTxId?: string;
+  testnetHash?: string;
+  testnetTxId?: string;
+}): Promise<string> {
+  const result = await query(
+    `INSERT INTO stellar_migration_checkpoints
+      (migration_run_id, record_id, user_id, testnet_tx_id, testnet_record_hash, status, mainnet_tx_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING id`,
+    [
+      input.runId,
+      input.recordId,
+      input.userId,
+      input.testnetTxId ?? VALID_TX_ID,
+      input.testnetHash ?? VALID_HASH,
+      input.status ?? 'pending',
+      input.mainnetTxId ?? null,
+    ],
+  );
+
+  return String(result.rows[0].id);
+}
+
+export async function getCheckpoint(recordId: string, runId: string) {
+  const result = await query(
+    `SELECT status, mainnet_tx_id, error_message
+     FROM stellar_migration_checkpoints
+     WHERE migration_run_id = $1 AND record_id = $2`,
+    [runId, recordId],
+  );
+  return result.rows[0] as
+    | { status: string; mainnet_tx_id: string | null; error_message: string | null }
+    | undefined;
+}
+
+export async function shutdownDatabase(): Promise<void> {
+  await closePool();
+}

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const baseConfig = require('./jest.config.js');
+
+module.exports = {
+  ...baseConfig,
+  testMatch: ['**/tests/integration/__tests__/**/*.integration.test.ts'],
+  moduleNameMapper: Object.fromEntries(
+    Object.entries(baseConfig.moduleNameMapper).filter(([key]) => key !== '^pg$'),
+  ),
+  setupFilesAfterEnv: ['<rootDir>/jest.integration.setup.js'],
+  testTimeout: 30000,
+};

--- a/jest.integration.setup.js
+++ b/jest.integration.setup.js
@@ -1,0 +1,8 @@
+/* eslint-env jest */
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-key';
+process.env.STELLAR_NETWORK = 'testnet';
+process.env.RUN_INTEGRATION_TESTS = 'true';
+
+// eslint-disable-next-line no-undef -- Jest global provided by test runner
+jest.useRealTimers();

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eas:build:prod": "eas build --platform all --profile production",
     "test": "jest --runInBand",
     "test:ci": "jest --runInBand --ci --coverage",
+    "test:integration": "jest --runInBand --config jest.integration.config.js",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/scripts/validate-migrations.ts
+++ b/scripts/validate-migrations.ts
@@ -3,14 +3,15 @@ import path from 'path';
 import { runner } from 'node-pg-migrate';
 import { Client } from 'pg';
 
-async function waitForPostgres(client: Client, retries = 10) {
+async function waitForPostgres(connectionString: string, retries = 10) {
   for (let i = 0; i < retries; i++) {
+    const client = new Client({ connectionString });
     try {
       await client.connect();
       await client.query('SELECT 1');
       await client.end();
       return;
-    } catch (err) {
+    } catch {
       await new Promise((r) => setTimeout(r, 1000));
     }
   }
@@ -23,7 +24,7 @@ async function main() {
   const baseClient = new Client({ connectionString: DATABASE_URL });
 
   console.log('[validate] Waiting for Postgres...');
-  await waitForPostgres(baseClient, 30);
+  await waitForPostgres(DATABASE_URL, 30);
 
   const testDbName = `petchain_migration_check_${Date.now()}`;
   console.log(`[validate] Creating temporary DB ${testDbName}`);


### PR DESCRIPTION
## Summary
- Added PostgreSQL integration tests for checkpoint success, rollback, reconcile divergence, and post-correction consistency
- Introduced jest.integration.config.js and npm run test:integration gated by RUN_INTEGRATION_TESTS
- Added migration DB helpers under backend/tests/integration/

Closes #600

## Test plan
- [x] npm run test:integration skips without DATABASE_URL
- [ ] Run with CI Postgres service and DATABASE_URL for full integration pass

Made with [Cursor](https://cursor.com)