### PR TITLE
fix(#601 #604): strictNullChecks for blockchainIntegration + sessionMonitoringService refactor

### DIFF
--- a/src/services/__tests__/deviceFingerprint.test.ts
+++ b/src/services/__tests__/deviceFingerprint.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Unit tests for src/services/deviceFingerprint.ts
+ */
+
+jest.mock('../../config', () => ({
+  __esModule: true,
+  default: {
+    app: { version: '1.2.3' },
+  },
+}));
+
+import { getDefaultDevice, type DeviceMetadata } from '../deviceFingerprint';
+
+describe('getDefaultDevice()', () => {
+  it('returns a DeviceMetadata object with unknown fields and the configured appVersion', () => {
+    const device: DeviceMetadata = getDefaultDevice();
+    expect(device.model).toBe('unknown');
+    expect(device.os).toBe('unknown');
+    expect(device.osVersion).toBe('unknown');
+    expect(device.platform).toBe('unknown');
+    expect(device.appVersion).toBe('1.2.3');
+  });
+});

--- a/src/services/__tests__/inactivityTracker.test.ts
+++ b/src/services/__tests__/inactivityTracker.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for src/services/inactivityTracker.ts
+ */
+
+import { InactivityTracker, SESSION_TIMEOUT_MS, WARNING_BEFORE_EXPIRY_MS } from '../inactivityTracker';
+
+describe('InactivityTracker', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('exports SESSION_TIMEOUT_MS as 30 minutes', () => {
+    expect(SESSION_TIMEOUT_MS).toBe(30 * 60 * 1000);
+  });
+
+  it('exports WARNING_BEFORE_EXPIRY_MS as 2 minutes', () => {
+    expect(WARNING_BEFORE_EXPIRY_MS).toBe(2 * 60 * 1000);
+  });
+
+  describe('onWarning / onExpired listeners', () => {
+    it('fires warning listener when warning period begins', () => {
+      const tracker = new InactivityTracker();
+      const warningListener = jest.fn();
+      tracker.onWarning(warningListener);
+
+      tracker.reset();
+
+      // Advance to just before the warning timer fires
+      jest.advanceTimersByTime(SESSION_TIMEOUT_MS - WARNING_BEFORE_EXPIRY_MS - 1);
+      expect(warningListener).not.toHaveBeenCalled();
+
+      // Advance past the warning threshold
+      jest.advanceTimersByTime(2);
+      expect(warningListener).toHaveBeenCalled();
+      expect(warningListener.mock.calls[0][0]).toMatchObject({
+        secondsRemaining: expect.any(Number),
+      });
+
+      tracker.clear();
+    });
+
+    it('fires expired listener after full timeout elapses', () => {
+      const tracker = new InactivityTracker();
+      const expiredListener = jest.fn();
+      tracker.onExpired(expiredListener);
+
+      tracker.reset();
+
+      // Advance through warning period + all countdown seconds
+      jest.advanceTimersByTime(SESSION_TIMEOUT_MS + 1000);
+      expect(expiredListener).toHaveBeenCalledTimes(1);
+
+      tracker.clear();
+    });
+
+    it('clears timers and stops events after clear()', () => {
+      const tracker = new InactivityTracker();
+      const warningListener = jest.fn();
+      const expiredListener = jest.fn();
+      tracker.onWarning(warningListener);
+      tracker.onExpired(expiredListener);
+
+      tracker.reset();
+      tracker.clear();
+
+      jest.advanceTimersByTime(SESSION_TIMEOUT_MS + 10000);
+
+      expect(warningListener).not.toHaveBeenCalled();
+      expect(expiredListener).not.toHaveBeenCalled();
+    });
+
+    it('restarting reset() cancels previous timers', () => {
+      const tracker = new InactivityTracker();
+      const warningListener = jest.fn();
+      tracker.onWarning(warningListener);
+
+      tracker.reset();
+      // Advance partway
+      jest.advanceTimersByTime(SESSION_TIMEOUT_MS - WARNING_BEFORE_EXPIRY_MS - 1000);
+      // Reset again — should restart the full timer
+      tracker.reset();
+      // Advance the remainder of the original timer — warning should NOT fire yet
+      jest.advanceTimersByTime(1001);
+      expect(warningListener).not.toHaveBeenCalled();
+
+      tracker.clear();
+    });
+
+    it('unsubscribe function stops warning notifications', () => {
+      const tracker = new InactivityTracker();
+      const listener = jest.fn();
+      const unsubscribe = tracker.onWarning(listener);
+      unsubscribe();
+
+      tracker.reset();
+      jest.advanceTimersByTime(SESSION_TIMEOUT_MS);
+
+      expect(listener).not.toHaveBeenCalled();
+      tracker.clear();
+    });
+
+    it('unsubscribe function stops expired notifications', () => {
+      const tracker = new InactivityTracker();
+      const listener = jest.fn();
+      const unsubscribe = tracker.onExpired(listener);
+      unsubscribe();
+
+      tracker.reset();
+      jest.advanceTimersByTime(SESSION_TIMEOUT_MS + 10000);
+
+      expect(listener).not.toHaveBeenCalled();
+      tracker.clear();
+    });
+  });
+});

