### PR TITLE
Replace remaining loading spinner with skeleton rows

### DIFF
--- a/src/screens/VetDirectoryScreen.tsx
+++ b/src/screens/VetDirectoryScreen.tsx
@@ -542,7 +542,11 @@ const VetDirectoryScreen: React.FC = () => {
         </View>
 
         {chatLoading ? (
-          <ActivityIndicator style={styles.loader} size="large" color="#4299e1" />
+          <View style={styles.chatList}>
+            {Array.from({ length: 4 }).map((_, index) => (
+              <SkeletonCard key={`chat-skeleton-${index}`} height={64} lines={2} />
+            ))}
+          </View>
         ) : (
           <FlatList
             data={messages}


### PR DESCRIPTION
## Summary
- Replaced the remaining vet chat history loading spinner with skeleton rows.
- Verified existing skeleton loading coverage in pet list, medications, appointments, vet directory, and notification center screens.
- Confirmed the existing minimum 300 ms loading delay is already wired through the shared loading hook.

## Testing
- [ ] `npm run typecheck`
- [ ] `npm test -- --runInBand`

Closes #637  