### PR TITLE
feat(notifications): localize push notification templates by user preferred language

### DIFF
--- a/backend/migrations/20260627000001000_users_preferred_language.sql
+++ b/backend/migrations/20260627000001000_users_preferred_language.sql
@@ -1,0 +1,10 @@
+-- Migration: 20260627000001_users_preferred_language
+-- Description: Add preferred_language to users so notifications can be localized
+
+-- up migration
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS preferred_language TEXT NOT NULL DEFAULT 'en';
+
+-- down migration
+ALTER TABLE users
+  DROP COLUMN IF EXISTS preferred_language;

--- a/backend/migrations/20260627000002000_seed_notification_templates.sql
+++ b/backend/migrations/20260627000002000_seed_notification_templates.sql
@@ -1,0 +1,52 @@
+-- Migration: 20260627000002_seed_notification_templates
+-- Description: Seed English + Spanish templates for lost_pet_alert and
+-- vaccination_transfer, used by sendNotification() in
+-- notificationTemplateService.ts. Variables: {{petName}}.
+-- (lost_pet_alert currently has no variables but is included for parity
+-- with the locale-selection mechanism.)
+
+-- up migration
+INSERT INTO notification_templates (id, key, locale, title, body, is_active)
+VALUES
+  (
+    gen_random_uuid(),
+    'lost_pet_alert',
+    'en',
+    'Lost pet alert near you',
+    'A lost pet has been reported nearby. Tap the app for details.',
+    TRUE
+  ),
+  (
+    gen_random_uuid(),
+    'lost_pet_alert',
+    'es',
+    'Alerta de mascota perdida cerca de ti',
+    'Se ha reportado una mascota perdida cerca de ti. Toca la app para ver los detalles.',
+    TRUE
+  ),
+  (
+    gen_random_uuid(),
+    'vaccination_transfer',
+    'en',
+    '🐾 Vaccination reminders transferred',
+    'Vaccination reminders for {{petName}} are now active on your account.',
+    TRUE
+  ),
+  (
+    gen_random_uuid(),
+    'vaccination_transfer',
+    'es',
+    '🐾 Recordatorios de vacunación transferidos',
+    'Los recordatorios de vacunación de {{petName}} ya están activos en tu cuenta.',
+    TRUE
+  )
+ON CONFLICT (key, locale) DO NOTHING;
+
+-- down migration
+DELETE FROM notification_templates
+WHERE (key, locale) IN (
+  ('lost_pet_alert', 'en'),
+  ('lost_pet_alert', 'es'),
+  ('vaccination_transfer', 'en'),
+  ('vaccination_transfer', 'es')
+);

--- a/backend/services/__tests__/notificationTemplateService.test.ts
+++ b/backend/services/__tests__/notificationTemplateService.test.ts
@@ -20,6 +20,14 @@ jest.mock('../../services/cacheService', () => ({
   invalidate: mockInvalidate,
 }));
 