--- a/src/services/__tests__/tokenRefreshScheduler.test.ts
+++ b/src/services/__tests__/tokenRefreshScheduler.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Unit tests for src/services/tokenRefreshScheduler.ts
+ */
+
+const mockRefreshToken = jest.fn();
+
+jest.mock('../authService', () => ({
+  refreshToken: mockRefreshToken,
+}));
+
+import { scheduleTokenRefresh } from '../tokenRefreshScheduler';
+
+describe('scheduleTokenRefresh()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls authService.refreshToken()', async () => {
+    mockRefreshToken.mockResolvedValue(undefined);
+    await scheduleTokenRefresh();
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when refreshToken rejects', async () => {
+    mockRefreshToken.mockRejectedValue(new Error('Network error'));
+    await expect(scheduleTokenRefresh()).resolves.toBeUndefined();
+  });
+});

--- a/src/services/blockchainIntegration.ts
+++ b/src/services/blockchainIntegration.ts
@@ -1,6 +1,12 @@
 /**
  * Integration service that connects blockchain events to app state updates
  * This demonstrates how to use the blockchain event service in a React Native app
+ *
+ * @remarks
+ * This file is compiled with `strictNullChecks: true` (see tsconfig.strict.json).
+ * All nullable types are explicitly annotated and every potential null access is
+ * guarded. Do NOT add non-null assertions (`!`) without a comment explaining why
+ * the assertion is safe.
  */
 
 import { EventEmitter } from 'events';
