### PR TITLE
feat(hooks): add pet record and metrics hooks

### DIFF
--- a/src/hooks/useBlockchainVerification.ts
+++ b/src/hooks/useBlockchainVerification.ts
@@ -1,0 +1,70 @@
+import { useCallback, useState } from 'react';
+
+import {
+  verifyRecordIntegrity,
+  type MedicalRecordWithChainData,
+  type RecordIntegrityResult,
+} from '../services/blockchainService';
+
+export type VerificationStatus = 'UNVERIFIED' | 'VERIFIED' | 'TAMPERED' | 'ERROR';
+
+export interface UseBlockchainVerificationResult {
+  verify: (record: MedicalRecordWithChainData) => Promise<RecordIntegrityResult | null>;
+  status: VerificationStatus;
+  isVerifying: boolean;
+  error: Error | null;
+}
+
+const verificationCache = new Map<string, RecordIntegrityResult>();
+
+const getStatusFromResult = (result: RecordIntegrityResult): VerificationStatus => {
+  const providedHashMatches = result.providedHash ? result.localHashMatchesProvidedHash : true;
+
+  return result.onChainVerified && providedHashMatches ? 'VERIFIED' : 'TAMPERED';
+};
+
+export function useBlockchainVerification(): UseBlockchainVerificationResult {
+  const [status, setStatus] = useState<VerificationStatus>('UNVERIFIED');
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const verify = useCallback(async (record: MedicalRecordWithChainData) => {
+    if (!record?.id) {
+      const invalidRecordError = new Error('Record ID is required');
+      setStatus('ERROR');
+      setError(invalidRecordError);
+      return null;
+    }
+
+    const cachedResult = verificationCache.get(record.id);
+    if (cachedResult) {
+      setStatus(getStatusFromResult(cachedResult));
+      setError(null);
+      return cachedResult;
+    }
+
+    setIsVerifying(true);
+    try {
+      const result = await verifyRecordIntegrity(record);
+
+      verificationCache.set(record.id, result);
+      setStatus(getStatusFromResult(result));
+      setError(null);
+      return result;
+    } catch (verificationError) {
+      setStatus('ERROR');
+      setError(
+        verificationError instanceof Error
+          ? verificationError
+          : new Error('Failed to verify record integrity'),
+      );
+      return null;
+    } finally {
+      setIsVerifying(false);
+    }
+  }, []);
+
+  return { verify, status, isVerifying, error };
+}
+
+export default useBlockchainVerification;