+// ─── Mock pushService ─────────────────────────────────────────────────────────
+
+const mockSendToUser = jest.fn().mockResolvedValue(1);
+
+jest.mock('../../services/pushService', () => ({
+  sendToUser: mockSendToUser,
+}));
+
 // ─── Mock logger ──────────────────────────────────────────────────────────────
 
 jest.mock('../../utils/logger', () => ({
@@ -187,6 +195,240 @@ describe('resolveTemplate', () => {
     await resolveTemplate('medication_reminder', { medicationName: 'X', petName: 'Y' }, 'en');
 
     expect(mockQuery).not.toHaveBeenCalled();
+  });
+});
+
+// ─── sendNotification ────────────────────────────────────────────────────────
+
+describe('sendNotification', () => {
+  let sendNotification: (
+    userId: string,
+    key: string,
+    vars?: Record<string, string>,
+    options?: { topic: string; data?: Record<string, unknown> },
+  ) => Promise<{ enqueued: number; locale: string }>;
+
+  beforeAll(async () => {
+    ({ sendNotification } = await import('../../services/notificationTemplateService'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCacheGet.mockResolvedValue(null);
+    mockSendToUser.mockResolvedValue(1);
+  });
+
+  /**
+   * sendNotification issues two DB queries in sequence:
+   *   1. SELECT preferred_language FROM users WHERE id = $1
+   *   2. SELECT * FROM notification_templates WHERE key = $1 AND locale = $2 ...
+   * (a second template query only happens if locale !== 'en' and falls back)
+   */
+  function mockUserThenTemplate(
+    preferredLanguage: string | undefined,
+    templateRows: Record<string, unknown>[],
+  ) {
+    mockQuery.mockResolvedValueOnce({ rows: [{ preferred_language: preferredLanguage }] });
+    mockQuery.mockResolvedValueOnce({ rows: templateRows });
+  }
+
+  it('selects the template matching the user preferred_language', async () => {
+    mockUserThenTemplate('es', [
+      makeRow({
+        key: 'vaccination_transfer',
+        locale: 'es',
+        title: '🐾 Recordatorios de vacunación transferidos',
+        body: 'Los recordatorios de vacunación de {{petName}} ya están activos en tu cuenta.',
+      }),
+    ]);
+
+    const result = await sendNotification(
+      'user-1',
+      'vaccination_transfer',
+      { petName: 'Rex' },
+      { topic: 'health_tips' },
+    );
+
+    expect(result.locale).toBe('es');
+    expect(mockSendToUser).toHaveBeenCalledWith(
+      'user-1',
+      'health_tips',
+      '🐾 Recordatorios de vacunación transferidos',
+      'Los recordatorios de vacunación de Rex ya están activos en tu cuenta.',
+      undefined,
+    );
+  });
+
+  it('falls back to English when the user locale has no template', async () => {
+    // 1) user lookup → 'fr', 2) fr template lookup → none, 3) en fallback → found
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ preferred_language: 'fr' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          makeRow({
+            key: 'vaccination_transfer',
+            locale: 'en',
+            title: '🐾 Vaccination reminders transferred',
+            body: 'Vaccination reminders for {{petName}} are now active on your account.',
+          }),
+        ],
+      });
+
+    const result = await sendNotification(
+      'user-2',
+      'vaccination_transfer',
+      { petName: 'Milo' },
+      { topic: 'health_tips' },
+    );
+
+    expect(result.locale).toBe('en');
+    expect(mockSendToUser).toHaveBeenCalledWith(
+      'user-2',
+      'health_tips',
+      '🐾 Vaccination reminders transferred',
+      'Vaccination reminders for Milo are now active on your account.',
+      undefined,
+    );
+  });
+
+  it('defaults to English when the user has no preferred_language set', async () => {
+    mockUserThenTemplate(undefined, [
+      makeRow({
+        key: 'vaccination_transfer',
+        locale: 'en',
+        title: '🐾 Vaccination reminders transferred',
+        body: 'Vaccination reminders for {{petName}} are now active on your account.',
+      }),
+    ]);
+
+    const result = await sendNotification(
+      'user-3',
+      'vaccination_transfer',
+      { petName: 'Milo' },
+      { topic: 'health_tips' },
+    );
+
+    expect(result.locale).toBe('en');
+  });
+
+  it('defaults to English when the user row is not found', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({
+      rows: [
+        makeRow({
+          key: 'vaccination_transfer',
+          locale: 'en',
+          title: '🐾 Vaccination reminders transferred',
+          body: 'Vaccination reminders for {{petName}} are now active on your account.',
+        }),
+      ],
+    });
+
+    const result = await sendNotification(
+      'missing-user',
+      'vaccination_transfer',
+      { petName: 'Milo' },
+      { topic: 'health_tips' },
+    );
+
+    expect(result.locale).toBe('en');
+  });
+
+  it('passes through the data payload to sendToUser', async () => {
+    mockUserThenTemplate('en', [
+      makeRow({
+        key: 'vaccination_transfer',
+        locale: 'en',
+        title: '🐾 Vaccination reminders transferred',
+        body: 'Vaccination reminders for {{petName}} are now active on your account.',
+      }),
+    ]);
+
+    await sendNotification(
+      'user-4',
+      'vaccination_transfer',
+      { petName: 'Milo' },
+      { topic: 'health_tips', data: { petId: 'pet-1' } },
+    );
+
+    expect(mockSendToUser).toHaveBeenCalledWith(
+      'user-4',
+      'health_tips',
+      expect.any(String),
+      expect.any(String),
+      { petId: 'pet-1' },
+    );
+  });
+
+  it('returns the enqueued count from pushService.sendToUser', async () => {
+    mockUserThenTemplate('en', [
+      makeRow({
+        key: 'vaccination_transfer',
+        locale: 'en',
+        title: 'T',
+        body: 'B {{petName}}',
+      }),
+    ]);
+    mockSendToUser.mockResolvedValue(3);
+
+    const result = await sendNotification(
+      'user-5',
+      'vaccination_transfer',
+      { petName: 'Milo' },
+      { topic: 'health_tips' },
+    );
+
+    expect(result.enqueued).toBe(3);
+  });
+
+  it('throws when no template exists for the key in any locale', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ preferred_language: 'es' }] })
+      .mockResolvedValueOnce({ rows: [] }) // es lookup
+      .mockResolvedValueOnce({ rows: [] }); // en fallback lookup
+
+    await expect(
+      sendNotification('user-6', 'nonexistent_key', {}, { topic: 'health_tips' }),
+    ).rejects.toThrow('No notification template found for key: "nonexistent_key"');
+
+    expect(mockSendToUser).not.toHaveBeenCalled();
+  });
+
+  it('throws when required variables are missing and does not send', async () => {
+    mockUserThenTemplate('en', [
+      makeRow({
+        key: 'vaccination_transfer',
+        locale: 'en',
+        title: 'T',
+        body: 'B {{petName}}',
+      }),
+    ]);
+
+    await expect(
+      sendNotification('user-7', 'vaccination_transfer', {}, { topic: 'health_tips' }),
+    ).rejects.toThrow('Missing template variables: petName');
+
+    expect(mockSendToUser).not.toHaveBeenCalled();
+  });
+
+  it('normalises a region-tagged user locale (es-MX → es)', async () => {
+    mockUserThenTemplate('es-MX', [
+      makeRow({
+        key: 'vaccination_transfer',
+        locale: 'es',
+        title: 'T',
+        body: 'B {{petName}}',
+      }),
+    ]);
+
+    const result = await sendNotification(
+      'user-8',
+      'vaccination_transfer',
+      { petName: 'Milo' },
+      { topic: 'health_tips' },
+    );
+
+    expect(result.locale).toBe('es');
   });
 });
 

