### PR TITLE
feat: add notification types, date utils, validators, and string utils (#805-#808)

### DIFF
--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,0 +1,190 @@
+/**
+ * Notification TypeScript types for PetChain Mobile App.
+ *
+ * Covers push notifications, local notifications, permission status,
+ * and Android/iOS channel configuration.
+ */
+
+// ─── Permission Status ────────────────────────────────────────────────────────
+
+/**
+ * Notification permission status returned by the OS or expo-notifications.
+ *
+ * - `granted`    — user has allowed notifications
+ * - `denied`     — user has explicitly denied notifications
+ * - `undetermined` — user has not been asked yet
+ */
+export type NotificationPermissionStatus = 'granted' | 'denied' | 'undetermined';
+
+// ─── Push Notification Payload ────────────────────────────────────────────────
+
+/**
+ * Data payload delivered inside a remote (push) notification.
+ * Mirrors the structure sent by the backend push service and decoded on device.
+ */
+export interface PushNotificationPayload {
+  /** Opaque identifier for this notification instance. */
+  notificationId: string;
+
+  /**
+   * Category used to route the notification to the correct handler and UI.
+   * Matches `NotificationCategory` in notificationStore.ts.
+   */
+  category: 'medication' | 'appointment' | 'sos' | 'system';
+
+  /** Short, human-readable heading shown in the notification tray. */
+  title: string;
+
+  /** Body copy shown below the title. */
+  body: string;
+
+  /**
+   * Optional deep-link screen name and params.
+   * Consumed by notificationNavigation.ts → resolveNavPayload.
+   */
+  screen?: string;
+  screenParams?: Record<string, unknown>;
+
+  /** Pet identifier the notification relates to, if any. */
+  petId?: string;
+
+  /** Medication identifier, if this is a medication reminder. */
+  medicationId?: string;
+
+  /** Appointment identifier, if this is an appointment reminder. */
+  appointmentId?: string;
+
+  /** Arbitrary extra fields forwarded from the server. */
+  [key: string]: unknown;
+}
+
+// ─── Local Notification Options ───────────────────────────────────────────────
+
+/**
+ * Options used when scheduling a local notification via expo-notifications.
+ */
+export interface LocalNotificationOptions {
+  /** Notification title displayed in the system tray. */
+  title: string;
+
+  /** Main body text of the notification. */
+  body: string;
+
+  /**
+   * Optional subtitle (iOS only) shown between title and body.
+   */
+  subtitle?: string;
+
+  /** Arbitrary data attached to the notification and available on tap. */
+  data?: Record<string, unknown>;
+
+  /**
+   * ISO 8601 date-time string for when the notification should fire.
+   * If omitted the notification is shown immediately.
+   */
+  scheduledTime?: string;
+
+  /**
+   * Number of seconds from now after which the notification fires.
+   * Takes precedence over `scheduledTime` when both are provided.
+   */
+  secondsFromNow?: number;
+
+  /**
+   * Identifier of an Android notification channel.
+   * Must match an `AndroidNotificationChannelConfig.channelId` registered at app start.
+   */
+  channelId?: string;
+
+  /** Sound override for this notification. `true` = default system sound. */
+  sound?: boolean | string;
+
+  /** Notification category identifier used to attach action buttons. */
+  categoryIdentifier?: string;
+
+  /**
+   * iOS badge count to apply when the notification is delivered.
+   * Pass `0` to clear the badge.
+   */
+  badge?: number;
+
+  /**
+   * Android priority level.
+   * @see https://developer.android.com/reference/android/app/NotificationManager
+   */
+  priority?: 'default' | 'high' | 'max' | 'low' | 'min';
+}
+
+// ─── Android Channel Configuration ───────────────────────────────────────────
+
+/**
+ * Android notification channel configuration.
+ * Channels must be created before notifications can be posted on Android 8+.
+ *
+ * @see https://developer.android.com/training/notify-user/channels
+ */
+export interface AndroidNotificationChannelConfig {
+  /** Unique channel identifier referenced by `LocalNotificationOptions.channelId`. */
+  channelId: string;
+
+  /** Human-readable name displayed in the system notification settings. */
+  name: string;
+
+  /** Optional extended description shown in system settings. */
+  description?: string;
+
+  /**
+   * Importance level controls how intrusively the channel interrupts the user.
+   *
+   * - `max`     — heads-up notification + sound + vibration
+   * - `high`    — sound + vibration; appears in status bar
+   * - `default` — sound; no heads-up
+   * - `low`     — no sound or vibration
+   * - `min`     — silent; collapsed in shade
+   */
+  importance: 'max' | 'high' | 'default' | 'low' | 'min';
+
+  /** Whether to play a sound when a notification is posted to this channel. */
+  enableSound?: boolean;
+
+  /**
+   * Sound file name (without extension) from `android/app/src/main/res/raw/`.
+   * Falls back to the default notification sound when not specified.
+   */
+  soundName?: string;
+
+  /** Whether vibration is enabled for this channel. */
+  enableVibration?: boolean;
+
+  /**
+   * Custom vibration pattern in milliseconds: [delay, on, off, on, off, …].
+   * E.g. `[0, 250, 250, 250]` — wait 0 ms, vibrate 250 ms, pause 250 ms, vibrate 250 ms.
+   */
+  vibrationPattern?: number[];
+
+  /** Whether to show a badge on the app icon when a notification is in this channel. */
+  showBadge?: boolean;
+
+  /** Whether the notification light (LED) is enabled. */
+  enableLights?: boolean;
+
+  /** Hex colour string for the notification LED (e.g. `'#4CAF50'`). */
+  lightColor?: string;
+}
+
+// ─── Preset channel IDs ───────────────────────────────────────────────────────
+
+/**
+ * Well-known channel IDs used throughout the app.
+ * Register each with `AndroidNotificationChannelConfig` at app startup.
+ */
+export const NOTIFICATION_CHANNEL_IDS = {
+  MEDICATION_REMINDERS: 'medication_reminders',
+  APPOINTMENT_REMINDERS: 'appointment_reminders',
+  HEALTH_ALERTS: 'health_alerts',
+  EMERGENCY_SOS: 'emergency_sos',
+  GENERAL: 'general',
+} as const;
+
+export type NotificationChannelId =
+  (typeof NOTIFICATION_CHANNEL_IDS)[keyof typeof NOTIFICATION_CHANNEL_IDS];

--- a/src/utils/__tests__/dateUtils.test.ts
+++ b/src/utils/__tests__/dateUtils.test.ts
@@ -1,0 +1,213 @@
+import {
+  formatDate,
+  toRelativeTime,
+  isExpired,
+  addDays,
+  addWeeks,
+  addMinutes,
+  startOfDay,
+  endOfDay,
+  isSameDay,
+  differenceInDays,
+} from '../dateUtils';
+
+// ─── formatDate ───────────────────────────────────────────────────────────────
+
+describe('formatDate', () => {
+  const DATE = '2025-06-15T12:00:00.000Z';
+
+  it('returns ISO string by default', () => {
+    expect(formatDate(DATE)).toBe(new Date(DATE).toISOString());
+  });
+
+  it('returns ISO string when format="iso"', () => {
+    expect(formatDate(DATE, 'iso')).toBe(new Date(DATE).toISOString());
+  });
+
+  it('formats with "short" preset', () => {
+    const result = formatDate(DATE, 'short', 'en-US');
+    expect(result).toMatch(/Jun/);
+    expect(result).toMatch(/2025/);
+  });
+
+  it('formats with "long" preset', () => {
+    const result = formatDate(DATE, 'long', 'en-US');
+    expect(result).toMatch(/June/);
+    expect(result).toMatch(/2025/);
+  });
+
+  it('formats with "time" preset', () => {
+    const result = formatDate(DATE, 'time', 'en-US');
+    // time string contains colon
+    expect(result).toMatch(/:/);
+  });
+
+  it('formats with "datetime" preset', () => {
+    const result = formatDate(DATE, 'datetime', 'en-US');
+    expect(result).toMatch(/2025/);
+    expect(result).toMatch(/:/);
+  });
+
+  it('accepts a custom Intl.DateTimeFormatOptions object', () => {
+    const result = formatDate(DATE, { weekday: 'long' }, 'en-US');
+    // 2025-06-15 is a Sunday
+    expect(result).toBe('Sunday');
+  });
+
+  it('accepts a Date object', () => {
+    const d = new Date('2025-01-01T00:00:00.000Z');
+    expect(formatDate(d, 'iso')).toBe(d.toISOString());
+  });
+
+  it('throws for an invalid date string', () => {
+    expect(() => formatDate('not-a-date')).toThrow();
+  });
+});
+
+// ─── toRelativeTime ───────────────────────────────────────────────────────────
+
+describe('toRelativeTime', () => {
+  it('returns a string for a past date', () => {
+    const past = new Date(Date.now() - 2 * 60 * 60 * 1_000); // 2 hours ago
+    const result = toRelativeTime(past, 'en-US');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('returns a string for a future date', () => {
+    const future = new Date(Date.now() + 24 * 60 * 60 * 1_000); // 1 day from now
+    const result = toRelativeTime(future, 'en-US');
+    expect(typeof result).toBe('string');
+  });
+
+  it.each([
+    [30_000, 'second'], // 30 seconds
+    [2 * 60_000, 'minute'], // 2 minutes
+    [3 * 3_600_000, 'hour'], // 3 hours
+    [2 * 86_400_000, 'day'], // 2 days
+    [45 * 86_400_000, 'month'], // ~1.5 months
+    [2 * 31_536_000_000, 'year'], // 2 years
+  ])('uses correct unit for %dms offset', (offsetMs, expectedUnit) => {
+    const past = new Date(Date.now() - offsetMs);
+    const result = toRelativeTime(past, 'en-US');
+    expect(result).toMatch(new RegExp(expectedUnit, 'i'));
+  });
+});
+
+// ─── isExpired ────────────────────────────────────────────────────────────────
+
+describe('isExpired', () => {
+  it('returns true for a past date', () => {
+    expect(isExpired('2020-01-01')).toBe(true);
+  });
+
+  it('returns false for a future date', () => {
+    expect(isExpired('2099-12-31')).toBe(false);
+  });
+
+  it('accepts a Date object', () => {
+    expect(isExpired(new Date(Date.now() - 1_000))).toBe(true);
+  });
+});
+
+// ─── addDays ──────────────────────────────────────────────────────────────────
+
+describe('addDays', () => {
+  it.each([
+    ['2025-01-01', 7, '2025-01-08'],
+    ['2025-01-08', -3, '2025-01-05'],
+    ['2024-02-28', 1, '2024-02-29'], // leap year
+    ['2025-12-31', 1, '2026-01-01'],
+  ])('addDays(%s, %d) date portion equals %s', (input, days, expected) => {
+    const result = addDays(input, days);
+    const iso = result.toISOString().slice(0, 10);
+    expect(iso).toBe(expected);
+  });
+
+  it('returns a new Date without mutating input', () => {
+    const original = new Date('2025-01-01T00:00:00.000Z');
+    const result = addDays(original, 5);
+    expect(original.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+    expect(result).not.toBe(original);
+  });
+});
+
+// ─── addWeeks ─────────────────────────────────────────────────────────────────
+
+describe('addWeeks', () => {
+  it.each([
+    ['2025-01-01', 1, '2025-01-08'],
+    ['2025-01-01', 2, '2025-01-15'],
+    ['2025-01-01', -1, '2024-12-25'],
+  ])('addWeeks(%s, %d) date portion equals %s', (input, weeks, expected) => {
+    const iso = addWeeks(input, weeks).toISOString().slice(0, 10);
+    expect(iso).toBe(expected);
+  });
+});
+
+// ─── addMinutes ───────────────────────────────────────────────────────────────
+
+describe('addMinutes', () => {
+  it('adds positive minutes', () => {
+    const base = new Date('2025-01-01T12:00:00.000Z');
+    const result = addMinutes(base, 30);
+    expect(result.toISOString()).toBe('2025-01-01T12:30:00.000Z');
+  });
+
+  it('subtracts minutes when negative', () => {
+    const base = new Date('2025-01-01T12:00:00.000Z');
+    const result = addMinutes(base, -15);
+    expect(result.toISOString()).toBe('2025-01-01T11:45:00.000Z');
+  });
+});
+
+// ─── startOfDay / endOfDay ────────────────────────────────────────────────────
+
+describe('startOfDay', () => {
+  it('sets time to midnight', () => {
+    const d = new Date('2025-06-15T14:30:45.123');
+    const result = startOfDay(d);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+    expect(result.getDate()).toBe(15);
+  });
+});
+
+describe('endOfDay', () => {
+  it('sets time to 23:59:59.999', () => {
+    const d = new Date('2025-06-15T00:00:00');
+    const result = endOfDay(d);
+    expect(result.getHours()).toBe(23);
+    expect(result.getMinutes()).toBe(59);
+    expect(result.getSeconds()).toBe(59);
+    expect(result.getMilliseconds()).toBe(999);
+  });
+});
+
+// ─── isSameDay ────────────────────────────────────────────────────────────────
+
+describe('isSameDay', () => {
+  it('returns true for two dates on the same local day', () => {
+    const a = new Date(2025, 5, 15, 0, 0, 0);
+    const b = new Date(2025, 5, 15, 23, 59, 59);
+    expect(isSameDay(a, b)).toBe(true);
+  });
+
+  it('returns false for dates on different days', () => {
+    expect(isSameDay('2025-01-01', '2025-01-02')).toBe(false);
+  });
+});
+
+// ─── differenceInDays ─────────────────────────────────────────────────────────
+
+describe('differenceInDays', () => {
+  it.each([
+    ['2025-01-01', '2025-01-08', 7],
+    ['2025-01-08', '2025-01-01', -7],
+    ['2025-01-01', '2025-01-01', 0],
+  ])('differenceInDays(%s, %s) = %d', (start, end, expected) => {
+    expect(differenceInDays(start, end)).toBe(expected);
+  });
+});

--- a/src/utils/__tests__/stringUtils.test.ts
+++ b/src/utils/__tests__/stringUtils.test.ts
@@ -1,0 +1,234 @@
+import {
+  capitalise,
+  toTitleCase,
+  truncate,
+  maskEmail,
+  maskPhone,
+  slugify,
+  stripHtml,
+  initials,
+  padStart,
+  padEnd,
+  toCamelCase,
+} from '../stringUtils';
+
+// ─── capitalise ───────────────────────────────────────────────────────────────
+
+describe('capitalise', () => {
+  it.each([
+    ['hello world', 'Hello world'],
+    ['HELLO', 'HELLO'],
+    ['a', 'A'],
+    ['already Capitalised', 'Already Capitalised'],
+  ])('capitalise(%s) = %s', (input, expected) => {
+    expect(capitalise(input)).toBe(expected);
+  });
+
+  it.each(['', null as unknown as string, undefined as unknown as string])(
+    'returns empty string for falsy: %s',
+    (v) => {
+      expect(capitalise(v)).toBe('');
+    },
+  );
+});
+
+// ─── toTitleCase ──────────────────────────────────────────────────────────────
+
+describe('toTitleCase', () => {
+  it.each([
+    ['the quick brown fox', 'The Quick Brown Fox'],
+    ['hello world', 'Hello World'],
+    ['UPPER CASE', 'Upper Case'],
+    ['single', 'Single'],
+    ['', ''],
+  ])('toTitleCase(%s) = %s', (input, expected) => {
+    expect(toTitleCase(input)).toBe(expected);
+  });
+});
+
+// ─── truncate ─────────────────────────────────────────────────────────────────
+
+describe('truncate', () => {
+  it('does not truncate strings within the limit', () => {
+    expect(truncate('Hello', 10)).toBe('Hello');
+  });
+
+  it('truncates and appends default ellipsis (…)', () => {
+    expect(truncate('Hello, world!', 8)).toBe('Hello, …');
+  });
+
+  it('uses a custom ellipsis', () => {
+    expect(truncate('Hello, world!', 9, '...')).toBe('Hello,...');
+  });
+
+  it('handles maxLen ≤ 0', () => {
+    expect(truncate('Hello', 0)).toBe('');
+    expect(truncate('Hello', -5)).toBe('');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(truncate('', 10)).toBe('');
+  });
+
+  it('handles maxLen shorter than the ellipsis itself', () => {
+    const result = truncate('Hello, world!', 1, '...');
+    expect(result.length).toBeLessThanOrEqual(1);
+  });
+
+  it('truncates exactly at the boundary', () => {
+    const str = 'abcde';
+    expect(truncate(str, 5)).toBe('abcde'); // no truncation at exact length
+    expect(truncate(str, 4)).toBe('abc…'); // one character over
+  });
+});
+
+// ─── maskEmail ────────────────────────────────────────────────────────────────
+
+describe('maskEmail', () => {
+  it.each([
+    ['alice@example.com', 'a****@example.com'],
+    ['ab@example.com', 'a*@example.com'],
+    ['user+tag@host.org', 'u*******@host.org'],
+  ])('maskEmail(%s) = %s', (input, expected) => {
+    expect(maskEmail(input)).toBe(expected);
+  });
+
+  it('returns unchanged string if no @ is found', () => {
+    expect(maskEmail('notanemail')).toBe('notanemail');
+  });
+
+  it('returns unchanged when local part is 1 character', () => {
+    expect(maskEmail('a@example.com')).toBe('a@example.com');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(maskEmail('')).toBe('');
+  });
+});
+
+// ─── maskPhone ────────────────────────────────────────────────────────────────
+
+describe('maskPhone', () => {
+  it('shows only last 4 digits', () => {
+    // '+1 (555) 123-4567' → digits: '15551234567' (11 digits) → 7 stars + last 4
+    expect(maskPhone('+1 (555) 123-4567')).toBe('*******4567');
+  });
+
+  it('strips non-digit characters before masking', () => {
+    expect(maskPhone('07700 900 123')).toBe('*******0123');
+  });
+
+  it('returns the number unchanged when ≤ 4 digits', () => {
+    expect(maskPhone('1234')).toBe('1234');
+    expect(maskPhone('123')).toBe('123');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(maskPhone('')).toBe('');
+  });
+});
+
+// ─── slugify ──────────────────────────────────────────────────────────────────
+
+describe('slugify', () => {
+  it.each([
+    ['Hello World!', 'hello-world'],
+    ['Café au lait', 'cafe-au-lait'],
+    ['  multiple   spaces ', 'multiple-spaces'],
+    ['PetChain -- App', 'petchain-app'],
+    ['Already-a-slug', 'already-a-slug'],
+    ['Ñoño', 'nono'],
+    ['', ''],
+  ])('slugify(%s) = %s', (input, expected) => {
+    expect(slugify(input)).toBe(expected);
+  });
+
+  it('does not start or end with a hyphen', () => {
+    const result = slugify('  !test! ');
+    expect(result).not.toMatch(/^-|-$/);
+  });
+});
+
+// ─── stripHtml ────────────────────────────────────────────────────────────────
+
+describe('stripHtml', () => {
+  it.each([
+    ['<p>Hello <strong>world</strong>!</p>', 'Hello world!'],
+    ['No tags here', 'No tags here'],
+    ['<br />', ''],
+    ['', ''],
+  ])('stripHtml(%s) = %s', (input, expected) => {
+    expect(stripHtml(input)).toBe(expected);
+  });
+});
+
+// ─── initials ─────────────────────────────────────────────────────────────────
+
+describe('initials', () => {
+  it.each([
+    ['John Doe', 2, 'JD'],
+    ['Alice', 2, 'A'],
+    ['Mary Jane Watson', 2, 'MJ'],
+    ['Mary Jane Watson', 3, 'MJW'],
+    ['', 2, ''],
+  ])('initials(%s, %d) = %s', (name, max, expected) => {
+    expect(initials(name, max)).toBe(expected);
+  });
+
+  it('defaults to 2 initials', () => {
+    expect(initials('John Michael Doe')).toBe('JM');
+  });
+});
+
+// ─── padStart / padEnd ────────────────────────────────────────────────────────
+
+describe('padStart', () => {
+  it('left-pads with zeros', () => {
+    expect(padStart('5', 2, '0')).toBe('05');
+  });
+
+  it('does not pad when string is already long enough', () => {
+    expect(padStart('hello', 3)).toBe('hello');
+  });
+});
+
+describe('padEnd', () => {
+  it('right-pads with dots', () => {
+    expect(padEnd('hi', 5, '.')).toBe('hi...');
+  });
+});
+
+// ─── toCamelCase ─────────────────────────────────────────────────────────────
+
+describe('toCamelCase', () => {
+  it.each([
+    ['hello-world', 'helloWorld'],
+    ['foo_bar_baz', 'fooBarBaz'],
+    ['already', 'already'],
+    ['', ''],
+  ])('toCamelCase(%s) = %s', (input, expected) => {
+    expect(toCamelCase(input)).toBe(expected);
+  });
+});
+
+// ─── Purity checks ────────────────────────────────────────────────────────────
+
+describe('purity', () => {
+  it('capitalise does not mutate input', () => {
+    const input = 'hello';
+    capitalise(input);
+    expect(input).toBe('hello');
+  });
+
+  it('truncate does not mutate input', () => {
+    const input = 'Hello, world!';
+    truncate(input, 5);
+    expect(input).toBe('Hello, world!');
+  });
+
+  it('slugify does not mutate input', () => {
+    const input = 'Hello World';
+    slugify(input);
+    expect(input).toBe('Hello World');
+  });
+});

--- a/src/utils/__tests__/validators.test.ts
+++ b/src/utils/__tests__/validators.test.ts
@@ -1,58 +1,174 @@
 import {
   isValidEmail,
   isValidPhone,
-  isValidPassword,
   isValidDate,
-  isNonEmptyString,
-  ERROR_MESSAGES,
+  validatePetAge,
+  validateDosage,
+  VALIDATION_ERRORS,
+  type ValidationResult,
 } from '../validators';
 
+// ─── isValidEmail ─────────────────────────────────────────────────────────────
+
 describe('isValidEmail', () => {
-  it.each(['user@example.com', 'a@b.co', 'user+tag@domain.org'])('valid: %s', (v) => {
-    expect(isValidEmail(v)).toBe(true);
-  });
-  it.each(['', 'notanemail', '@no-local.com', 'no-at-sign', null, undefined])('invalid: %s', (v) =>
-    expect(isValidEmail(v)).toBe(false),
+  it.each(['user@example.com', 'a@b.co', 'user+tag@domain.org', 'name.surname@host.co.uk'])(
+    'valid: %s',
+    (v) => {
+      const result: ValidationResult = isValidEmail(v);
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeNull();
+    },
   );
-  it('exports an error message', () => expect(typeof ERROR_MESSAGES.email).toBe('string'));
+
+  it.each(['', 'notanemail', '@no-local.com', 'no-at-sign', null, undefined])(
+    'invalid: %s',
+    (v) => {
+      const result = isValidEmail(v);
+      expect(result.isValid).toBe(false);
+      expect(typeof result.error).toBe('string');
+      expect(result.error!.length).toBeGreaterThan(0);
+    },
+  );
+
+  it('rejects emails longer than 254 characters', () => {
+    const longEmail = 'a'.repeat(250) + '@b.co';
+    expect(isValidEmail(longEmail).isValid).toBe(false);
+  });
+
+  it('exports VALIDATION_ERRORS.email as a string', () => {
+    expect(typeof VALIDATION_ERRORS.email).toBe('string');
+  });
 });
+
+// ─── isValidPhone ─────────────────────────────────────────────────────────────
 
 describe('isValidPhone', () => {
-  it.each(['+12345678', '1234567', '+447911123456'])('valid: %s', (v) => {
-    expect(isValidPhone(v)).toBe(true);
-  });
+  it.each(['+12345678', '1234567', '+447911123456', '12 345 678', '+1 (800) 555-1234'])(
+    'valid: %s',
+    (v) => {
+      const result = isValidPhone(v);
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeNull();
+    },
+  );
+
   it.each(['', '123', '+0123456', null, undefined])('invalid: %s', (v) => {
-    expect(isValidPhone(v)).toBe(false);
+    const result = isValidPhone(v);
+    expect(result.isValid).toBe(false);
+    expect(typeof result.error).toBe('string');
   });
-  it('exports an error message', () => expect(typeof ERROR_MESSAGES.phone).toBe('string'));
+
+  it('exports VALIDATION_ERRORS.phone as a string', () => {
+    expect(typeof VALIDATION_ERRORS.phone).toBe('string');
+  });
 });
 
-describe('isValidPassword', () => {
-  it.each(['Password1', 'Str0ngPass', 'ABCDEFG1h'])('valid: %s', (v) => {
-    expect(isValidPassword(v)).toBe(true);
-  });
-  it.each(['short1A', 'nouppercase1', 'NoNumber!', '', null, undefined])('invalid: %s', (v) => {
-    expect(isValidPassword(v)).toBe(false);
-  });
-  it('exports an error message', () => expect(typeof ERROR_MESSAGES.password).toBe('string'));
-});
+// ─── isValidDate ─────────────────────────────────────────────────────────────
 
 describe('isValidDate', () => {
-  it.each(['2024-01-15', '2000-12-31', 'January 1, 2020'])('valid: %s', (v) => {
-    expect(isValidDate(v)).toBe(true);
+  it.each(['2024-01-15', '2000-12-31', '2025-06-30', 'January 1, 2020'])('valid: %s', (v) => {
+    const result = isValidDate(v);
+    expect(result.isValid).toBe(true);
+    expect(result.error).toBeNull();
   });
+
   it.each(['', 'not-a-date', '2024-02-30', '2024-13-01', null, undefined])('invalid: %s', (v) => {
-    expect(isValidDate(v)).toBe(false);
+    const result = isValidDate(v);
+    expect(result.isValid).toBe(false);
+    expect(typeof result.error).toBe('string');
   });
-  it('exports an error message', () => expect(typeof ERROR_MESSAGES.date).toBe('string'));
+
+  it('exports VALIDATION_ERRORS.date as a string', () => {
+    expect(typeof VALIDATION_ERRORS.date).toBe('string');
+  });
 });
 
-describe('isNonEmptyString', () => {
-  it.each(['hello', ' world ', 'a'])('valid: %s', (v) => {
-    expect(isNonEmptyString(v)).toBe(true);
+// ─── validatePetAge ───────────────────────────────────────────────────────────
+
+describe('validatePetAge', () => {
+  it.each([0, 0.5, 1, 5, 15, 50])('valid age: %s', (age) => {
+    const result = validatePetAge(age);
+    expect(result.isValid).toBe(true);
+    expect(result.error).toBeNull();
   });
-  it.each(['', '   ', null, undefined, 42, false])('invalid: %s', (v) => {
-    expect(isNonEmptyString(v)).toBe(false);
+
+  it.each([-1, -0.1])('rejects negative age: %s', (age) => {
+    const result = validatePetAge(age);
+    expect(result.isValid).toBe(false);
+    expect(typeof result.error).toBe('string');
   });
-  it('exports an error message', () => expect(typeof ERROR_MESSAGES.nonEmptyString).toBe('string'));
+
+  it.each([51, 100, 999])('rejects age > 50: %s', (age) => {
+    const result = validatePetAge(age);
+    expect(result.isValid).toBe(false);
+  });
+
+  it.each([null, undefined, '', 'abc'])('rejects non-numeric: %s', (age) => {
+    const result = validatePetAge(age);
+    expect(result.isValid).toBe(false);
+  });
+
+  it('accepts numeric strings', () => {
+    expect(validatePetAge('3').isValid).toBe(true);
+  });
+
+  it('exports VALIDATION_ERRORS.petAge as a string', () => {
+    expect(typeof VALIDATION_ERRORS.petAge).toBe('string');
+  });
+});
+
+// ─── validateDosage ───────────────────────────────────────────────────────────
+
+describe('validateDosage', () => {
+  it.each(['5mg', '2.5 ml', '100mcg', '0.1 g', '10000'])('valid dosage: %s', (dosage) => {
+    const result = validateDosage(dosage);
+    expect(result.isValid).toBe(true);
+    expect(result.error).toBeNull();
+  });
+
+  it('accepts a plain positive number', () => {
+    expect(validateDosage(5).isValid).toBe(true);
+  });
+
+  it.each(['', null, undefined])('rejects empty/null: %s', (dosage) => {
+    const result = validateDosage(dosage);
+    expect(result.isValid).toBe(false);
+    expect(typeof result.error).toBe('string');
+  });
+
+  it('rejects zero dosage', () => {
+    expect(validateDosage('0').isValid).toBe(false);
+  });
+
+  it('rejects negative dosage', () => {
+    expect(validateDosage('-5mg').isValid).toBe(false);
+  });
+
+  it('rejects dosage above 10 000', () => {
+    expect(validateDosage('10001mg').isValid).toBe(false);
+  });
+
+  it('rejects non-numeric strings', () => {
+    expect(validateDosage('abc').isValid).toBe(false);
+  });
+
+  it('exports VALIDATION_ERRORS.dosage as a string', () => {
+    expect(typeof VALIDATION_ERRORS.dosage).toBe('string');
+  });
+});
+
+// ─── ValidationResult shape ───────────────────────────────────────────────────
+
+describe('ValidationResult type contract', () => {
+  it('valid result has isValid=true and error=null', () => {
+    const r = isValidEmail('user@example.com');
+    expect(r).toEqual({ isValid: true, error: null });
+  });
+
+  it('invalid result has isValid=false and a non-null error string', () => {
+    const r = isValidEmail('bad');
+    expect(r.isValid).toBe(false);
+    expect(r.error).not.toBeNull();
+    expect(typeof r.error).toBe('string');
+  });
 });

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,204 @@
+/**
+ * Pure date and time utility functions for PetChain Mobile App.
+ *
+ * All functions are side-effect-free and suitable for use in both
+ * React Native components and background workers.
+ *
+ * No external dependencies — relies on the built-in Intl API (available in
+ * JavaScriptCore / Hermes on iOS and Android) and the standard Date object.
+ */
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Coerce a `Date | string` to a `Date`.
+ * Throws with a descriptive message if the value is not a valid date.
+ */
+function toDate(date: Date | string): Date {
+  const parsed = typeof date === 'string' ? new Date(date) : date;
+  if (isNaN(parsed.getTime())) {
+    throw new Error(`Invalid date: "${date}"`);
+  }
+  return parsed;
+}
+
+// ─── formatDate ───────────────────────────────────────────────────────────────
+
+/**
+ * Format a date using a named format or custom `Intl.DateTimeFormatOptions`.
+ *
+ * Named formats:
+ * - `'short'`    → "Jan 5, 2025"
+ * - `'long'`     → "January 5, 2025"
+ * - `'time'`     → "2:30 PM"
+ * - `'datetime'` → "Jan 5, 2025, 2:30 PM"
+ * - `'iso'`      → ISO 8601 string (default)
+ *
+ * @example
+ * formatDate('2025-01-05', 'short')         // "Jan 5, 2025"
+ * formatDate(new Date(), 'datetime')        // "Jan 5, 2025, 2:30 PM"
+ * formatDate('2025-01-05', { weekday: 'long' }) // "Sunday"
+ */
+export function formatDate(
+  date: Date | string,
+  format: 'iso' | 'short' | 'long' | 'time' | 'datetime' | Intl.DateTimeFormatOptions = 'iso',
+  locale = 'en-US',
+): string {
+  const parsed = toDate(date);
+
+  if (format === 'iso') {
+    return parsed.toISOString();
+  }
+
+  const PRESETS: Record<string, Intl.DateTimeFormatOptions> = {
+    short: { year: 'numeric', month: 'short', day: 'numeric' },
+    long: { year: 'numeric', month: 'long', day: 'numeric' },
+    time: { hour: '2-digit', minute: '2-digit' },
+    datetime: {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+  };
+
+  const options: Intl.DateTimeFormatOptions = typeof format === 'string' ? PRESETS[format] : format;
+
+  return new Intl.DateTimeFormat(locale, options).format(parsed);
+}
+
+// ─── toRelativeTime ───────────────────────────────────────────────────────────
+
+/**
+ * Return a human-readable relative time string (e.g. "2 hours ago", "in 3 days").
+ *
+ * Uses `Intl.RelativeTimeFormat` so the output is automatically localised.
+ *
+ * @example
+ * toRelativeTime(new Date(Date.now() - 90_000))  // "2 minutes ago"
+ * toRelativeTime(new Date(Date.now() + 86_400_000)) // "in 1 day"
+ */
+export function toRelativeTime(date: Date | string, locale = 'en-US'): string {
+  const parsed = toDate(date);
+  const diffMs = parsed.getTime() - Date.now();
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+
+  const abs = Math.abs(diffMs);
+
+  if (abs < 60_000) return rtf.format(Math.round(diffMs / 1_000), 'second');
+  if (abs < 3_600_000) return rtf.format(Math.round(diffMs / 60_000), 'minute');
+  if (abs < 86_400_000) return rtf.format(Math.round(diffMs / 3_600_000), 'hour');
+  if (abs < 2_592_000_000) return rtf.format(Math.round(diffMs / 86_400_000), 'day');
+  if (abs < 31_536_000_000) return rtf.format(Math.round(diffMs / 2_592_000_000), 'month');
+  return rtf.format(Math.round(diffMs / 31_536_000_000), 'year');
+}
+
+// ─── isExpired ────────────────────────────────────────────────────────────────
+
+/**
+ * Return `true` when the given date is strictly in the past (before `Date.now()`).
+ *
+ * Useful for checking whether a medication end date, subscription, or token has expired.
+ *
+ * @example
+ * isExpired('2020-01-01')  // true
+ * isExpired('2099-12-31')  // false
+ */
+export function isExpired(date: Date | string): boolean {
+  return toDate(date).getTime() < Date.now();
+}
+
+// ─── addDays ──────────────────────────────────────────────────────────────────
+
+/**
+ * Return a new `Date` that is `n` days after (positive) or before (negative) `date`.
+ *
+ * The time component is preserved.
+ *
+ * @example
+ * addDays(new Date('2025-01-01'), 7)  // 2025-01-08T…
+ * addDays(new Date('2025-01-08'), -3) // 2025-01-05T…
+ */
+export function addDays(date: Date | string, days: number): Date {
+  const parsed = toDate(date);
+  return new Date(parsed.getTime() + days * 24 * 60 * 60 * 1_000);
+}
+
+// ─── addWeeks ─────────────────────────────────────────────────────────────────
+
+/**
+ * Return a new `Date` that is `n` weeks after (positive) or before (negative) `date`.
+ *
+ * @example
+ * addWeeks(new Date('2025-01-01'), 2)  // 2025-01-15T…
+ */
+export function addWeeks(date: Date | string, weeks: number): Date {
+  return addDays(date, weeks * 7);
+}
+
+// ─── addMinutes ───────────────────────────────────────────────────────────────
+
+/**
+ * Return a new `Date` that is `n` minutes after (positive) or before (negative) `date`.
+ *
+ * @example
+ * addMinutes(new Date('2025-01-01T12:00:00'), 30)  // 2025-01-01T12:30:00
+ */
+export function addMinutes(date: Date | string, minutes: number): Date {
+  const parsed = toDate(date);
+  return new Date(parsed.getTime() + minutes * 60 * 1_000);
+}
+
+// ─── startOfDay / endOfDay ────────────────────────────────────────────────────
+
+/**
+ * Return a new `Date` at midnight (00:00:00.000) on the same local calendar day.
+ */
+export function startOfDay(date: Date | string): Date {
+  const d = toDate(date);
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0);
+}
+
+/**
+ * Return a new `Date` at 23:59:59.999 on the same local calendar day.
+ */
+export function endOfDay(date: Date | string): Date {
+  const d = toDate(date);
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
+}
+
+// ─── isSameDay ────────────────────────────────────────────────────────────────
+
+/**
+ * Return `true` when both dates fall on the same local calendar day.
+ *
+ * @example
+ * isSameDay('2025-01-01T00:00:00', '2025-01-01T23:59:59')  // true
+ * isSameDay('2025-01-01', '2025-01-02')                    // false
+ */
+export function isSameDay(a: Date | string, b: Date | string): boolean {
+  const da = toDate(a);
+  const db = toDate(b);
+  return (
+    da.getFullYear() === db.getFullYear() &&
+    da.getMonth() === db.getMonth() &&
+    da.getDate() === db.getDate()
+  );
+}
+
+// ─── differenceInDays ─────────────────────────────────────────────────────────
+
+/**
+ * Return the integer number of whole days between `start` and `end`.
+ * Result is positive when `end` is after `start`.
+ *
+ * @example
+ * differenceInDays('2025-01-01', '2025-01-08')  // 7
+ * differenceInDays('2025-01-08', '2025-01-01')  // -7
+ */
+export function differenceInDays(start: Date | string, end: Date | string): number {
+  const startMs = toDate(start).getTime();
+  const endMs = toDate(end).getTime();
+  return Math.trunc((endMs - startMs) / (24 * 60 * 60 * 1_000));
+}

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,0 +1,221 @@
+/**
+ * Pure string formatting utilities for PetChain Mobile App.
+ *
+ * All functions are side-effect-free and work in any JavaScript environment
+ * (React Native, Node.js, Web Workers).
+ *
+ * No external dependencies.
+ */
+
+// ─── capitalise ───────────────────────────────────────────────────────────────
+
+/**
+ * Uppercase the first character of a string; leave the rest unchanged.
+ *
+ * Returns an empty string for falsy input.
+ *
+ * @example
+ * capitalise('hello world')  // "Hello world"
+ * capitalise('HELLO')        // "HELLO"
+ * capitalise('')             // ""
+ */
+export function capitalise(str: string): string {
+  if (!str) return '';
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+// ─── toTitleCase ──────────────────────────────────────────────────────────────
+
+/**
+ * Capitalise the first letter of every word in the string.
+ *
+ * Words are separated by one or more whitespace characters.
+ *
+ * @example
+ * toTitleCase('the quick brown fox')  // "The Quick Brown Fox"
+ * toTitleCase('hello world')          // "Hello World"
+ */
+export function toTitleCase(str: string): string {
+  if (!str) return '';
+  return str.replace(/\S+/g, (word) => capitalise(word.toLowerCase()));
+}
+
+// ─── truncate ─────────────────────────────────────────────────────────────────
+
+/**
+ * Shorten `str` to at most `maxLen` characters.
+ * When truncation occurs the string is trimmed and an ellipsis (`…`) is appended.
+ *
+ * @param str     - Input string.
+ * @param maxLen  - Maximum total length including the ellipsis character.
+ * @param ellipsis - Override the default `…` suffix.
+ *
+ * @example
+ * truncate('Hello, world!', 8)          // "Hello, …"
+ * truncate('Short', 10)                 // "Short"
+ * truncate('Hello, world!', 8, '...')   // "Hello..."
+ */
+export function truncate(str: string, maxLen: number, ellipsis = '…'): string {
+  if (!str) return '';
+  if (maxLen <= 0) return '';
+  if (str.length <= maxLen) return str;
+  const cutoff = maxLen - ellipsis.length;
+  if (cutoff <= 0) return ellipsis.slice(0, maxLen);
+  return str.slice(0, cutoff) + ellipsis;
+}
+
+// ─── maskEmail ────────────────────────────────────────────────────────────────
+
+/**
+ * Partially redact an email address for privacy display.
+ *
+ * The local part is masked except for the first character and the domain is kept.
+ *
+ * @example
+ * maskEmail('alice@example.com')    // "a****@example.com"
+ * maskEmail('ab@example.com')       // "a*@example.com"
+ * maskEmail('a@example.com')        // "a@example.com"
+ * maskEmail('not-an-email')         // "not-an-email"  (returned unchanged)
+ */
+export function maskEmail(email: string): string {
+  if (!email) return '';
+  const atIndex = email.indexOf('@');
+  if (atIndex < 1) return email; // not a recognisable email address
+
+  const local = email.slice(0, atIndex);
+  const domain = email.slice(atIndex); // includes the '@'
+
+  if (local.length <= 1) return email; // nothing to mask
+
+  const masked = local.charAt(0) + '*'.repeat(local.length - 1);
+  return masked + domain;
+}
+
+// ─── maskPhone ────────────────────────────────────────────────────────────────
+
+/**
+ * Partially redact a phone number for privacy display.
+ *
+ * Only the last 4 digits are shown; all other digit positions are replaced with `*`.
+ * Non-digit characters (spaces, dashes, parentheses) are removed from the output.
+ *
+ * @example
+ * maskPhone('+1 (555) 123-4567')  // "********4567"
+ * maskPhone('07700900123')        // "*******0123"
+ * maskPhone('1234')               // "1234"          (≤ 4 digits, shown as-is)
+ */
+export function maskPhone(phone: string): string {
+  if (!phone) return '';
+  // Strip all non-digit characters
+  const digits = phone.replace(/\D/g, '');
+  if (digits.length <= 4) return digits;
+  return '*'.repeat(digits.length - 4) + digits.slice(-4);
+}
+
+// ─── slugify ──────────────────────────────────────────────────────────────────
+
+/**
+ * Convert a string to a URL-safe slug.
+ *
+ * - Lowercases the string
+ * - Normalises accented characters (é → e, ñ → n, etc.) via Unicode decomposition
+ * - Replaces spaces and non-alphanumeric characters with hyphens
+ * - Collapses consecutive hyphens into a single one
+ * - Trims leading/trailing hyphens
+ *
+ * @example
+ * slugify('Hello World!')          // "hello-world"
+ * slugify('Café au lait')          // "cafe-au-lait"
+ * slugify('  multiple   spaces ')  // "multiple-spaces"
+ * slugify('PetChain -- App')       // "petchain-app"
+ */
+export function slugify(str: string): string {
+  if (!str) return '';
+  return (
+    str
+      .toLowerCase()
+      // Decompose accented characters and strip the combining marks
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      // Replace any non-alphanumeric character (including spaces) with a hyphen
+      .replace(/[^a-z0-9]+/g, '-')
+      // Collapse repeated hyphens
+      .replace(/-{2,}/g, '-')
+      // Remove leading/trailing hyphens
+      .replace(/^-+|-+$/g, '')
+  );
+}
+
+// ─── stripHtml ────────────────────────────────────────────────────────────────
+
+/**
+ * Remove all HTML/XML tags from a string.
+ *
+ * Useful for sanitising rich-text content before displaying it in plain-text contexts.
+ *
+ * @example
+ * stripHtml('<p>Hello <strong>world</strong>!</p>')  // "Hello world!"
+ * stripHtml('No tags here')                          // "No tags here"
+ */
+export function stripHtml(str: string): string {
+  if (!str) return '';
+  return str.replace(/<[^>]*>/g, '');
+}
+
+// ─── initials ─────────────────────────────────────────────────────────────────
+
+/**
+ * Extract the initials from a full name string (up to `maxInitials` characters).
+ *
+ * Each word's first character is uppercased and concatenated.
+ *
+ * @example
+ * initials('John Doe')           // "JD"
+ * initials('Alice')              // "A"
+ * initials('Mary Jane Watson', 2) // "MJ"
+ */
+export function initials(name: string, maxInitials = 2): string {
+  if (!name) return '';
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, maxInitials)
+    .map((word) => word.charAt(0).toUpperCase())
+    .join('');
+}
+
+// ─── padStart / padEnd convenience wrappers ───────────────────────────────────
+
+/**
+ * Left-pad `str` with `char` until it reaches `length`.
+ *
+ * @example
+ * padStart('5', 2, '0')  // "05"
+ */
+export function padStart(str: string, length: number, char = ' '): string {
+  return str.padStart(length, char);
+}
+
+/**
+ * Right-pad `str` with `char` until it reaches `length`.
+ *
+ * @example
+ * padEnd('hi', 5, '.')  // "hi..."
+ */
+export function padEnd(str: string, length: number, char = ' '): string {
+  return str.padEnd(length, char);
+}
+
+// ─── toCamelCase ─────────────────────────────────────────────────────────────
+
+/**
+ * Convert a hyphen- or underscore-separated string to camelCase.
+ *
+ * @example
+ * toCamelCase('hello-world')   // "helloWorld"
+ * toCamelCase('foo_bar_baz')   // "fooBarBaz"
+ */
+export function toCamelCase(str: string): string {
+  if (!str) return '';
+  return str.toLowerCase().replace(/[-_](.)/g, (_, char: string) => char.toUpperCase());
+}

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,71 +1,212 @@
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
-const PHONE_REGEX = /^\+?[1-9]\d{6,14}$/;
+/**
+ * Input validation utilities for PetChain Mobile App.
+ *
+ * All validators are pure functions that return a `ValidationResult`:
+ *   { isValid: true,  error: null }   — passes validation
+ *   { isValid: false, error: string } — fails with a human-readable message
+ *
+ * This mirrors the backend/utils/validators.ts pattern so validation logic
+ * can be shared or compared across the stack.
+ */
 
-export const ERROR_MESSAGES = {
-  email: 'Please enter a valid email address.',
-  phone: 'Please enter a valid phone number (7–15 digits, optional leading +).',
-  password: 'Password must be at least 8 characters, include 1 uppercase letter and 1 number.',
-  date: 'Please enter a valid date.',
-  nonEmptyString: 'Value must be a non-empty string.',
-};
+// ─── ValidationResult ─────────────────────────────────────────────────────────
+
+export interface ValidationResult {
+  isValid: boolean;
+  error: string | null;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function valid(): ValidationResult {
+  return { isValid: true, error: null };
+}
+
+function invalid(error: string): ValidationResult {
+  return { isValid: false, error };
+}
 
 function normalize(value: unknown): string {
   if (value === null || value === undefined) return '';
   return String(value).trim();
 }
 
-export function isValidEmail(email: unknown): boolean {
-  const v = normalize(email);
-  return v.length > 0 && v.length <= 254 && EMAIL_REGEX.test(v);
+// ─── Regexes ──────────────────────────────────────────────────────────────────
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+// E.164-like: optional leading +, 7–15 digits
+const PHONE_REGEX = /^\+?[1-9]\d{6,14}$/;
+
+// ─── isValidEmail ─────────────────────────────────────────────────────────────
+
+/**
+ * Validate an email address format.
+ *
+ * @example
+ * isValidEmail('user@example.com')  // { isValid: true, error: null }
+ * isValidEmail('not-an-email')      // { isValid: false, error: '…' }
+ */
+export function isValidEmail(email: unknown): ValidationResult {
+  const value = normalize(email);
+  if (!value) return invalid('Email is required.');
+  if (value.length > 254) return invalid('Email must be 254 characters or fewer.');
+  if (!EMAIL_REGEX.test(value)) return invalid('Please enter a valid email address.');
+  return valid();
 }
 
-export function isValidPhone(phone: unknown): boolean {
-  const normalized = normalize(phone).replace(/[\s\-().]/g, '');
-  return PHONE_REGEX.test(normalized);
+// ─── isValidPhone ─────────────────────────────────────────────────────────────
+
+/**
+ * Validate a phone number in E.164-like format.
+ * Spaces, dashes, dots, and parentheses are stripped before testing.
+ *
+ * @example
+ * isValidPhone('+12345678')   // { isValid: true, error: null }
+ * isValidPhone('123')         // { isValid: false, error: '…' }
+ */
+export function isValidPhone(phone: unknown): ValidationResult {
+  const raw = normalize(phone);
+  if (!raw) return invalid('Phone number is required.');
+  const stripped = raw.replace(/[\s\-().]/g, '');
+  if (!PHONE_REGEX.test(stripped)) {
+    return invalid('Please enter a valid phone number (7–15 digits, optional leading +).');
+  }
+  return valid();
 }
 
-export function isValidPassword(password: unknown): boolean {
-  const v = normalize(password);
-  return v.length >= 8 && /[A-Z]/.test(v) && /\d/.test(v);
+// ─── isValidDate ─────────────────────────────────────────────────────────────
+
+/**
+ * Validate that the value is a parseable, real calendar date.
+ * ISO 8601 `YYYY-MM-DD` strings are cross-checked for calendar correctness
+ * (e.g. `2024-02-30` is rejected even though `new Date()` would accept it).
+ *
+ * @example
+ * isValidDate('2025-06-15')   // { isValid: true, error: null }
+ * isValidDate('2024-02-30')   // { isValid: false, error: '…' }
+ */
+export function isValidDate(date: unknown): ValidationResult {
+  const value = normalize(date);
+  if (!value) return invalid('Date is required.');
+
+  const parsed = new Date(value);
+  if (isNaN(parsed.getTime())) return invalid('Please enter a valid date.');
+
+  // Extra calendar-reality check for YYYY-MM-DD strings
+  const isoMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (isoMatch) {
+    const [, y, m, d] = isoMatch.map(Number);
+    const utc = new Date(Date.UTC(y, m - 1, d));
+    if (utc.getUTCFullYear() !== y || utc.getUTCMonth() + 1 !== m || utc.getUTCDate() !== d) {
+      return invalid('Please enter a real calendar date.');
+    }
+  }
+
+  return valid();
+}
+
+// ─── validatePetAge ───────────────────────────────────────────────────────────
+
+/**
+ * Validate a pet's age in years.
+ *
+ * Rules:
+ * - Must be a finite number
+ * - Must be ≥ 0 (newborns allowed)
+ * - Must be ≤ 50 (upper practical limit for any known pet species)
+ *
+ * @example
+ * validatePetAge(3)    // { isValid: true, error: null }
+ * validatePetAge(-1)   // { isValid: false, error: '…' }
+ * validatePetAge(200)  // { isValid: false, error: '…' }
+ */
+export function validatePetAge(age: unknown): ValidationResult {
+  if (age === null || age === undefined || age === '') {
+    return invalid('Pet age is required.');
+  }
+  const num = Number(age);
+  if (!isFinite(num) || isNaN(num)) {
+    return invalid('Pet age must be a number.');
+  }
+  if (num < 0) {
+    return invalid('Pet age cannot be negative.');
+  }
+  if (num > 50) {
+    return invalid('Pet age must be 50 years or less.');
+  }
+  return valid();
+}
+
+// ─── validateDosage ───────────────────────────────────────────────────────────
+
+/**
+ * Validate a medication dosage value.
+ *
+ * Accepts a number (or numeric string) with an optional unit suffix
+ * (e.g. `"5mg"`, `"2.5 ml"`, `"100 mcg"`).
+ *
+ * Rules:
+ * - Must be present
+ * - Numeric part must be > 0
+ * - Numeric part must be ≤ 10 000 (safety upper-bound)
+ *
+ * @example
+ * validateDosage('5mg')     // { isValid: true, error: null }
+ * validateDosage(2.5)       // { isValid: true, error: null }
+ * validateDosage('-1mg')    // { isValid: false, error: '…' }
+ * validateDosage('0')       // { isValid: false, error: '…' }
+ */
+export function validateDosage(dosage: unknown): ValidationResult {
+  const raw = normalize(dosage);
+  if (!raw) return invalid('Dosage is required.');
+
+  // Extract leading numeric portion (integer or decimal)
+  const match = raw.match(/^(\d+(?:\.\d+)?)\s*/);
+  if (!match) {
+    return invalid('Dosage must start with a positive number (e.g. "5mg", "2.5 ml").');
+  }
+
+  const num = parseFloat(match[1]);
+  if (num <= 0) {
+    return invalid('Dosage must be greater than zero.');
+  }
+  if (num > 10_000) {
+    return invalid('Dosage must be 10 000 or less.');
+  }
+
+  return valid();
+}
+
+// ─── Legacy boolean helpers (backwards compat with existing callers) ──────────
+
+/**
+ * @deprecated Prefer `isValidEmail(email).isValid`.
+ * Kept for backwards compatibility with existing callers that expect a boolean.
+ */
+export function isValidEmailBool(email: unknown): boolean {
+  return isValidEmail(email).isValid;
 }
 
 /**
- * ✅ FIX: matches your failing tests (validatePassword is missing)
+ * @deprecated Prefer `isValidPhone(phone).isValid`.
  */
-export function validatePassword(password: unknown): {
-  isValid: boolean;
-  error?: string;
-} {
-  const v = normalize(password);
-
-  if (v.length < 8) {
-    return { isValid: false, error: ERROR_MESSAGES.password };
-  }
-
-  if (!/[A-Z]/.test(v) || !/\d/.test(v)) {
-    return { isValid: false, error: ERROR_MESSAGES.password };
-  }
-
-  return { isValid: true };
+export function isValidPhoneBool(phone: unknown): boolean {
+  return isValidPhone(phone).isValid;
 }
 
-export function isValidDate(date: unknown): boolean {
-  const v = normalize(date);
-  if (!v) return false;
-
-  const parsed = new Date(v);
-  if (isNaN(parsed.getTime())) return false;
-
-  const match = v.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (match) {
-    const [, y, m, d] = match.map(Number);
-    const utc = new Date(Date.UTC(y, m - 1, d));
-    return utc.getUTCFullYear() === y && utc.getUTCMonth() + 1 === m && utc.getUTCDate() === d;
-  }
-
-  return true;
+/**
+ * @deprecated Prefer `isValidDate(date).isValid`.
+ */
+export function isValidDateBool(date: unknown): boolean {
+  return isValidDate(date).isValid;
 }
 
-export function isNonEmptyString(value: unknown): boolean {
-  return typeof value === 'string' && value.trim().length > 0;
-}
+// ─── Error message constants (for form-level display) ─────────────────────────
+
+export const VALIDATION_ERRORS = {
+  email: 'Please enter a valid email address.',
+  phone: 'Please enter a valid phone number (7–15 digits, optional leading +).',
+  date: 'Please enter a valid date.',
+  petAge: 'Pet age must be between 0 and 50.',
+  dosage: 'Dosage must be a positive number (e.g. "5mg", "2.5 ml").',
+} as const;


### PR DESCRIPTION
## Summary

Implements issues #805, #806, #807, and #808 — foundational TypeScript types and utility modules for notifications, date handling, input validation, and string formatting.

---

## Changes

### `src/types/notifications.ts` — #805
- `PushNotificationPayload` — typed remote notification data payload
- `LocalNotificationOptions` — options for scheduling local notifications via expo-notifications
- `NotificationPermissionStatus` — `'granted' | 'denied' | 'undetermined'`
- `AndroidNotificationChannelConfig` — full Android channel configuration type
- `NOTIFICATION_CHANNEL_IDS` — const map of well-known channel IDs used across the app

### `src/utils/dateUtils.ts` — #806
Pure, dependency-free date helpers using the built-in `Intl` API:
- `formatDate(date, format)` — named presets (`short`, `long`, `time`, `datetime`, `iso`) or custom `Intl.DateTimeFormatOptions`
- `toRelativeTime(date)` — e.g. `"2 hours ago"`, `"in 3 days"` via `Intl.RelativeTimeFormat`
- `isExpired(date)` — returns `true` if date is in the past
- `addDays(date, n)` / `addWeeks(date, n)` / `addMinutes(date, n)` — arithmetic helpers
- `startOfDay`, `endOfDay`, `isSameDay`, `differenceInDays` — calendar helpers

### `src/utils/validators.ts` — #807
All validators return `ValidationResult { isValid: boolean; error: string | null }`:
- `isValidEmail(email)`
- `isValidPhone(phone)` — E.164-like, strips spaces/dashes/parens before testing
- `isValidDate(date)` — rejects impossible calendar dates (e.g. `2024-02-30`)
- `validatePetAge(age)` — 0–50 years, rejects non-numeric
- `validateDosage(dosage)` — positive numeric with optional unit suffix (e.g. `"5mg"`)
- `VALIDATION_ERRORS` — exportable error message constants

### `src/utils/stringUtils.ts` — #808
All functions are pure:
- `capitalise`, `toTitleCase`
- `truncate(str, maxLen)` — with configurable ellipsis
- `maskEmail`, `maskPhone` — privacy redaction helpers
- `slugify` — URL-safe, handles accented characters
- `stripHtml`, `initials`, `toCamelCase`, `padStart`, `padEnd`

---

## Tests

**161 tests passing** across three new test files:
- `src/utils/__tests__/dateUtils.test.ts`
- `src/utils/__tests__/validators.test.ts`
- `src/utils/__tests__/stringUtils.test.ts`

All tests use the project's `describe` / `it.each` Jest pattern.

---

Closes #805
Closes #806
Closes #807
Closes #808