### PR TITLE
feat: standardize pull-to-refresh across main list screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -145,22 +145,23 @@ function App() {
     <ThemeProvider>
       <ToastProvider>
         <PetProvider>
-        <ErrorBoundary>
-          <ThemeTransitionView>
-            <View style={styles.root}>
-              <OfflineIndicator />
-              <AppNavigator />
-              <UpdatePrompt
-                visible={updateStatus.visible}
-                variant={updateStatus.visible ? updateStatus.variant : 'optional'}
-                storeUrl={updateStatus.visible ? updateStatus.storeUrl : undefined}
-                onUpdate={handleUpdate}
-                onDismiss={handleDismiss}
-              />
-            </View>
-          </ThemeTransitionView>
-        </ErrorBoundary>
-      </PetProvider>
+          <ErrorBoundary>
+            <ThemeTransitionView>
+              <View style={styles.root}>
+                <OfflineIndicator />
+                <AppNavigator />
+                <UpdatePrompt
+                  visible={updateStatus.visible}
+                  variant={updateStatus.visible ? updateStatus.variant : 'optional'}
+                  storeUrl={updateStatus.visible ? updateStatus.storeUrl : undefined}
+                  onUpdate={handleUpdate}
+                  onDismiss={handleDismiss}
+                />
+              </View>
+            </ThemeTransitionView>
+          </ErrorBoundary>
+        </PetProvider>
+      </ToastProvider>
     </ThemeProvider>
   );
 }

--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,7 @@ import ThemeTransitionView from './src/components/ThemeTransitionView';
 import UpdatePrompt from './src/components/UpdatePrompt';
 import { PetProvider } from './src/context/PetContext';
 import { ThemeProvider } from './src/context/ThemeContext';
+import { ToastProvider } from './src/context/ToastContext';
 import i18n, { isRTL } from './src/i18n';
 import AppNavigator, { handleNotificationDeepLink } from './src/navigation/AppNavigator';
 import LockScreen from './src/screens/LockScreen';
@@ -142,7 +143,8 @@ function App() {
 
   return (
     <ThemeProvider>
-      <PetProvider>
+      <ToastProvider>
+        <PetProvider>
         <ErrorBoundary>
           <ThemeTransitionView>
             <View style={styles.root}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16532,32 +16532,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/expo/node_modules/react-native-worklets": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.8.3.tgz",
-      "integrity": "sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.28.4",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/preset-typescript": "^7.27.1",
-        "convert-source-map": "^2.0.0",
-        "semver": "^7.7.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "*",
-        "@react-native/metro-config": "*",
-        "react": "*",
-        "react-native": "0.81 - 0.85"
-      }
-    },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -1,0 +1,138 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from 'react';
+import { Animated, StyleSheet, Text } from 'react-native';
+
+import { useTheme } from './ThemeContext';
+
+export type ToastVariant = 'info' | 'error' | 'success';
+
+interface ToastOptions {
+  variant?: ToastVariant;
+  durationMs?: number;
+}
+
+interface ToastState {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastContextValue {
+  show: (message: string, options?: ToastOptions) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+const DEFAULT_DURATION_MS = 3000;
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [toast, setToast] = useState<ToastState | null>(null);
+  const opacity = useRef(new Animated.Value(0)).current;
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const idRef = useRef(0);
+
+  const hide = useCallback(() => {
+    Animated.timing(opacity, {
+      toValue: 0,
+      duration: 200,
+      useNativeDriver: true,
+    }).start(() => setToast(null));
+  }, [opacity]);
+
+  const show = useCallback(
+    (message: string, options?: ToastOptions) => {
+      const id = ++idRef.current;
+      const variant = options?.variant ?? 'info';
+      const durationMs = options?.durationMs ?? DEFAULT_DURATION_MS;
+
+      if (hideTimer.current) {
+        clearTimeout(hideTimer.current);
+      }
+
+      setToast({ id, message, variant });
+      opacity.setValue(0);
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 200,
+        useNativeDriver: true,
+      }).start();
+
+      hideTimer.current = setTimeout(() => {
+        // Guard against a newer toast having replaced this one
+        if (idRef.current === id) {
+          hide();
+        }
+      }, durationMs);
+    },
+    [hide, opacity],
+  );
+
+  return (
+    <ToastContext.Provider value={{ show }}>
+      {children}
+      <ToastHost toast={toast} opacity={opacity} />
+    </ToastContext.Provider>
+  );
+};
+
+const ToastHost: React.FC<{
+  toast: ToastState | null;
+  opacity: Animated.Value;
+}> = ({ toast, opacity }) => {
+  const { colors } = useTheme();
+
+  if (!toast) return null;
+
+  const backgroundColor =
+    toast.variant === 'error'
+      ? colors.error
+      : toast.variant === 'success'
+        ? colors.success
+        : colors.text;
+
+  return (
+    <Animated.View
+      style={[styles.container, { opacity, backgroundColor }]}
+      pointerEvents="none"
+      accessibilityLiveRegion="polite"
+      testID="toast-host"
+    >
+      <Text style={[styles.text, { color: colors.white }]}>{toast.message}</Text>
+    </Animated.View>
+  );
+};
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return ctx;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    bottom: 32,
+    borderRadius: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 6,
+    elevation: 4,
+    zIndex: 1000,
+  },
+  text: {
+    fontSize: 14,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+});

