### PR TITLE
Add vet/clinic model, medication scheduling types, analytics + QR APIs

### DIFF
--- a/src/models/Medication.ts
+++ b/src/models/Medication.ts
@@ -13,6 +13,40 @@ export interface PharmacyInfo {
 export type MedicationStatus = 'active' | 'paused' | 'completed' | 'discontinued';
 
 /**
+ * How often a medication is administered. Complements the numeric `frequency`
+ * field (hours between doses) with a human-friendly, categorical cadence.
+ */
+export enum FrequencyType {
+  DAILY = 'DAILY',
+  TWICE_DAILY = 'TWICE_DAILY',
+  WEEKLY = 'WEEKLY',
+  BIWEEKLY = 'BIWEEKLY',
+  MONTHLY = 'MONTHLY',
+  AS_NEEDED = 'AS_NEEDED',
+  CUSTOM = 'CUSTOM',
+}
+
+/**
+ * Reminder configuration for a medication. Drives the local notification
+ * schedule so the owner is prompted at each dose time.
+ */
+export interface ReminderSchedule {
+  /** Whether reminders are active for this medication. */
+  enabled: boolean;
+  /** Local times of day to remind, in 24-hour `HH:mm` format. */
+  times: string[];
+  /**
+   * Days of the week to remind on (0 = Sunday … 6 = Saturday). Omit for every
+   * day / cadence-driven schedules.
+   */
+  daysOfWeek?: number[];
+  /** Minutes before the dose time to fire the reminder. Defaults to 0. */
+  leadTimeMinutes?: number;
+  /** IANA timezone the reminder times are expressed in (e.g. 'Africa/Lagos'). */
+  timezone?: string;
+}
+
+/**
  * Refill status derived from current supply and dosage schedule.
  * - 'ok'       : supply will last > 7 days
  * - 'warning'  : supply will run out in 4-7 days (7-day reminder window)
@@ -28,8 +62,14 @@ export interface Medication {
   name: string;
   dosage: string;
   frequency: number; // hours between doses
+  /** Categorical cadence (DAILY, WEEKLY, AS_NEEDED, …) complementing `frequency`. */
+  frequencyType?: FrequencyType;
   startDate: string; // ISO date string
   endDate?: string; // ISO date string
+  /** Reminder schedule driving dose-time notifications. */
+  reminders?: ReminderSchedule;
+  /** Name or ID of the prescribing veterinarian. */
+  prescribedBy?: string;
   instructions?: string;
   prescriberInfo?: PrescriberInfo;
   pharmacyInfo?: PharmacyInfo;

--- a/src/models/Vet.ts
+++ b/src/models/Vet.ts
@@ -1,0 +1,152 @@
+/**
+ * Veterinarian & Clinic data models for the PetChain mobile app.
+ *
+ * Captures contact information, location, and specialisations for vets and the
+ * clinics they practise at. Kept dependency-free so it can be shared across
+ * services, screens, and offline caches.
+ */
+
+// ─── Shared value types ───────────────────────────────────────────────────────
+
+/** Contact details shared by veterinarians and clinics. */
+export interface ContactInfo {
+  phone?: string;
+  email?: string;
+  website?: string;
+}
+
+/** Geographic coordinates (WGS-84 decimal degrees). */
+export interface Coordinates {
+  latitude: number;
+  longitude: number;
+}
+
+/** Postal address for a clinic. */
+export interface ClinicAddress {
+  street?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  country?: string;
+}
+
+/** Common veterinary areas of specialisation. */
+export type VetSpecialisation =
+  | 'general_practice'
+  | 'surgery'
+  | 'dentistry'
+  | 'dermatology'
+  | 'cardiology'
+  | 'oncology'
+  | 'orthopedics'
+  | 'ophthalmology'
+  | 'internal_medicine'
+  | 'emergency_critical_care'
+  | 'exotic_animals'
+  | 'behaviour'
+  | 'nutrition'
+  | 'other';
+
+export type DayOfWeek =
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday'
+  | 'sunday';
+
+/** Opening/closing time for a single day, in 24-hour `HH:mm` format. */
+export interface DayHours {
+  open: string; // 'HH:mm'
+  close: string; // 'HH:mm'
+}
+
+/**
+ * Weekly opening hours. A day mapped to `'closed'` (or omitted) is treated as
+ * not open that day.
+ */
+export type ClinicHours = Partial<Record<DayOfWeek, DayHours | 'closed'>>;
+
+// ─── Veterinarian ─────────────────────────────────────────────────────────────
+
+export interface Vet {
+  id: string;
+  name: string;
+  /** Primary area of specialisation. */
+  specialisation: VetSpecialisation;
+  /** Additional specialisations, if the vet covers more than one area. */
+  specialisations?: VetSpecialisation[];
+  /** Clinic the vet primarily practises at. */
+  clinicId: string;
+  /** Professional licence / registration number. */
+  licenseNumber: string;
+  /** How to reach the vet directly. */
+  contact: ContactInfo;
+  yearsOfExperience?: number;
+  photoUrl?: string;
+  bio?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** Alias for callers that prefer the fuller noun. */
+export type Veterinarian = Vet;
+
+// ─── Clinic ───────────────────────────────────────────────────────────────────
+
+export interface Clinic {
+  id: string;
+  name: string;
+  address: ClinicAddress;
+  coordinates: Coordinates;
+  phone: string;
+  /** Weekly opening hours keyed by day of week. */
+  hours: ClinicHours;
+  /** Whether the clinic offers emergency / after-hours care. */
+  emergencyAvailable: boolean;
+  contact?: ContactInfo;
+  /** IDs of vets that practise at this clinic. */
+  vetIds?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+// ─── Factories ────────────────────────────────────────────────────────────────
+
+/**
+ * Safely build a {@link Vet} from partial/raw data, applying sensible defaults
+ * for required fields. Mirrors the factory convention used by other models.
+ */
+export const createVet = (data: Partial<Vet>): Vet => ({
+  id: data.id ?? '',
+  name: data.name ?? 'Unknown Vet',
+  specialisation: data.specialisation ?? 'general_practice',
+  specialisations: data.specialisations,
+  clinicId: data.clinicId ?? '',
+  licenseNumber: data.licenseNumber ?? '',
+  contact: data.contact ?? {},
+  yearsOfExperience: data.yearsOfExperience,
+  photoUrl: data.photoUrl,
+  bio: data.bio,
+  createdAt: data.createdAt,
+  updatedAt: data.updatedAt,
+});
+
+/**
+ * Safely build a {@link Clinic} from partial/raw data, applying sensible
+ * defaults for required fields.
+ */
+export const createClinic = (data: Partial<Clinic>): Clinic => ({
+  id: data.id ?? '',
+  name: data.name ?? 'Unknown Clinic',
+  address: data.address ?? {},
+  coordinates: data.coordinates ?? { latitude: 0, longitude: 0 },
+  phone: data.phone ?? '',
+  hours: data.hours ?? {},
+  emergencyAvailable: data.emergencyAvailable ?? false,
+  contact: data.contact,
+  vetIds: data.vetIds,
+  createdAt: data.createdAt,
+  updatedAt: data.updatedAt,
+});

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -1,6 +1,6 @@
 import apiClient from './apiClient';
 
-export type EventType = 'screen_view' | 'feature_usage' | 'error';
+export type EventType = 'screen_view' | 'feature_usage' | 'error' | 'custom';
 
 export interface AnalyticsEvent {
   type: EventType;
@@ -9,21 +9,163 @@ export interface AnalyticsEvent {
   timestamp: number;
 }
 
-async function track(type: EventType, name: string, meta?: Record<string, unknown>): Promise<void> {
-  const event: AnalyticsEvent = { type, name, meta, timestamp: Date.now() };
+/** Non-PII user attributes attached to batched events (e.g. plan tier, locale). */
+export type UserProperties = Record<string, string | number | boolean>;
+
+// ─── Batching config ──────────────────────────────────────────────────────────
+
+/** Flush automatically once this many events are queued. */
+const BATCH_SIZE = 20;
+/** Or flush after this long, whichever comes first. */
+const FLUSH_INTERVAL_MS = 30_000;
+const BATCH_ENDPOINT = '/analytics/events';
+
+// ─── Privacy: PII scrubbing (no personally-identifiable data leaves the device) ─
+
+/**
+ * Property keys that must never be sent to analytics. Matching is
+ * case-insensitive and substring-based so `userEmail`, `ownerPhone`, etc. are
+ * all caught.
+ */
+const PII_KEY_PATTERNS = [
+  'email',
+  'phone',
+  'password',
+  'token',
+  'secret',
+  'address',
+  'name',
+  'ssn',
+  'dob',
+  'birth',
+  'lat',
+  'lng',
+  'latitude',
+  'longitude',
+  'ip',
+  'location',
+  'card',
+];
+
+const isPiiKey = (key: string): boolean => {
+  const lower = key.toLowerCase();
+  return PII_KEY_PATTERNS.some((pattern) => lower.includes(pattern));
+};
+
+/**
+ * Remove any property whose key looks like PII. Returns `undefined` when there
+ * is nothing safe left to send, so empty objects are not transmitted.
+ */
+const scrubPii = <T extends Record<string, unknown>>(
+  meta?: T,
+): Record<string, unknown> | undefined => {
+  if (!meta) return undefined;
+  const safe: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if (isPiiKey(key)) continue;
+    safe[key] = value;
+  }
+  return Object.keys(safe).length > 0 ? safe : undefined;
+};
+
+// ─── Queue state ──────────────────────────────────────────────────────────────
+
+let queue: AnalyticsEvent[] = [];
+let userProperties: UserProperties = {};
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+const scheduleFlush = (): void => {
+  if (flushTimer) return;
+  flushTimer = setTimeout(() => {
+    void flush();
+  }, FLUSH_INTERVAL_MS);
+};
+
+/**
+ * Send all queued events to the backend in a single batch. Best-effort: on
+ * failure the events are re-queued so nothing is silently dropped.
+ */
+export async function flush(): Promise<void> {
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  if (queue.length === 0) return;
+
+  const batch = queue;
+  queue = [];
+
   try {
-    await apiClient.post('/analytics/events', event);
+    await apiClient.post(BATCH_ENDPOINT, {
+      events: batch,
+      userProperties,
+    });
   } catch {
-    // best-effort — never throw
+    // Re-queue so events survive transient failures; never throw to callers.
+    queue = batch.concat(queue);
+    scheduleFlush();
   }
 }
 
+const enqueue = (type: EventType, name: string, meta?: Record<string, unknown>): void => {
+  queue.push({ type, name, meta: scrubPii(meta), timestamp: Date.now() });
+  if (queue.length >= BATCH_SIZE) {
+    void flush();
+  } else {
+    scheduleFlush();
+  }
+};
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/** Track an arbitrary custom event with optional (PII-free) properties. */
+export const trackEvent = (name: string, properties?: Record<string, unknown>): void =>
+  enqueue('custom', name, properties);
+
+/** Track a screen/route view. */
+export const trackScreenView = (screenName: string, properties?: Record<string, unknown>): void =>
+  enqueue('screen_view', screenName, properties);
+
+/** Track a handled/unhandled error event. */
+export const trackError = (error: unknown, properties?: Record<string, unknown>): void => {
+  const message = error instanceof Error ? error.message : String(error);
+  enqueue('error', message, properties);
+};
+
+/**
+ * Merge non-PII attributes onto the current user. PII keys are stripped before
+ * storage so they can never be attached to future batches.
+ */
+export const setUserProperties = (properties: UserProperties): void => {
+  const safe = scrubPii(properties) as UserProperties | undefined;
+  if (safe) {
+    userProperties = { ...userProperties, ...safe };
+  }
+};
+
+/** Clear all in-memory user properties (e.g. on logout). */
+export const resetUserProperties = (): void => {
+  userProperties = {};
+};
+
+/**
+ * Backwards-compatible object API. Existing callers use
+ * `analyticsService.screenView` / `.featureUsed` / `.error`; the newer
+ * `track*` helpers are exposed here too for convenience.
+ */
 export const analyticsService = {
-  screenView: (screenName: string) => track('screen_view', screenName),
+  screenView: (screenName: string, meta?: Record<string, unknown>) =>
+    trackScreenView(screenName, meta),
   featureUsed: (featureName: string, meta?: Record<string, unknown>) =>
-    track('feature_usage', featureName, meta),
+    enqueue('feature_usage', featureName, meta),
   error: (errorMessage: string, meta?: Record<string, unknown>) =>
-    track('error', errorMessage, meta),
+    enqueue('error', errorMessage, meta),
+  trackEvent,
+  trackScreenView,
+  trackError,
+  setUserProperties,
+  resetUserProperties,
+  flush,
 };
 
 export default analyticsService;

--- a/src/services/qrCodeService.ts
+++ b/src/services/qrCodeService.ts
@@ -1,6 +1,7 @@
 import CryptoJS from 'crypto-js';
 import { Share } from 'react-native';
 
+import apiClient from './apiClient';
 import { getItem, removeItem, setItem } from './localDB';
 import type { Pet } from '../models/Pet';
 import {
@@ -367,3 +368,75 @@ export const scanQRCode = async (qrData: string): Promise<QRScanResult> => {
 export const validateQRCode = (
   qrData: string,
 ): Promise<{ valid: boolean; petId?: string; error?: string }> => scanQRCode(qrData);
+
+// ─── Canonical named API (issue #794) ─────────────────────────────────────────
+
+/**
+ * Generate a QR payload string for a pet.
+ *
+ * Thin, explicitly-named wrapper over {@link generatePetQRCode} so callers can
+ * use the canonical `generateQRCode` name. Honours expiry / one-time-use
+ * options and persists the payload to the offline cache.
+ */
+export const generateQRCode = (pet: Pet, options: QRCodeOptions = {}): Promise<string> =>
+  generatePetQRCode(pet, options);
+
+/**
+ * Decode a raw QR string into its typed payload without running the full
+ * validation pipeline. Throws a descriptive error on malformed input.
+ *
+ * Use {@link scanQRCode} / {@link validateQRCode} when you also need checksum,
+ * expiry, revocation, and one-time-use enforcement.
+ */
+export const decodeQRPayload = (qrData: string): PetQRData => parseQRCodeData(qrData);
+
+// ─── Backend integration ──────────────────────────────────────────────────────
+
+/** Server-issued QR record for a pet. */
+export interface RemoteQRData {
+  /** Encoded QR payload string, ready to render. */
+  qrData: string;
+  /** Unix ms timestamp after which the code is invalid. */
+  expiresAt?: number;
+  /** Server-side revocation / usage token. */
+  token?: string;
+}
+
+/**
+ * Fetch a server-issued QR code for a pet from the backend. Falls back to the
+ * offline cache when the request fails so scanning still works offline.
+ *
+ * @returns the encoded QR payload string, or `null` if none is available.
+ */
+export const fetchPetQRCode = async (petId: string): Promise<string | null> => {
+  if (!PET_ID_REGEX.test(petId)) {
+    throw new Error('fetchPetQRCode failed: invalid pet ID format');
+  }
+
+  try {
+    const response = await apiClient.get<{ data: RemoteQRData }>(
+      `/pets/${encodeURIComponent(petId)}/qr`,
+    );
+    const remote = response.data?.data;
+    if (remote?.qrData) {
+      await cacheQRPayload(petId, remote.qrData);
+      return remote.qrData;
+    }
+  } catch {
+    // Network / server error — fall back to any cached payload below.
+  }
+
+  return getOfflineQRCode(petId);
+};
+
+/**
+ * Register a locally-generated QR token with the backend so it can be revoked
+ * or usage-tracked server-side. Best-effort — never throws.
+ */
+export const syncQRToken = async (petId: string, token: string): Promise<void> => {
+  try {
+    await apiClient.post(`/pets/${encodeURIComponent(petId)}/qr/tokens`, { token });
+  } catch {
+    // best-effort — server sync is optional; local token state remains valid.
+  }
+};


### PR DESCRIPTION
## Summary

Implements four data-model / service issues for the mobile app. All changes are additive and backward-compatible — existing importers of `Medication`, `analyticsService`, and `qrCodeService` continue to compile unchanged.

Closes #787
Closes #786
Closes #797
Closes #794

## Changes

### `src/models/Vet.ts` (new) — #787
- `Vet` interface: `id`, `name`, `specialisation`, `clinicId`, `licenseNumber`, `contact` (+ optional `specialisations[]`, experience, photo, bio).
- `Clinic` interface: `id`, `name`, `address`, `coordinates`, `phone`, `hours`, `emergencyAvailable`.
- Supporting types: `ContactInfo`, `Coordinates`, `ClinicAddress`, `VetSpecialisation`, `ClinicHours`, plus `createVet` / `createClinic` factories (matching the existing `createPet` convention).

### `src/models/Medication.ts` — #786
- Added `FrequencyType` enum (`DAILY`, `TWICE_DAILY`, `WEEKLY`, `BIWEEKLY`, `MONTHLY`, `AS_NEEDED`, `CUSTOM`).
- Added `ReminderSchedule` type.
- Added optional `reminders`, `prescribedBy`, and `frequencyType` fields to `Medication` (existing numeric `frequency` and all current fields preserved).

### `src/services/analyticsService.ts` — #797
- Added `trackEvent`, `trackScreenView`, `trackError`, `setUserProperties`.
- Events are queued and flushed in batches (size- and time-based).
- Privacy-compliant: PII-shaped keys are scrubbed from event metadata and user properties before anything is sent.
- Existing `analyticsService.screenView` / `.featureUsed` / `.error` API kept intact.

### `src/services/qrCodeService.ts` — #794
- Added canonical `generateQRCode` and `decodeQRPayload` named exports (`scanQRCode` / `validateQRCode` already existed).
- Added backend integration: `fetchPetQRCode` (server QR with offline-cache fallback) and `syncQRToken`.
- Expired / invalid / revoked QR handling already covered by the existing scan pipeline.

## Verification
- `npx tsc --noEmit` — no new type errors in the changed files (pre-existing errors in unrelated `blockchainService` / `nutritionService` / `stellarAssetService` are untouched by this PR).
- `eslint` and `prettier --check` pass on all changed files.