--- a/backend/services/notificationTemplateService.ts
+++ b/backend/services/notificationTemplateService.ts
@@ -9,6 +9,7 @@
 import { randomUUID } from 'crypto';
 
 import { cacheKey, get as cacheGet, invalidate, set as cacheSet } from '../services/cacheService';
+import { sendToUser, type NotificationTopic } from '../services/pushService';
 import { query } from '../src/db';
 import logger from '../utils/logger';
 
@@ -139,6 +140,67 @@ export async function resolveTemplate(
     body: interpolate(tmpl.body, vars),
     locale: usedLocale,
   };
+}
+
+// ─── User locale lookup ───────────────────────────────────────────────────────
+
+/**
+ * Looks up a user's preferred_language. Falls back to 'en' if the user
+ * is missing or the column is empty for any reason.
+ */
+async function getUserPreferredLanguage(userId: string): Promise<string> {
+  const { rows } = await query('SELECT preferred_language FROM users WHERE id = $1', [userId]);
+  const lang = rows[0]?.preferred_language as string | undefined;
+  return lang && lang.trim() ? lang : 'en';
+}
+
+// ─── Send ─────────────────────────────────────────────────────────────────────
+
+export interface SendNotificationOptions {
+  /** Push topic used for subscription/preference gating in pushService. */
+  topic: NotificationTopic;
+  /** Extra payload passed through to the push job (e.g. for deep-linking). */
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Sends a push notification to `userId` using the localized template for
+ * `key`, rendered with `vars`. The user's `preferred_language` is read from
+ * the DB and used to select the template locale, falling back to English
+ * (via resolveTemplate) if no translation exists for that locale.
+ *
+ * Returns the number of push jobs enqueued (see pushService.sendToUser),
+ * and the locale that was actually used for the rendered copy.
+ *
+ * @throws if no template exists for the key in any supported locale
+ * @throws if required variables are missing for the resolved template
+ */
+export async function sendNotification(
+  userId: string,
+  key: string,
+  vars: TemplateVariables = {},
+  options: SendNotificationOptions,
+): Promise<{ enqueued: number; locale: string }> {
+  const preferredLanguage = await getUserPreferredLanguage(userId);
+  const rendered = await resolveTemplate(key, vars, preferredLanguage);
+
+  const enqueued = await sendToUser(
+    userId,
+    options.topic,
+    rendered.title,
+    rendered.body,
+    options.data,
+  );
+
+  logger.info('notification_sent', {
+    userId,
+    key,
+    locale: rendered.locale,
+    topic: options.topic,
+    enqueued,
+  });
+
+  return { enqueued, locale: rendered.locale };
 }
 
 // ─── Admin CRUD ───────────────────────────────────────────────────────────────

--- a/backend/src/routes/lostFound.ts
+++ b/backend/src/routes/lostFound.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import express from 'express';
 
 import { authenticateJWT, type AuthenticatedRequest } from '../../middleware/auth';
+import { sendNotification } from '../../services/notificationTemplateService';
 import { ok, sendError } from '../../server/response';
 import {
   findNearbyMatches,
@@ -10,7 +11,6 @@ import {
   type LostFoundLocation,
   type LostFoundReport,
 } from '../../services/matchingService';
-import { sendToUser } from '../../services/pushService';
 
 const router = express.Router();
 router.use(authenticateJWT);
@@ -91,12 +91,14 @@ async function broadcastLostReport(report: StoredLostFoundReport, radiusKm: numb
 
   await Promise.all(
     nearbyUsers.map((userId) =>
-      sendToUser(
+      sendNotification(
         userId,
-        'sos_notifications',
-        'Lost pet alert near you',
-        `A lost pet has been reported nearby. Tap the app for details.`,
-        { reportId: report.id, route: 'LostFound' },
+        'lost_pet_alert',
+        { reportId: report.id },
+        {
+          topic: 'sos_notifications',
+          data: { reportId: report.id, route: 'LostFound' },
+        },
       ),
     ),
   );

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -4,6 +4,7 @@ import express from 'express';
 
 import { authenticateJWT, authorizeRoles, type AuthenticatedRequest } from '../../middleware/auth';
 import { UserRole } from '../../models/UserRole';
+import { sendNotification } from '../../services/notificationTemplateService';
 import { ok, sendError } from '../../server/response';
 import {
   ALL_TOPICS,
@@ -141,7 +142,13 @@ router.patch('/preferences', async (req: AuthenticatedRequest, res) => {
 
 // ─── Send (internal / admin) ──────────────────────────────────────────────────
 
-/** POST /api/notifications/send — send a push to a user (admin only) */
+/**
+ * POST /api/notifications/send — send a push to a user (admin only)
+ *
+ * NOTE: title/body are admin-authored free text, not a template key, so this
+ * route intentionally bypasses sendNotification()/template locale resolution
+ * and calls pushService.sendToUser() directly, same as before.
+ */
 router.post('/send', authorizeRoles(UserRole.ADMIN), async (req: AuthenticatedRequest, res) => {
   const { userId, topic, title, body, data } = req.body as {
     userId?: string;
@@ -224,12 +231,14 @@ router.post('/vaccination-transfer', async (req: AuthenticatedRequest, res) => {
     return sendError(res, 403, 'FORBIDDEN', 'You do not have permission to transfer notifications for this pet');
   }
 
-  await sendToUser(
+  await sendNotification(
     newOwnerUserId.trim(),
-    'health_tips' as NotificationTopic, // closest available topic for health-related push
-    '🐾 Vaccination reminders transferred',
-    `Vaccination reminders for ${pet.name} are now active on your account.`,
-    { type: 'vaccination_transfer', petId: petId.trim() },
+    'vaccination_transfer',
+    { petName: pet.name },
+    {
+      topic: 'health_tips' as NotificationTopic, // closest available topic for health-related push
+      data: { type: 'vaccination_transfer', petId: petId.trim() },
+    },
   );
 
   logger.info('vaccination_notifications_transferred', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16532,32 +16532,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/expo/node_modules/react-native-worklets": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.8.3.tgz",
-      "integrity": "sha512-oCBJROyLU7yG/1R8s0INMflygTH71bx+5XcYkH0CM938TlhSoVbiunE1WVW5FZa51vwYqfLie/IXMX2s1Kh3eg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.28.4",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/preset-typescript": "^7.27.1",
-        "convert-source-map": "^2.0.0",
-        "semver": "^7.7.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "*",
-        "@react-native/metro-config": "*",
-        "react": "*",
-        "react-native": "0.81 - 0.85"
-      }
-    },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",


### PR DESCRIPTION
## Summary

Notifications were always sent in English regardless of the user's
language setting. This PR adds locale-aware notification sending on top
of the existing template infrastructure in `notificationTemplateService.ts`.

## Changes

- **`users.preferred_language`** (new migration) — added with
  `NOT NULL DEFAULT 'en'`, matching the short-code convention already used
  by `notification_templates.locale`.
- **`sendNotification(userId, key, vars, { topic, data })`** (new, in
  `notificationTemplateService.ts`) — looks up the recipient's
  `preferred_language`, resolves the localized template via the existing
  `resolveTemplate()` (which already handled fallback-to-English and
  `{{variable}}` interpolation), then dispatches through the existing
  `pushService.sendToUser()`.
- **Seed migration** — adds English + Spanish templates for two
  notification keys that previously had hardcoded English strings inline:
  - `lost_pet_alert` (`backend/src/routes/lostFound.ts`)
  - `vaccination_transfer` (`backend/src/routes/notifications.ts`)
- **Call sites updated** to use `sendNotification()` instead of calling
  `pushService.sendToUser()` directly with hardcoded English text.
- **Tests** — added coverage for `sendNotification()`: exact-locale match,
  fallback to English when no translation exists, missing
  `preferred_language`/missing user row, region-tagged locale
  normalization (`es-MX` → `es`), missing-variable errors, and
  payload/topic passthrough.

## Out of scope / intentionally untouched

- `POST /api/notifications/send` (admin-only free-text broadcast) still
  calls `pushService.sendToUser()` directly. Title/body there are
  admin-authored at request time, not a template key, so template
  resolution doesn't apply.
- `src/services/waitlistService.ts` was found to be dead code (only
  referenced by its own test file, with a broken import to a
  nonexistent module) — left as-is, out of scope for this ticket.

## How to test

1. Run migrations: `npm run migrate`
2. Run unit tests: `npx jest backend/services/__tests__/notificationTemplateService.test.ts`
3. Manually: set a test user's `preferred_language` to `es`, trigger a
   lost-pet report or vaccination transfer, and confirm the push payload
   is in Spanish; confirm it falls back to English for any other locale.

## Checklist

- [ ✅] Migrations run cleanly against a fresh DB
- [✅ ] `notificationTemplateService.test.ts` passes
- [✅ ] Manually verified locale selection end-to-end

Closes #563 