### PR TITLE
feat(models): add assigned data models

### DIFF
--- a/src/models/BlockchainRecord.ts
+++ b/src/models/BlockchainRecord.ts
@@ -1,0 +1,25 @@
+export enum VerificationStatus {
+  PENDING = 'PENDING',
+  VERIFIED = 'VERIFIED',
+  FAILED = 'FAILED',
+}
+
+/**
+ * Stellar blockchain transaction record linked to a PetChain record.
+ */
+export interface BlockchainRecord {
+  txHash: string;
+  recordId: string;
+  timestamp: string;
+  networkId: string;
+  verified: boolean;
+}
+
+/**
+ * Result returned after checking a Stellar transaction verification state.
+ */
+export type VerificationResult = {
+  status: VerificationStatus;
+  verifiedAt: string;
+  txHash: string;
+};

--- a/src/models/EmergencyContact.ts
+++ b/src/models/EmergencyContact.ts
@@ -1,0 +1,35 @@
+export enum EmergencyContactType {
+  PERSONAL_VET = 'PERSONAL_VET',
+  EMERGENCY_CLINIC = 'EMERGENCY_CLINIC',
+  POISON_CONTROL = 'POISON_CONTROL',
+}
+
+export interface Coordinates {
+  latitude: number;
+  longitude: number;
+}
+
+/**
+ * Emergency contact for urgent pet care support.
+ */
+export interface EmergencyContact {
+  id: string;
+  name: string;
+  phone: string;
+  type: EmergencyContactType;
+  address: string;
+  coordinates: Coordinates;
+}
+
+/**
+ * Veterinary clinic details used for nearby emergency care.
+ */
+export interface VetClinic {
+  id: string;
+  name: string;
+  phone: string;
+  address: string;
+  coordinates: Coordinates;
+  hours: string;
+  emergencyAvailable: boolean;
+}

--- a/src/models/HealthMetrics.ts
+++ b/src/models/HealthMetrics.ts
@@ -1,0 +1,26 @@
+export enum HealthTrend {
+  IMPROVING = 'IMPROVING',
+  STABLE = 'STABLE',
+  DECLINING = 'DECLINING',
+}
+
+export type WeightRecord = {
+  id: string;
+  petId: string;
+  weight: number;
+  date: string;
+};
+
+export type HealthScore = {
+  score: number;
+  trend: HealthTrend;
+  evaluatedAt: string;
+};
+
+export interface HealthMetrics {
+  petId: string;
+  weight: number;
+  height: number;
+  bcs: number;
+  date: string;
+}

--- a/src/models/UserPreferences.ts
+++ b/src/models/UserPreferences.ts
@@ -1,0 +1,31 @@
+export enum Theme {
+  LIGHT = 'LIGHT',
+  DARK = 'DARK',
+  SYSTEM = 'SYSTEM',
+}
+
+export type NotificationPreferences = {
+  pushEnabled: boolean;
+  emailEnabled: boolean;
+  smsEnabled: boolean;
+};
+
+export interface UserPreferences {
+  language: string;
+  theme: Theme;
+  notificationsEnabled: boolean;
+  reminderLeadTimeDays: number;
+  notificationPreferences: NotificationPreferences;
+}
+
+export const DEFAULT_USER_PREFERENCES: UserPreferences = {
+  language: 'en',
+  theme: Theme.SYSTEM,
+  notificationsEnabled: true,
+  reminderLeadTimeDays: 1,
+  notificationPreferences: {
+    pushEnabled: true,
+    emailEnabled: false,
+    smsEnabled: false,
+  },
+};


### PR DESCRIPTION
Summary:
- Add health metrics, emergency contact, blockchain record, and user preference data models.
- Export requested enums, nested types, defaults, and JSDoc where required.

Closes #855
Closes #856
Closes #857
Closes #858

Validation:
- node_modules/.bin/prettier --check src/models/HealthMetrics.ts src/models/EmergencyContact.ts src/models/BlockchainRecord.ts src/models/UserPreferences.ts
- node_modules/.bin/eslint src/models/HealthMetrics.ts src/models/EmergencyContact.ts src/models/BlockchainRecord.ts src/models/UserPreferences.ts
- node_modules/.bin/tsc --noEmit (fails on pre-existing unrelated service errors)