--- a/src/screens/AppointmentScreen.tsx
+++ b/src/screens/AppointmentScreen.tsx
@@ -4,6 +4,7 @@ import {
   ActivityIndicator,
   FlatList,
   Modal,
+  RefreshControl,
   ScrollView,
   StyleSheet,
   Text,
@@ -15,6 +16,8 @@ import {
 import { v4 as uuid } from 'uuid';
 
 import { SkeletonCard } from '../components/SkeletonCard';
+import { useTheme } from '../context/ThemeContext';
+import { useToast } from '../context/ToastContext';
 import { useMinimumLoadingTime } from '../hooks/useMinimumLoadingTime';
 import type { Medication } from '../models/Medication';
 import type { MainTabParamList } from '../navigation/types';
@@ -60,6 +63,9 @@ const EMPTY_FORM = {
 const AppointmentScreen: React.FC = () => {
   useSecureScreen();
 
+  const { colors } = useTheme();
+  const { show: showToast } = useToast();
+
   const route = useRoute<{
     key: string;
     name: string;
@@ -73,6 +79,7 @@ const AppointmentScreen: React.FC = () => {
   const [appointments, setAppointments] = useState<Appointment[]>([]);
   const [medications, setMedications] = useState<Medication[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const [bookingVisible, setBookingVisible] = useState(false);
   const [detailAppt, setDetailAppt] = useState<Appointment | null>(null);
   const [rescheduleVisible, setRescheduleVisible] = useState(false);
@@ -90,16 +97,30 @@ const AppointmentScreen: React.FC = () => {
   // Enforce minimum 300ms display for skeleton
   const displayLoading = useMinimumLoadingTime(isLoading, { minLoadingTime: 300 });
 
+  const hasData = appointments.length > 0;
+
   const load = useCallback(async () => {
     setIsLoading(true);
     try {
       const [appts, meds] = await Promise.all([getAppointments(), getMedications()]);
       setAppointments(appts);
       setMedications(meds);
+    } catch (err) {
+      // Only surface a toast if we already have cached data on screen — an
+      // initial-load failure with no data falls through to the empty state.
+      if (hasData) {
+        showToast("Couldn't refresh — showing cached data", { variant: 'error' });
+      }
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [hasData, showToast]);
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    await load();
+    setIsRefreshing(false);
+  }, [load]);
 
   // Pre-fill booking form when navigated from VetMapScreen
   useEffect(() => {
@@ -126,7 +147,8 @@ const AppointmentScreen: React.FC = () => {
 
   useEffect(() => {
     void load();
-  }, [load]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const displayed = tab === 'upcoming' ? getUpcoming(appointments) : getPast(appointments);
 
@@ -401,6 +423,14 @@ const AppointmentScreen: React.FC = () => {
             <Text style={styles.emptyText}>
               {tab === 'upcoming' ? 'No upcoming appointments.' : 'No past appointments.'}
             </Text>
+          }
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefreshing}
+              onRefresh={() => void handleRefresh()}
+              colors={[colors.primary]}
+              tintColor={colors.primary}
+            />
           }
           removeClippedSubviews
           maxToRenderPerBatch={10}

--- a/src/screens/ForumScreen.tsx
+++ b/src/screens/ForumScreen.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   FlatList,
   Modal,
+  RefreshControl,
   ScrollView,
   StyleSheet,
   Text,
@@ -11,6 +12,8 @@ import {
   View,
 } from 'react-native';
 
+import { useTheme } from '../context/ThemeContext';
+import { useToast } from '../context/ToastContext';
 import apiClient from '../services/apiClient';
 
 type Post = {
@@ -31,8 +34,12 @@ type Answer = {
 };
 
 export default function ForumScreen() {
+  const { colors } = useTheme();
+  const { show: showToast } = useToast();
+
   const [posts, setPosts] = React.useState<Post[]>([]);
   const [loading, setLoading] = React.useState(false);
+  const [isRefreshing, setIsRefreshing] = React.useState(false);
   const [title, setTitle] = React.useState('');
   const [body, setBody] = React.useState('');
   const [species, setSpecies] = React.useState('');
@@ -48,7 +55,8 @@ export default function ForumScreen() {
     void loadPosts();
   }, []);
 
-  async function loadPosts(queryString = '') {
+  async function loadPosts(queryString = '', isRefresh = false) {
+    const hadData = posts.length > 0;
     setLoading(true);
     try {
       const res = await apiClient.get('/api/forum/posts', {
@@ -56,10 +64,24 @@ export default function ForumScreen() {
       });
       setPosts(res.data.posts ?? []);
     } catch (e) {
-      // ignore for now
+      // Pull-to-refresh (or any fetch) on an already-populated list: keep
+      // the existing posts on screen and surface a toast instead of failing
+      // silently.
+      if (isRefresh && hadData) {
+        showToast("Couldn't refresh — showing cached data", { variant: 'error' });
+      }
+      // Initial load / search failure with no data: fall through to the
+      // empty state. (Pre-existing behavior — this screen had no error UI
+      // for that case before, and adding one is out of scope for #639.)
     } finally {
       setLoading(false);
     }
+  }
+
+  async function handleRefresh() {
+    setIsRefreshing(true);
+    await loadPosts(search, true);
+    setIsRefreshing(false);
   }
 
   async function handleCreate() {
@@ -188,11 +210,17 @@ export default function ForumScreen() {
       <FlatList
         data={posts}
         keyExtractor={(item) => String(item.id)}
-        refreshing={loading}
-        onRefresh={() => void loadPosts(search)}
         renderItem={renderPost}
         contentContainerStyle={styles.listContent}
         ListEmptyComponent={<Text style={styles.emptyText}>No questions yet.</Text>}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={() => void handleRefresh()}
+            colors={[colors.primary]}
+            tintColor={colors.primary}
+          />
+        }
       />
 
       <Modal visible={modalVisible} animationType="slide">

--- a/src/screens/MedicationScreen.tsx
+++ b/src/screens/MedicationScreen.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   FlatList,
   Modal,
+  RefreshControl,
   ScrollView,
   StyleSheet,
   Text,
@@ -12,6 +13,8 @@ import {
 } from 'react-native';
 
 import { SkeletonCard } from '../components/SkeletonCard';
+import { useTheme } from '../context/ThemeContext';
+import { useToast } from '../context/ToastContext';
 import { useMinimumLoadingTime } from '../hooks/useMinimumLoadingTime';
 import {
   checkDrugInteractions,
@@ -75,10 +78,14 @@ function weekDates(): Date[] {
 const MedicationScreen: React.FC = () => {
   useSecureScreen();
 
+  const { colors } = useTheme();
+  const { show: showToast } = useToast();
+
   const [tab, setTab] = useState<Tab>('list');
   const [medications, setMedications] = useState<Medication[]>([]);
   const [doseLogs, setDoseLogs] = useState<DoseLog[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
   const [editingMed, setEditingMed] = useState<Medication | null>(null);
   const [form, setForm] = useState<Omit<Medication, 'id'>>(EMPTY_FORM);
@@ -95,19 +102,34 @@ const MedicationScreen: React.FC = () => {
   // Enforce minimum 300ms display for skeleton
   const displayLoading = useMinimumLoadingTime(isLoading, { minLoadingTime: 300 });
 
+  const hasData = medications.length > 0 || doseLogs.length > 0;
+
   const loadData = useCallback(async () => {
     setIsLoading(true);
     try {
       const [meds, logs] = await Promise.all([getMedications(), getDoseLogs()]);
       setMedications(meds);
       setDoseLogs(logs);
+    } catch (err) {
+      // Only surface a toast if we already have cached data on screen — an
+      // initial-load failure with no data falls through to the empty state.
+      if (hasData) {
+        showToast("Couldn't refresh — showing cached data", { variant: 'error' });
+      }
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [hasData, showToast]);
 
   useEffect(() => {
     void loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    await loadData();
+    setIsRefreshing(false);
   }, [loadData]);
 
   const openAdd = () => {
@@ -763,6 +785,14 @@ const MedicationScreen: React.FC = () => {
           renderItem={renderMedItem}
           contentContainerStyle={styles.listContent}
           ListEmptyComponent={<Text style={styles.emptyText}>No medications added yet.</Text>}
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefreshing}
+              onRefresh={() => void handleRefresh()}
+              colors={[colors.primary]}
+              tintColor={colors.primary}
+            />
+          }
           removeClippedSubviews
           maxToRenderPerBatch={10}
           windowSize={5}

--- a/src/screens/NotificationCenterScreen.tsx
+++ b/src/screens/NotificationCenterScreen.tsx
@@ -25,6 +25,8 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import NotificationItem, { resolveNavPayload } from '../components/NotificationItem';
 import { SkeletonCard } from '../components/SkeletonCard';
+import { useTheme } from '../context/ThemeContext';
+import { useToast } from '../context/ToastContext';
 import { useMinimumLoadingTime } from '../hooks/useMinimumLoadingTime';
 import {
   deleteAll,
@@ -62,6 +64,7 @@ type Action =
   | { type: 'LOAD_SUCCESS'; notifications: AppNotification[]; unreadCount: number }
   | { type: 'LOAD_ERROR'; error: string }
   | { type: 'REFRESH_START' }
+  | { type: 'REFRESH_ERROR_KEEP_DATA' }
   | { type: 'SET_FILTER'; filter: Filter }
   | { type: 'TOGGLE_SELECT'; id: string }
   | { type: 'CLEAR_SELECTION' }
@@ -87,6 +90,12 @@ function reducer(state: State, action: Action): State {
       };
     case 'LOAD_ERROR':
       return { ...state, loading: false, refreshing: false, error: action.error };
+    case 'REFRESH_ERROR_KEEP_DATA':
+      // A refresh (or any fetch) failed, but we already had data on screen.
+      // Clear the loading/refreshing flags without touching `notifications`
+      // or setting `error`, so the existing list stays visible — the toast
+      // is the only signal to the user that this fetch failed.
+      return { ...state, loading: false, refreshing: false, error: null };
     case 'SET_FILTER':
       return { ...state, filter: action.filter, selected: new Set(), loading: true };
     case 'TOGGLE_SELECT': {
@@ -155,6 +164,8 @@ export default function NotificationCenterScreen() {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
   const navigation = useNavigation<{ navigate: (screen: string, params?: unknown) => void }>();
   const isMounted = useRef(true);
+  const { colors } = useTheme();
+  const { show: showToast } = useToast();
 
   const [groupByPet, setGroupByPet] = useState(false);
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
@@ -242,6 +253,7 @@ export default function NotificationCenterScreen() {
 
   const load = useCallback(
     async (isRefresh = false) => {
+      const hadData = state.notifications.length > 0;
       dispatch({ type: isRefresh ? 'REFRESH_START' : 'LOAD_START' });
       try {
         const [notifications, unreadCount] = await Promise.all([
@@ -252,7 +264,13 @@ export default function NotificationCenterScreen() {
           dispatch({ type: 'LOAD_SUCCESS', notifications, unreadCount });
         }
       } catch (err) {
-        if (isMounted.current) {
+        if (!isMounted.current) return;
+
+        if (hadData) {
+          // Keep the existing list on screen; surface the failure as a toast.
+          showToast("Couldn't refresh — showing cached data", { variant: 'error' });
+          dispatch({ type: 'REFRESH_ERROR_KEEP_DATA' });
+        } else {
           dispatch({
             type: 'LOAD_ERROR',
             error: err instanceof Error ? err.message : 'Failed to load notifications',
@@ -260,12 +278,13 @@ export default function NotificationCenterScreen() {
         }
       }
     },
-    [state.filter],
+    [state.filter, state.notifications.length, showToast],
   );
 
   useEffect(() => {
     void load();
-  }, [load]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.filter]);
 
   // ── Actions ─────────────────────────────────────────────────────────────────
 
@@ -396,6 +415,7 @@ export default function NotificationCenterScreen() {
 
   const hasSelection = state.selected.size > 0;
   const hasUnread = state.notifications.some((n) => !n.isRead);
+  const showFullErrorState = state.error !== null && state.notifications.length === 0;
 
   // ── Render ──────────────────────────────────────────────────────────────────
 
@@ -435,7 +455,7 @@ export default function NotificationCenterScreen() {
           <Switch 
             value={groupByPet} 
             onValueChange={handleToggleGroup}
-            trackColor={{ false: '#D1D5DB', true: '#4CAF50' }}
+            trackColor={{ false: '#D1D5DB', true: colors.primary }}
           />
         </View>
       </View>
@@ -498,7 +518,7 @@ export default function NotificationCenterScreen() {
             <SkeletonCard key={`skeleton-${index}`} />
           ))}
         </View>
-      ) : state.error ? (
+      ) : showFullErrorState ? (
         <View style={styles.centered} testID="error-state">
           <Text style={styles.errorText}>{state.error}</Text>
           <TouchableOpacity onPress={() => load()} style={styles.retryBtn}>
@@ -514,7 +534,8 @@ export default function NotificationCenterScreen() {
             <RefreshControl
               refreshing={state.refreshing}
               onRefresh={() => load(true)}
-              tintColor="#4CAF50"
+              colors={[colors.primary]}
+              tintColor={colors.primary}
             />
           }
           ListEmptyComponent={

--- a/src/screens/PetListScreen.tsx
+++ b/src/screens/PetListScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { FlatList, RefreshControl, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { HeaderOfflineStatus, useOfflineStatus } from '../components/OfflineIndicator';
 import { OptimizedImage } from '../components/OptimizedImage';
@@ -10,6 +10,8 @@ import { RetryError } from '../components/RetryError';
 import { SkeletonCard } from '../components/SkeletonCard';
 import SOSButton from '../components/SOSButton';
 import { usePetContext } from '../context/PetContext';
+import { useTheme } from '../context/ThemeContext';
+import { useToast } from '../context/ToastContext';
 import { useMinimumLoadingTime } from '../hooks/useMinimumLoadingTime';
 import petService, { type Pet } from '../services/petService';
 import subscriptionService, { type SubscriptionStatus } from '../services/subscriptionService';
@@ -25,12 +27,15 @@ const PetListScreen: React.FC<Props> = ({ onSelectPet, onAddPet, onAdoptPet }) =
   const [pets, setPets] = useState<Pet[]>([]);
   const offlineStatus = useOfflineStatus();
   const { refreshPets } = usePetContext();
+  const { colors } = useTheme();
+  const { show: showToast } = useToast();
   const [subscriptionStatus, setSubscriptionStatus] = useState<SubscriptionStatus>({
     isPremium: false,
     plan: 'free',
     expiresAt: null,
   });
   const [showPaywall, setShowPaywall] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   const loadPets = useCallback(async () => {
     const data = await petService.getAllPets();
@@ -58,6 +63,22 @@ const PetListScreen: React.FC<Props> = ({ onSelectPet, onAddPet, onAdoptPet }) =
         /* keep free default */
       });
   }, []);
+
+  const hasData = pets.length > 0;
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    const result = await execute();
+    void refreshPets();
+
+    // If the refresh failed but we already had data on screen, don't let
+    // the inline RetryError replace the list — surface a toast instead and
+    // keep showing the cached pets.
+    if (result === undefined && hasData) {
+      showToast("Couldn't refresh — showing cached data", { variant: 'error' });
+    }
+    setIsRefreshing(false);
+  }, [execute, refreshPets, hasData, showToast]);
 
   const handleAddPet = useCallback(() => {
     const atLimit =
@@ -160,7 +181,7 @@ const PetListScreen: React.FC<Props> = ({ onSelectPet, onAddPet, onAdoptPet }) =
       {/* Aggregate view — Issue #151/#82 */}
       <PetAggregateView onSelectPet={onSelectPet} />
 
-      {retryState.error ? (
+      {retryState.error && !hasData ? (
         <RetryError
           error={retryState.error}
           onRetry={() => {
@@ -188,11 +209,14 @@ const PetListScreen: React.FC<Props> = ({ onSelectPet, onAddPet, onAdoptPet }) =
               No pets yet. Add one!
             </Text>
           }
-          onRefresh={() => {
-            void execute();
-            void refreshPets();
-          }}
-          refreshing={retryState.loading}
+          refreshControl={
+            <RefreshControl
+              refreshing={isRefreshing}
+              onRefresh={handleRefresh}
+              colors={[colors.primary]}
+              tintColor={colors.primary}
+            />
+          }
           removeClippedSubviews
           maxToRenderPerBatch={10}
           windowSize={5}

--- a/src/screens/VetDirectoryScreen.tsx
+++ b/src/screens/VetDirectoryScreen.tsx
@@ -7,6 +7,7 @@ import {
   Modal,
   PanResponder,
   Platform,
+  RefreshControl,
   ScrollView,
   StyleSheet,
   Text,
@@ -16,6 +17,8 @@ import {
 } from 'react-native';
 
 import { SkeletonCard } from '../components/SkeletonCard';
+import { useTheme } from '../context/ThemeContext';
+import { useToast } from '../context/ToastContext';
 import { useMinimumLoadingTime } from '../hooks/useMinimumLoadingTime';
 import mapService from '../services/mapService';
 import {
@@ -139,10 +142,14 @@ const sliderStyles = StyleSheet.create({
 // ─── Component ────────────────────────────────────────────────────────────────
 
 const VetDirectoryScreen: React.FC = () => {
+  const { colors } = useTheme();
+  const { show: showToast } = useToast();
+
   const [screen, setScreen] = useState<Screen>('directory');
   const [vets, setVets] = useState<VetProfile[]>([]);
   const [selectedVet, setSelectedVet] = useState<VetProfile | null>(null);
   const [loading, setLoading] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   const displayLoading = useMinimumLoadingTime(loading, { minLoadingTime: 300 });
 
@@ -201,7 +208,9 @@ const VetDirectoryScreen: React.FC = () => {
       r: number,
       specialties: string[],
       availOnly: boolean,
+      isRefresh = false,
     ) => {
+      const hadData = vets.length > 0;
       setLoading(true);
       try {
         const specialtyParam = specialties.length === 1 ? specialties[0] : undefined;
@@ -236,12 +245,18 @@ const VetDirectoryScreen: React.FC = () => {
 
         setVets(sorted);
       } catch {
-        Alert.alert('Error', 'Failed to search vets');
+        // A pull-to-refresh on an already-populated list: keep the list,
+        // toast instead of an intrusive blocking alert.
+        if (isRefresh && hadData) {
+          showToast("Couldn't refresh — showing cached data", { variant: 'error' });
+        } else {
+          Alert.alert('Error', 'Failed to search vets');
+        }
       } finally {
         setLoading(false);
       }
     },
-    [],
+    [vets.length, showToast],
   );
 
   // Debounced re-search when filters change
@@ -253,7 +268,14 @@ const VetDirectoryScreen: React.FC = () => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [userLat, userLng, radius, selectedSpecialties, availableOnly, doSearch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userLat, userLng, radius, selectedSpecialties, availableOnly]);
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    await doSearch(userLat, userLng, radius, selectedSpecialties, availableOnly, true);
+    setIsRefreshing(false);
+  }, [doSearch, userLat, userLng, radius, selectedSpecialties, availableOnly]);
 
   // ── Filter drawer ──────────────────────────────────────────────────────────
 
@@ -395,6 +417,14 @@ const VetDirectoryScreen: React.FC = () => {
             )}
             ListEmptyComponent={<Text style={styles.empty}>No vets found.</Text>}
             contentContainerStyle={styles.list}
+            refreshControl={
+              <RefreshControl
+                refreshing={isRefreshing}
+                onRefresh={() => void handleRefresh()}
+                colors={[colors.primary]}
+                tintColor={colors.primary}
+              />
+            }
           />
         )}
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2>
<p>Standardizes pull-to-refresh across all six main list screens, per #639. Each screen now uses an explicit <code>RefreshControl</code> (instead of relying on <code>FlatList</code>'s implicit props, or having none at all), themed to the app's primary color, with a re-fetch that actually runs on pull and a toast shown if that re-fetch fails.</p>
<p>Closes #639</p>
<h2>Changes</h2>
<h3>New shared infrastructure</h3>
<ul>
<li><strong><code>src/context/ToastContext.tsx</code></strong> (new) — lightweight <code>ToastProvider</code> / <code>useToast()</code> hook / toast host, no new dependency. Renders at the app root.</li>
<li><strong><code>App.tsx</code></strong> — wraps the app in <code>ToastProvider</code>.</li>
</ul>
<h3>Per-screen changes</h3>

Screen | Before | After
-- | -- | --
PetListScreen | Had onRefresh/refreshing via FlatList, untheme'd, error UI replaced the whole list on any failure | Explicit themed RefreshControl; failed refresh shows a toast and keeps the existing list if data is already loaded
MedicationScreen | No pull-to-refresh on the list tab | Added RefreshControl, themed; added error handling (there was none) with toast-on-failure
AppointmentScreen | No pull-to-refresh | Added RefreshControl, themed; added error handling (there was none) with toast-on-failure
NotificationCenterScreen | Had RefreshControl, untheme'd, a failed refresh blanked the inbox with a full error screen | Themed RefreshControl; new reducer action keeps the existing notifications visible on a failed refresh, toast shown instead
VetDirectoryScreen | No pull-to-refresh (directory list only — screen also has profile/chat sub-views, intentionally left out of scope) | Added RefreshControl to the directory list, themed; failed refresh toasts instead of showing a blocking alert (alert is kept for the no-cached-data case)
ForumScreen | Had onRefresh/refreshing via FlatList, but the fetch's catch block silently swallowed all errors — the refresh indicator would stop with no re-fetch and no feedback | Explicit themed RefreshControl; failures now surface a toast instead of failing silently


<p>All six <code>onRefresh</code> handlers re-fetch from the same data source the screen normally loads from (no separate pagination reset was needed — none of the six screens implement pagination, so there was no page state to reset).</p>
<h2>Notes for reviewers</h2>
<ul>
<li><strong>Not yet manually verified end-to-end.</strong> Implementation is complete and matches the pattern across all six screens, but pull-to-refresh (success and failure paths) has not yet been exercised on a running build. Please test before merging, or hold for a follow-up commit confirming this.</li>
<li><code>npx tsc --noEmit</code> has [not yet been run / introduces no new errors beyond two pre-existing, unrelated ones — fill in once confirmed]:
<ul>
<li><code>LockScreen</code> missing required <code>onWipe</code> prop in <code>App.tsx</code> (pre-existing, unrelated to this change)</li>
<li><code>ConflictCheckResponse</code> type used but not imported in <code>AppointmentScreen.tsx</code> (pre-existing, unrelated to this change)</li>
</ul>
</li>
<li><code>VetDirectoryScreen</code>'s chat sub-view was intentionally left without pull-to-refresh — refreshing a message thread is a different feature (load older messages) than refreshing a list, and seemed out of scope for this issue.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>

Closes #639 