@@ -64,7 +70,7 @@ export class BlockchainIntegrationService extends EventEmitter {
   private config: IntegrationConfig;
   private verificationStatuses = new Map<string, RecordVerificationStatus>();
   private pendingVerifications = new Set<string>();
-  private verificationInterval: NodeJS.Timeout | null = null;
+  private verificationInterval: ReturnType<typeof setInterval> | null = null;
   private isInitialized = false;
 
   constructor(customConfig?: Partial<IntegrationConfig>) {
@@ -355,7 +361,7 @@ export class BlockchainIntegrationService extends EventEmitter {
 
     this.verificationInterval = setInterval(() => {
       this.pollPendingVerifications();
-    }, this.config.verificationCheckInterval) as unknown as NodeJS.Timeout;
+    }, this.config.verificationCheckInterval);
 
     loggerService.debug('Started verification polling', {
       interval: this.config.verificationCheckInterval,

--- a/src/services/deviceFingerprint.ts
+++ b/src/services/deviceFingerprint.ts
@@ -1,0 +1,34 @@
+/**
+ * Device Fingerprint Module
+ *
+ * Responsible for constructing and providing device metadata used in session
+ * monitoring and crash reports.
+ */
+
+import config from '../config';
+
+export interface DeviceMetadata {
+  /** Device model identifier, e.g. "iPhone 14 Pro", "Pixel 7" */
+  model: string;
+  /** OS name, e.g. "iOS", "Android" */
+  os: string;
+  /** OS version string, e.g. "17.2", "14" */
+  osVersion: string;
+  /** App version from config */
+  appVersion: string;
+  /** Platform: "ios" | "android" | "web" */
+  platform: string;
+}
+
+/**
+ * Returns a fallback DeviceMetadata object when no device info is available.
+ */
+export function getDefaultDevice(): DeviceMetadata {
+  return {
+    model: 'unknown',
+    os: 'unknown',
+    osVersion: 'unknown',
+    appVersion: config.app.version,
+    platform: 'unknown',
+  };
+}

--- a/src/services/inactivityTracker.ts
+++ b/src/services/inactivityTracker.ts
@@ -1,0 +1,100 @@
+/**
+ * Inactivity Tracker
+ *
+ * Manages the session inactivity timer and the pre-expiry warning countdown.
+ * Fires warning callbacks N milliseconds before the session expires, then
+ * fires expiry callbacks when the timeout elapses.
+ *
+ * Fully decoupled from session storage and API calls so it can be tested
+ * in isolation.
+ */
+
+/** How long (ms) a session may be idle before it expires. */
+export const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+
+/** How many ms before expiry to start the warning countdown. */
+export const WARNING_BEFORE_EXPIRY_MS = 2 * 60 * 1000; // 2 minutes
+
+export interface SessionTimeoutWarningPayload {
+  /** Seconds remaining until auto-logout. */
+  secondsRemaining: number;
+}
+
+type WarningListener = (payload: SessionTimeoutWarningPayload) => void;
+type ExpiredListener = () => void;
+
+export class InactivityTracker {
+  private inactivityTimer: ReturnType<typeof setTimeout> | null = null;
+  private warningTimer: ReturnType<typeof setTimeout> | null = null;
+  private warningCountdownInterval: ReturnType<typeof setInterval> | null = null;
+
+  private warningListeners: WarningListener[] = [];
+  private expiredListeners: ExpiredListener[] = [];
+
+  // ── Listener registration ──────────────────────────────────────────────────
+
+  onWarning(listener: WarningListener): () => void {
+    this.warningListeners.push(listener);
+    return () => {
+      this.warningListeners = this.warningListeners.filter((l) => l !== listener);
+    };
+  }
+
+  onExpired(listener: ExpiredListener): () => void {
+    this.expiredListeners.push(listener);
+    return () => {
+      this.expiredListeners = this.expiredListeners.filter((l) => l !== listener);
+    };
+  }
+
+  // ── Timer management ───────────────────────────────────────────────────────
+
+  /**
+   * Reset the inactivity timer (call on any user activity or navigation).
+   * Clears any active warning countdown.
+   */
+  reset(): void {
+    this.clear();
+
+    const warningAt = SESSION_TIMEOUT_MS - WARNING_BEFORE_EXPIRY_MS;
+
+    this.warningTimer = setTimeout(() => {
+      this._startWarningCountdown();
+    }, warningAt);
+  }
+
+  /** Clear all timers (call when the session ends). */
+  clear(): void {
+    if (this.inactivityTimer) {
+      clearTimeout(this.inactivityTimer);
+      this.inactivityTimer = null;
+    }
+    if (this.warningTimer) {
+      clearTimeout(this.warningTimer);
+      this.warningTimer = null;
+    }
+    if (this.warningCountdownInterval) {
+      clearInterval(this.warningCountdownInterval);
+      this.warningCountdownInterval = null;
+    }
+  }
+
+  // ── Private ───────────────────────────────────────────────────────────────
+
+  private _startWarningCountdown(): void {
+    let secondsRemaining = Math.round(WARNING_BEFORE_EXPIRY_MS / 1000);
+
+    this.warningListeners.forEach((l) => l({ secondsRemaining }));
+
+    this.warningCountdownInterval = setInterval(() => {
+      secondsRemaining -= 1;
+      this.warningListeners.forEach((l) => l({ secondsRemaining }));
+
+      if (secondsRemaining <= 0) {
+        if (this.warningCountdownInterval) clearInterval(this.warningCountdownInterval);
+        this.warningCountdownInterval = null;
+        this.expiredListeners.forEach((l) => l());
+      }
+    }, 1000);
+  }
+}

--- a/src/services/sessionMonitoringService.ts
+++ b/src/services/sessionMonitoringService.ts
@@ -4,12 +4,25 @@
  * Tracks session lifecycle events, crash occurrences, and user flows.
  * Integrates with Sentry session tracking APIs for crash-free rate calculation.
  * Alerts when crash-free rate drops below 99.5%.
+ *
+ * This facade delegates inactivity detection to {@link InactivityTracker},
+ * token refresh to {@link scheduleTokenRefresh}, and device fingerprinting
+ * to {@link getDefaultDevice} — keeping each responsibility isolated and
+ * independently testable.
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import apiClient from './apiClient';
 import config from '../config';
+import { InactivityTracker, SESSION_TIMEOUT_MS } from './inactivityTracker';
+import { scheduleTokenRefresh } from './tokenRefreshScheduler';
+import { type DeviceMetadata, getDefaultDevice } from './deviceFingerprint';
+
+// ─── Re-exports (backwards-compatible public API) ─────────────────────────────
+
+export type { DeviceMetadata } from './deviceFingerprint';
+export type { SessionTimeoutWarningPayload } from './inactivityTracker';
 
 // ─── Storage Keys ─────────────────────────────────────────────────────────────
 
@@ -27,9 +40,6 @@ export const CRASH_FREE_THRESHOLD = 99.5;
 
 /** Maximum events to buffer locally before flushing */
 const MAX_PENDING_EVENTS = 100;
-
-/** Session timeout in ms — sessions idle longer than this are auto-ended */
-const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -65,19 +75,6 @@ export type SessionEventType =
   | 'user_action'
   | 'network_error'
   | 'api_error';
-
-export interface DeviceMetadata {
-  /** Device model identifier, e.g. "iPhone 14 Pro", "Pixel 7" */
-  model: string;
-  /** OS name, e.g. "iOS", "Android" */
-  os: string;
-  /** OS version string, e.g. "17.2", "14" */
-  osVersion: string;
-  /** App version from config */
-  appVersion: string;
-  /** Platform: "ios" | "android" | "web" */
-  platform: string;
-}
 
 export interface SessionEvent {
   id: string;
@@ -142,19 +139,6 @@ export interface AlertPayload {
   timestamp: string;
 }
 
-// ─── Timeout warning configuration ───────────────────────────────────────────
-
-/** How many ms before session expiry to show the warning modal */
-const WARNING_BEFORE_EXPIRY_MS = 2 * 60 * 1000; // 2 minutes
-
-export interface SessionTimeoutWarningPayload {
-  /** Seconds remaining until auto-logout */
-  secondsRemaining: number;
-}
-
-type TimeoutWarningListener = (payload: SessionTimeoutWarningPayload) => void;
-type TimeoutExpiredListener = () => void;
-
 // ─── Error Class ──────────────────────────────────────────────────────────────
 
 export class SessionMonitoringError extends Error {
@@ -177,7 +161,7 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
-// ─── Service ──────────────────────────────────────────────────────────────────
+// ─── Facade ───────────────────────────────────────────────────────────────────
 
 class SessionMonitoringService {
   private currentSession: Session | null = null;
@@ -185,13 +169,15 @@ class SessionMonitoringService {
   private statusListeners: Array<(status: SessionStatus) => void> = [];
   private alertListeners: Array<(alert: AlertPayload) => void> = [];
 
-  // ── Inactivity / timeout warning ──────────────────────────────────────────
-  private inactivityTimer: ReturnType<typeof setTimeout> | null = null;
-  private warningTimer: ReturnType<typeof setTimeout> | null = null;
-  private warningCountdownInterval: ReturnType<typeof setInterval> | null = null;
-  private timeoutWarningListeners: TimeoutWarningListener[] = [];
-  private timeoutExpiredListeners: TimeoutExpiredListener[] = [];
-  private warningActive = false;
+  /** Inactivity detection — delegated to InactivityTracker */
+  private readonly inactivity = new InactivityTracker();
+
+  constructor() {
+    // Wire InactivityTracker expiry to session end
+    this.inactivity.onExpired(() => {
+      this.endSession('ended').catch(() => {});
+    });
+  }
 
   // ── Session lifecycle ──────────────────────────────────────────────────────
 
@@ -200,7 +186,6 @@ class SessionMonitoringService {
    * Sends a Sentry-compatible session_start event to the backend.
    */
   async startSession(device: DeviceMetadata): Promise<string> {
-    // End any lingering session before starting a new one
     if (this.currentSession && this.currentSession.status === 'active') {
       await this.endSession('abnormal');
     }
@@ -238,7 +223,7 @@ class SessionMonitoringService {
       appVersion: device.appVersion,
     });
 
-    this._resetInactivityTimer();
+    this.inactivity.reset();
 
     return session.id;
   }
@@ -247,7 +232,7 @@ class SessionMonitoringService {
    * End the current session normally.
    */
   async endSession(status: Extract<SessionStatus, 'ended' | 'abnormal'> = 'ended'): Promise<void> {
-    this._clearTimers();
+    this.inactivity.clear();
     if (!this.currentSession) return;
 
     const now = Date.now();
@@ -286,7 +271,6 @@ class SessionMonitoringService {
 
   /**
    * Track a navigation event and update the active user flow.
-   * Call this whenever the user navigates to a new screen.
    */
   async trackNavigation(flow: UserFlowStep, screenName?: string): Promise<void> {
     if (!this.currentSession) return;
@@ -295,7 +279,7 @@ class SessionMonitoringService {
     this.currentSession.flowPath.push(flow);
     await this._persistCurrentSession();
 
-    this._resetInactivityTimer();
+    this.inactivity.reset();
 
     await this._trackEvent({
       type: 'navigation',
@@ -327,18 +311,16 @@ class SessionMonitoringService {
 
   /**
    * Report a fatal crash. Marks the session as crashed and sends a crash report.
-   * This is the Sentry-equivalent of `captureException` with session marking.
    */
   async reportCrash(error: Error, context?: Record<string, unknown>): Promise<void> {
     if (!this.currentSession) {
-      // Crash outside of a tracked session — still report it
       await this._sendCrashReport({
         sessionId: 'unknown',
         error: error.message,
         stack: error.stack,
         timestamp: Date.now(),
         appVersion: config.app.version,
-        device: this._getDefaultDevice(),
+        device: getDefaultDevice(),
         activeFlow: this.activeFlow,
         flowPath: [],
       });
@@ -373,7 +355,6 @@ class SessionMonitoringService {
 
     await this._sendCrashReport(crashReport);
 
-    // End the session as crashed
     await this.endSession('abnormal');
 
     this._notifyStatusListeners('crashed');
@@ -385,7 +366,7 @@ class SessionMonitoringService {
   async trackUserAction(action: string, data?: Record<string, unknown>): Promise<void> {
     if (!this.currentSession) return;
 
-    this._resetInactivityTimer();
+    this.inactivity.reset();
 
     await this._trackEvent({
       type: 'user_action',
@@ -398,7 +379,6 @@ class SessionMonitoringService {
 
   /**
    * Fetch crash-free session stats for a given app version.
-   * Calculates crash-free rate and identifies top crash-prone flows.
    */
   async getCrashFreeStats(appVersion?: string): Promise<CrashFreeStats> {
     try {
@@ -409,7 +389,6 @@ class SessionMonitoringService {
 
       const stats: CrashFreeStats = response.data.data;
 
-      // Fire alert if rate is below threshold
       if (stats.isBelowThreshold) {
         const alert: AlertPayload = {
           type: 'crash_free_rate_below_threshold',
@@ -435,7 +414,6 @@ class SessionMonitoringService {
 
   /**
    * Restore a session that was interrupted (e.g. app killed mid-session).
-   * Call this on app startup to detect abnormal terminations.
    */
   async recoverInterruptedSession(): Promise<Session | null> {
     try {
@@ -444,15 +422,12 @@ class SessionMonitoringService {
 
       const session: Session = JSON.parse(raw);
 
-      // If the session is still marked active but was started more than SESSION_TIMEOUT_MS ago,
-      // it was abnormally terminated (app killed, OOM crash, etc.)
       const isStale = Date.now() - session.startedAt > SESSION_TIMEOUT_MS;
       if (session.status === 'active' && isStale) {
         session.status = 'abnormal';
         session.endedAt = Date.now();
         session.durationMs = session.endedAt - session.startedAt;
 
-        // Report as an abnormal termination (Sentry: "abnormal" session)
         await this._sendToBackend('/monitoring/sessions/end', {
           sessionId: session.id,
           endedAt: new Date(session.endedAt).toISOString(),
@@ -476,10 +451,6 @@ class SessionMonitoringService {
 
   // ── Listeners ──────────────────────────────────────────────────────────────
 
-  /**
-   * Subscribe to session status changes.
-   * Returns an unsubscribe function.
-   */
   onStatusChange(listener: (status: SessionStatus) => void): () => void {
     this.statusListeners.push(listener);
     return () => {
@@ -487,10 +458,6 @@ class SessionMonitoringService {
     };
   }
 
-  /**
-   * Subscribe to crash-free rate alerts.
-   * Returns an unsubscribe function.
-   */
   onAlert(listener: (alert: AlertPayload) => void): () => void {
     this.alertListeners.push(listener);
     return () => {
@@ -500,57 +467,37 @@ class SessionMonitoringService {
 
   /**
    * Subscribe to session timeout warning events (fires 2 min before expiry).
-   * Receives a countdown payload updated every second.
-   * Returns an unsubscribe function.
+   * Delegates to InactivityTracker.
    */
-  onTimeoutWarning(listener: TimeoutWarningListener): () => void {
-    this.timeoutWarningListeners.push(listener);
-    return () => {
-      this.timeoutWarningListeners = this.timeoutWarningListeners.filter((l) => l !== listener);
-    };
+  onTimeoutWarning(listener: (payload: { secondsRemaining: number }) => void): () => void {
+    return this.inactivity.onWarning(listener);
   }
 
   /**
-   * Subscribe to session expiry (fires when the inactivity timeout has elapsed).
-   * Returns an unsubscribe function.
+   * Subscribe to session expiry events.
+   * Delegates to InactivityTracker.
    */
-  onTimeoutExpired(listener: TimeoutExpiredListener): () => void {
-    this.timeoutExpiredListeners.push(listener);
-    return () => {
-      this.timeoutExpiredListeners = this.timeoutExpiredListeners.filter((l) => l !== listener);
-    };
+  onTimeoutExpired(listener: () => void): () => void {
+    return this.inactivity.onExpired(listener);
   }
 
   /**
    * Extend the current session (call after the user taps "Stay logged in").
-   * Resets the inactivity timer and calls authService.refreshToken().
+   * Resets the inactivity timer and schedules a token refresh.
    */
   async extendSession(): Promise<void> {
     if (!this.currentSession) return;
-    this._resetInactivityTimer();
-    try {
-      const { refreshToken } = await import('./authService');
-      await refreshToken();
-    } catch {
-      // Non-fatal — session extension failure is not a crash
-    }
+    this.inactivity.reset();
+    await scheduleTokenRefresh();
   }
 
   // ── Biometric check timestamp tracking ───────────────────────────────────
 
-  /**
-   * Record the timestamp of the last successful biometric authentication.
-   * Used by screens to determine if re-authentication is needed.
-   */
   async setLastBiometricCheck(): Promise<void> {
     const now = Date.now().toString();
     await AsyncStorage.setItem(STORAGE_KEYS.LAST_BIOMETRIC_CHECK, now);
   }
 
-  /**
-   * Get the timestamp of the last biometric authentication.
-   * Returns the timestamp in ms since epoch, or 0 if never checked.
-   */
   async getLastBiometricCheck(): Promise<number> {
     try {
       const raw = await AsyncStorage.getItem(STORAGE_KEYS.LAST_BIOMETRIC_CHECK);
@@ -562,13 +509,9 @@ class SessionMonitoringService {
     }
   }
 
-  /**
-   * Check if the last biometric check is older than the given duration.
-   * @param durationMs - Duration in milliseconds (defaults to 5 minutes).
-   */
   async isBiometricCheckExpired(durationMs = 5 * 60 * 1000): Promise<boolean> {
     const lastCheck = await this.getLastBiometricCheck();
-    if (lastCheck === 0) return true; // Never checked
+    if (lastCheck === 0) return true;
     return Date.now() - lastCheck > durationMs;
   }
 
@@ -598,13 +541,9 @@ class SessionMonitoringService {
       data: partial.data,
     };
 
-    // Buffer locally
     await this._bufferEvent(event);
 
-    // Flush to backend (fire-and-forget — non-fatal if it fails)
-    this._flushEvents().catch(() => {
-      // Silently retain buffered events for next flush
-    });
+    this._flushEvents().catch(() => {});
   }
 
   private async _bufferEvent(event: SessionEvent): Promise<void> {
@@ -614,7 +553,6 @@ class SessionMonitoringService {
 
       events.push(event);
 
-      // Cap buffer size to avoid unbounded growth
       const trimmed = events.slice(-MAX_PENDING_EVENTS);
       await AsyncStorage.setItem(STORAGE_KEYS.PENDING_EVENTS, JSON.stringify(trimmed));
     } catch {
@@ -649,7 +587,6 @@ class SessionMonitoringService {
     try {
       await apiClient.post('/monitoring/crashes', report);
     } catch {
-      // Persist locally for retry on next launch
       try {
         const raw = await AsyncStorage.getItem(STORAGE_KEYS.CRASH_HISTORY);
         const history: CrashReport[] = raw ? JSON.parse(raw) : [];
@@ -684,70 +621,6 @@ class SessionMonitoringService {
 
   private _notifyAlertListeners(alert: AlertPayload): void {
     this.alertListeners.forEach((l) => l(alert));
-  }
-
-  private _getDefaultDevice(): DeviceMetadata {
-    return {
-      model: 'unknown',
-      os: 'unknown',
-      osVersion: 'unknown',
-      appVersion: config.app.version,
-      platform: 'unknown',
-    };
-  }
-
-  // ── Inactivity / warning timer helpers ────────────────────────────────────
-
-  private _clearTimers(): void {
-    if (this.inactivityTimer) {
-      clearTimeout(this.inactivityTimer);
-      this.inactivityTimer = null;
-    }
-    if (this.warningTimer) {
-      clearTimeout(this.warningTimer);
-      this.warningTimer = null;
-    }
-    if (this.warningCountdownInterval) {
-      clearInterval(this.warningCountdownInterval);
-      this.warningCountdownInterval = null;
-    }
-    this.warningActive = false;
-  }
-
-  private _resetInactivityTimer(): void {
-    if (!this.currentSession) return;
-    this._clearTimers();
-
-    const warningAt = SESSION_TIMEOUT_MS - WARNING_BEFORE_EXPIRY_MS;
-
-    // Schedule warning at (SESSION_TIMEOUT_MS - 2 minutes)
-    this.warningTimer = setTimeout(() => {
-      this._startWarningCountdown();
-    }, warningAt);
-  }
-
-  private _startWarningCountdown(): void {
-    if (!this.currentSession) return;
-    this.warningActive = true;
-    let secondsRemaining = Math.round(WARNING_BEFORE_EXPIRY_MS / 1000);
-
-    // Emit initial warning
-    this.timeoutWarningListeners.forEach((l) => l({ secondsRemaining }));
-
-    // Tick every second
-    this.warningCountdownInterval = setInterval(() => {
-      secondsRemaining -= 1;
-      this.timeoutWarningListeners.forEach((l) => l({ secondsRemaining }));
-
-      if (secondsRemaining <= 0) {
-        if (this.warningCountdownInterval) clearInterval(this.warningCountdownInterval);
-        this.warningCountdownInterval = null;
-        this.warningActive = false;
-        // Fire expiry — UI/caller should call authService.logout()
-        this.timeoutExpiredListeners.forEach((l) => l());
-        this.endSession('ended').catch(() => {});
-      }
-    }, 1000);
   }
 }
 

--- a/src/services/tokenRefreshScheduler.ts
+++ b/src/services/tokenRefreshScheduler.ts
@@ -1,0 +1,20 @@
+/**
+ * Token Refresh Scheduler
+ *
+ * Responsible for triggering a token refresh when a session is extended.
+ * Decoupled from session lifecycle so it can be tested in isolation.
+ */
+
+/**
+ * Attempt to refresh the auth token by dynamically importing authService.
+ * Non-fatal: refresh failures are swallowed so the caller's session
+ * extension logic is not disrupted.
+ */
+export async function scheduleTokenRefresh(): Promise<void> {
+  try {
+    const { refreshToken } = await import('./authService');
+    await refreshToken();
+  } catch {
+    // Non-fatal — session extension failure must not crash the app.
+  }
+}

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "noEmit": true
+  },
+  "include": ["src/services/blockchainIntegration.ts"]
+}


### PR DESCRIPTION
## Summary

This PR resolves two related frontend/architecture issues in the same service layer.

---

### Closes #604 — Refactor `sessionMonitoringService.ts`

The 500-line `SessionMonitoringService` class has been split into three focused, independently-testable modules:

| New module | Responsibility |
|---|---|
| `src/services/inactivityTracker.ts` | Session inactivity timer + pre-expiry warning countdown |
| `src/services/tokenRefreshScheduler.ts` | Token refresh on session extension |
| `src/services/deviceFingerprint.ts` | Device metadata construction and fallback default |

`sessionMonitoringService.ts` is now a thin **facade** that delegates to these modules. The **public API is 100% backwards-compatible** — all existing exports and method signatures are preserved, so `sessionMonitoringService.test.ts` passes without modification.

Each sub-module has its own isolated test file:
- `src/services/__tests__/inactivityTracker.test.ts`
- `src/services/__tests__/tokenRefreshScheduler.test.ts`
- `src/services/__tests__/deviceFingerprint.test.ts`

---

### Closes #601 — Add `strictNullChecks` to `blockchainIntegration.ts`

- Added `tsconfig.strict.json` — extends the root tsconfig with `strictNullChecks: true`, scoped to `blockchainIntegration.ts` only
- Replaced `NodeJS.Timeout` (requires `@types/node`) with `ReturnType<typeof setInterval>` — correct, dependency-free type
- Removed the `as unknown as NodeJS.Timeout` cast in `startVerificationPolling`
- Added `@remarks` JSDoc documenting the strict null check policy for this file: all nullable types are explicitly annotated; `!` assertions are forbidden without an explanatory comment
- All existing `blockchainIntegration.test.ts` tests pass unchanged

---

### Testing

- `sessionMonitoringService.test.ts` — all existing tests pass (facade preserves full API)
- `blockchainIntegration.test.ts` — all existing tests pass
- New isolated tests for each extracted sub-module

Closes #604
Closes #601