--- a/src/hooks/useHealthMetrics.ts
+++ b/src/hooks/useHealthMetrics.ts
@@ -1,0 +1,88 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { getHealthMetrics, type HealthMetricEntry } from '../services/healthMetricService';
+import healthMetricsService from '../services/healthScoringServiceV2';
+
+export type HealthTrend = 'up' | 'stable' | 'down';
+
+export interface UseHealthMetricsResult {
+  metrics: HealthMetricEntry[];
+  trend: HealthTrend;
+  healthScore: number | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const getTrend = (metrics: HealthMetricEntry[]): HealthTrend => {
+  if (metrics.length < 2) return 'stable';
+
+  const sortedMetrics = [...metrics]
+    .filter((metric) => typeof metric.weightKg === 'number')
+    .sort(
+      (firstMetric, secondMetric) =>
+        new Date(firstMetric.recordedAt).getTime() - new Date(secondMetric.recordedAt).getTime(),
+    );
+
+  if (sortedMetrics.length < 2) return 'stable';
+
+  const previousWeight = sortedMetrics[sortedMetrics.length - 2].weightKg ?? 0;
+  const latestWeight = sortedMetrics[sortedMetrics.length - 1].weightKg ?? 0;
+
+  if (latestWeight > previousWeight) return 'up';
+  if (latestWeight < previousWeight) return 'down';
+  return 'stable';
+};
+
+export function useHealthMetrics(petId: string): UseHealthMetricsResult {
+  const [metrics, setMetrics] = useState<HealthMetricEntry[]>([]);
+  const [healthScore, setHealthScore] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchMetrics = async () => {
+      if (!petId) {
+        setMetrics([]);
+        setHealthScore(null);
+        setError(null);
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const [fetchedMetrics, scoreExplanation] = await Promise.all([
+          getHealthMetrics(petId),
+          healthMetricsService.calculateHealthScore(petId),
+        ]);
+
+        if (!isMounted) return;
+
+        setMetrics(fetchedMetrics);
+        setHealthScore(scoreExplanation.overallScore);
+        setError(null);
+      } catch (fetchError) {
+        if (!isMounted) return;
+
+        setError(fetchError instanceof Error ? fetchError : new Error('Failed to fetch metrics'));
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void fetchMetrics();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [petId]);
+
+  const trend = useMemo(() => getTrend(metrics), [metrics]);
+
+  return { metrics, trend, healthScore, isLoading, error };
+}
+
+export default useHealthMetrics;

--- a/src/hooks/useMedicalRecords.ts
+++ b/src/hooks/useMedicalRecords.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  getMedicalRecords,
+  type MedicalRecord,
+  type RecordFilters,
+} from '../services/medicalRecordService';
+
+type MedicalRecordType = NonNullable<RecordFilters['type']>;
+
+export interface UseMedicalRecordsResult {
+  records: MedicalRecord[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+  filterByType: (type?: MedicalRecordType) => void;
+}
+
+const recordsCache = new Map<string, MedicalRecord[]>();
+
+export function useMedicalRecords(petId: string): UseMedicalRecordsResult {
+  const [records, setRecords] = useState<MedicalRecord[]>(
+    () => recordsCache.get(`${petId}:all`) ?? [],
+  );
+  const [recordType, setRecordType] = useState<MedicalRecordType | undefined>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchRecords = useCallback(async () => {
+    if (!petId) {
+      setRecords([]);
+      setError(null);
+      return;
+    }
+
+    const cacheKey = `${petId}:${recordType ?? 'all'}`;
+    const cachedRecords = recordsCache.get(cacheKey);
+
+    if (cachedRecords) {
+      setRecords(cachedRecords);
+      setError(null);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await getMedicalRecords(
+        petId,
+        recordType ? { type: recordType } : undefined,
+      );
+      const fetchedRecords = response.data.data;
+
+      recordsCache.set(cacheKey, fetchedRecords);
+      setRecords(fetchedRecords);
+      setError(null);
+    } catch (fetchError) {
+      setError(fetchError instanceof Error ? fetchError : new Error('Failed to fetch records'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [petId, recordType]);
+
+  const refetch = useCallback(async () => {
+    if (petId) {
+      recordsCache.delete(`${petId}:${recordType ?? 'all'}`);
+    }
+    await fetchRecords();
+  }, [fetchRecords, petId, recordType]);
+
+  const filterByType = useCallback((type?: MedicalRecordType) => {
+    setRecordType(type);
+  }, []);
+
+  useEffect(() => {
+    void fetchRecords();
+  }, [fetchRecords]);
+
+  return { records, isLoading, error, refetch, filterByType };
+}
+
+export default useMedicalRecords;

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,45 @@
+import { useCallback, useState } from 'react';
+
+export type PaginatedFetch<T> = (page: number) => Promise<T[]>;
+
+export interface UsePaginationResult<T> {
+  data: T[];
+  page: number;
+  isLoading: boolean;
+  hasMore: boolean;
+  loadMore: () => Promise<void>;
+  reset: () => void;
+}
+
+export function usePagination<T>(fetchPage: PaginatedFetch<T>): UsePaginationResult<T> {
+  const [data, setData] = useState<T[]>([]);
+  const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  const loadMore = useCallback(async () => {
+    if (isLoading || !hasMore) return;
+
+    setIsLoading(true);
+    try {
+      const nextData = await fetchPage(page);
+
+      setData((currentData) => [...currentData, ...nextData]);
+      setPage((currentPage) => currentPage + 1);
+      setHasMore(nextData.length > 0);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fetchPage, hasMore, isLoading, page]);
+
+  const reset = useCallback(() => {
+    setData([]);
+    setPage(1);
+    setIsLoading(false);
+    setHasMore(true);
+  }, []);
+
+  return { data, page, isLoading, hasMore, loadMore, reset };
+}
+
+export default usePagination;


### PR DESCRIPTION
Summary:
- Add useMedicalRecords for fetching, filtering, caching, refetching, and error state.
- Add useBlockchainVerification with cached integrity checks and verification statuses.
- Add useHealthMetrics and generic usePagination hooks.

Closes #851
Closes #852
Closes #853
Closes #854

Validation:
- npm ci --legacy-peer-deps
- npx prettier --check src/hooks/usePagination.ts src/hooks/useMedicalRecords.ts src/hooks/useBlockchainVerification.ts src/hooks/useHealthMetrics.ts
- node_modules/.bin/eslint src/hooks/usePagination.ts src/hooks/useMedicalRecords.ts src/hooks/useBlockchainVerification.ts src/hooks/useHealthMetrics.ts
- npm run lint -- src/hooks/usePagination.ts src/hooks/useMedicalRecords.ts src/hooks/useBlockchainVerification.ts src/hooks/useHealthMetrics.ts
- npm run typecheck (fails on existing unrelated errors in backend/services/stellarAssetService.ts, src/services/blockchainService.ts, src/services/nutritionService.ts)