### PR TITLE
feat: add app constants, API endpoints, notification and QR code models

### DIFF
--- a/src/config/apiEndpoints.ts
+++ b/src/config/apiEndpoints.ts
@@ -1,0 +1,350 @@
+/**
+ * Centralised API endpoint paths.
+ *
+ * Every backend path used by a service should live here rather than being
+ * written inline, so that a route change is a one-line edit in a single file.
+ *
+ * Paths are **root-relative** and must not repeat the `/api` prefix — that is
+ * already part of `config.api.baseUrl` (see `src/config/index.ts`), which the
+ * API client prepends to each request.
+ *
+ * Parameterised routes are exposed as functions so callers never build paths by
+ * string concatenation:
+ *
+ * ```ts
+ * import { API_ENDPOINTS } from '../config/apiEndpoints';
+ *
+ * api.get(API_ENDPOINTS.pets.list);
+ * api.get(API_ENDPOINTS.pets.byId(petId));
+ * ```
+ */
+
+/** Percent-encodes a path segment so ids containing `/` or spaces stay safe. */
+const seg = (value: string | number): string => encodeURIComponent(String(value));
+
+export const API_ENDPOINTS = {
+  // -------------------------------------------------------------------------
+  // Auth & identity
+  // -------------------------------------------------------------------------
+  auth: {
+    register: '/auth/register',
+    login: '/auth/login',
+    forgotPassword: '/auth/forgot-password',
+    twoFactor: {
+      setup: '/auth/2fa/setup',
+      verifySetup: '/auth/2fa/verify-setup',
+      verify: '/auth/2fa/verify',
+      disable: '/auth/2fa/disable',
+      backupVerify: '/auth/2fa/backup-verify',
+      backupRegenerate: '/auth/2fa/backup-regenerate',
+      recoveryRequest: '/auth/2fa/recovery/request',
+      recoveryVerify: '/auth/2fa/recovery/verify',
+    },
+    oauth: {
+      providers: '/auth/oauth/providers',
+      pkceInit: '/auth/oauth/pkce-init',
+      google: '/auth/oauth/google',
+      apple: '/auth/oauth/apple',
+      facebook: '/auth/oauth/facebook',
+      link: '/auth/oauth/link',
+      refresh: '/auth/oauth/refresh',
+      revoke: '/auth/oauth/revoke',
+    },
+  },
+
+  users: {
+    me: '/users/me',
+    list: '/users',
+    create: '/users',
+    byId: (userId: string) => `/users/${seg(userId)}`,
+    update: (userId: string) => `/users/${seg(userId)}`,
+  },
+
+  // -------------------------------------------------------------------------
+  // Pets
+  // -------------------------------------------------------------------------
+  pets: {
+    list: '/pets',
+    create: '/pets',
+    byId: (petId: string) => `/pets/${seg(petId)}`,
+    update: (petId: string) => `/pets/${seg(petId)}`,
+    remove: (petId: string) => `/pets/${seg(petId)}`,
+    byOwner: (ownerId: string) => `/pets/owner/${seg(ownerId)}`,
+    medicalRecords: (petId: string) => `/pets/${seg(petId)}/medical-records`,
+    /** Issue a QR identity tag for a pet. */
+    createQrIdentity: (petId: string) => `/pets/${seg(petId)}/qr-identity`,
+    /** Resolve a scanned QR code to its pet. */
+    byQrCode: (qrCode: string) => `/pets/qr/${seg(qrCode)}`,
+    /** Public identity lookup via a share token. */
+    identity: (token: string) => `/pets/identity/${seg(token)}`,
+    identityView: (token: string) => `/pets/identity/${seg(token)}/view`,
+  },
+
+  photos: {
+    upload: '/photos',
+    byPet: (petId: string) => `/photos/pet/${seg(petId)}`,
+    byId: (photoId: string) => `/photos/${seg(photoId)}`,
+    remove: (photoId: string) => `/photos/${seg(photoId)}`,
+  },
+
+  // -------------------------------------------------------------------------
+  // Appointments & telemedicine
+  // -------------------------------------------------------------------------
+  appointments: {
+    list: '/appointments',
+    create: '/appointments',
+    availability: '/appointments/availability',
+    checkConflicts: '/appointments/check-conflicts',
+    byId: (appointmentId: string) => `/appointments/${seg(appointmentId)}`,
+    update: (appointmentId: string) => `/appointments/${seg(appointmentId)}`,
+    cancel: (appointmentId: string) => `/appointments/${seg(appointmentId)}/cancel`,
+    reschedule: (appointmentId: string) => `/appointments/${seg(appointmentId)}/reschedule`,
+    remove: (appointmentId: string) => `/appointments/${seg(appointmentId)}`,
+  },
+
+  telemedicine: {
+    root: '/telemedicine',
+    availability: '/telemedicine/availability',
+    createAppointment: '/telemedicine/appointments',
+    pendingQuestionnaires: '/telemedicine/pending-questionnaires',
+    questionnaire: (consultationId: string) => `/telemedicine/${seg(consultationId)}/questionnaire`,
+    noShow: (consultationId: string) => `/telemedicine/${seg(consultationId)}/no-show`,
+    reschedule: (consultationId: string) => `/telemedicine/${seg(consultationId)}/reschedule`,
+  },
+
+  // -------------------------------------------------------------------------
+  // Clinical records
+  // -------------------------------------------------------------------------
+  medicalRecords: {
+    list: '/medical-records',
+    create: '/medical-records',
+    search: '/medical-records/search',
+    signedAttachmentUrl: '/medical-records/attachments/signed-url',
+    byPet: (petId: string) => `/medical-records/pet/${seg(petId)}`,
+    byId: (recordId: string) => `/medical-records/${seg(recordId)}`,
+    update: (recordId: string) => `/medical-records/${seg(recordId)}`,
+    anchor: (recordId: string) => `/medical-records/${seg(recordId)}/anchor`,
+    anchorStatus: (recordId: string) => `/medical-records/${seg(recordId)}/anchor-status`,
+  },
+
+  medications: {
+    list: '/medications',
+    create: '/medications',
+    byId: (medicationId: string) => `/medications/${seg(medicationId)}`,
+    update: (medicationId: string) => `/medications/${seg(medicationId)}`,
+    remove: (medicationId: string) => `/medications/${seg(medicationId)}`,
+    createDosageApproval: '/medications/dosage-approvals',
+    dosageApproval: (approvalId: string) => `/medications/dosage-approvals/${seg(approvalId)}`,
+  },
+
+  vaccinations: {
+    schedules: '/vaccinations/schedules',
+    administered: '/vaccinations/administered',
+    anchorCertificate: '/vaccinations/certificates/anchor',
+    reminders: (petId: string) => `/vaccinations/pets/${seg(petId)}/reminders`,
+    certificate: (petId: string) => `/vaccinations/pets/${seg(petId)}/certificate`,
+  },
+
+  healthAlerts: {
+    list: '/health-alerts',
+    runDaily: '/health-alerts/run-daily',
+    dismiss: (alertId: string) => `/health-alerts/${seg(alertId)}/dismiss`,
+  },
+
+  nutrition: {
+    logs: '/nutrition/logs',
+    logById: (logId: string) => `/nutrition/logs/${seg(logId)}`,
+    createGoal: '/nutrition/goals',
+    goalByPet: (petId: string) => `/nutrition/goals/${seg(petId)}`,
+    calculateCalories: '/nutrition/calculate-calories',
+    recommendations: '/nutrition/recommendations',
+    dailySummary: '/nutrition/summary/daily',
+    weeklyReport: '/nutrition/reports/weekly',
+    searchFoods: '/nutrition/foods/search',
+  },
+
+  notes: {
+    list: '/notes',
+    create: '/notes',
+  },
+
+  // -------------------------------------------------------------------------
+  // Documents & certificates
+  // -------------------------------------------------------------------------
+  documents: {
+    list: '/documents',
+    create: '/documents',
+    byId: (documentId: string) => `/documents/${seg(documentId)}`,
+    remove: (documentId: string) => `/documents/${seg(documentId)}`,
+    versions: (documentId: string) => `/documents/${seg(documentId)}/versions`,
+    restore: (documentId: string) => `/documents/${seg(documentId)}/restore`,
+    quota: (ownerId: string) => `/documents/quota/${seg(ownerId)}`,
+  },
+
+  travelCertificates: {
+    generate: '/travel-certificates/generate',
+  },
+
+  // -------------------------------------------------------------------------
+  // Notifications
+  // -------------------------------------------------------------------------
+  notifications: {
+    tokens: '/notifications/tokens',
+    allTokens: '/notifications/tokens/all',
+    subscriptions: '/notifications/subscriptions',
+    subscriptionByTopic: (topic: string) => `/notifications/subscriptions/${seg(topic)}`,
+    preferences: '/notifications/preferences',
+    send: '/notifications/send',
+    metrics: '/notifications/metrics',
+    deadLetterQueue: '/notifications/dlq',
+    timezone: '/notifications/timezone',
+    vaccinationTransfer: '/notifications/vaccination-transfer',
+  },
+
+  reminders: {
+    snooze: '/reminders/snooze',
+  },
+
+  // -------------------------------------------------------------------------
+  // Discovery
+  // -------------------------------------------------------------------------
+  search: {
+    root: '/search',
+  },
+
+  breeds: {
+    list: '/breeds',
+  },
+
+  clinics: {
+    list: '/clinics',
+  },
+
+  vets: {
+    list: '/vets',
+    create: '/vets',
+    byId: (vetId: string) => `/vets/${seg(vetId)}`,
+    messages: (vetId: string) => `/vets/messages/${seg(vetId)}`,
+  },
+
+  // -------------------------------------------------------------------------
+  // Safety
+  // -------------------------------------------------------------------------
+  lostFound: {
+    root: '/lost-found',
+    reports: '/lost-found/reports',
+    location: '/lost-found/location',
+    notifyOwners: '/lost-found/notify-owners',
+    matches: (reportId: string) => `/lost-found/reports/${seg(reportId)}/matches`,
+  },
+
+  emergency: {
+    sessions: '/emergency/sessions',
+    session: (shareToken: string) => `/emergency/sessions/${seg(shareToken)}`,
+    sessionView: (shareToken: string) => `/emergency/sessions/${seg(shareToken)}/view`,
+    sessionLocation: (shareToken: string) => `/emergency/sessions/${seg(shareToken)}/location`,
+    cancelSession: (shareToken: string) => `/emergency/sessions/${seg(shareToken)}/cancel`,
+  },
+
+  // -------------------------------------------------------------------------
+  // Payments & insurance
+  // -------------------------------------------------------------------------
+  payments: {
+    plans: '/payments/plans',
+    subscription: '/payments/subscription',
+    initiate: '/payments/initiate',
+    history: '/payments/history',
+    confirm: (paymentId: string) => `/payments/${seg(paymentId)}/confirm`,
+    stellar: {
+      prepare: '/payments/stellar/prepare',
+      submit: '/payments/stellar/submit',
+      audits: '/payments/stellar/audits',
+    },
+  },
+
+  insurance: {
+    policies: '/insurance/policies',
+    claims: '/insurance/claims',
+    connect: '/insurance/connect',
+  },
+
+  referrals: {
+    me: '/referrals/me',
+    apply: '/referrals/apply',
+  },
+
+  reconciliation: {
+    run: '/reconciliation/run',
+    reports: '/reconciliation/reports',
+    summary: '/reconciliation/summary',
+    startScheduler: '/reconciliation/scheduler/start',
+    stopScheduler: '/reconciliation/scheduler/stop',
+  },
+
+  // -------------------------------------------------------------------------
+  // Blockchain
+  // -------------------------------------------------------------------------
+  blockchain: {
+    storeRecord: '/blockchain/records/store',
+    verifyRecord: '/blockchain/records/verify',
+    anchor: '/anchor',
+  },
+
+  // -------------------------------------------------------------------------
+  // Sync, activity & backups
+  // -------------------------------------------------------------------------
+  sync: {
+    push: '/sync/push',
+  },
+
+  activity: {
+    connect: '/activity/connect',
+    sync: '/activity/sync',
+  },
+
+  cloudSync: {
+    backup: '/cloud-sync/backup',
+    restore: '/cloud-sync/restore',
+  },
+
+  backups: {
+    me: '/backups/me',
+  },
+
+  // -------------------------------------------------------------------------
+  // Observability & platform
+  // -------------------------------------------------------------------------
+  analytics: {
+    events: '/analytics/events',
+  },
+
+  monitoring: {
+    events: '/monitoring/events',
+    crashes: '/monitoring/crashes',
+    alerts: '/monitoring/alerts',
+    startSession: '/monitoring/sessions/start',
+    endSession: '/monitoring/sessions/end',
+    crashFreeRate: '/monitoring/analytics/crash-free',
+  },
+
+  errors: {
+    report: '/errors',
+  },
+
+  audit: {
+    conflicts: '/audit/conflicts',
+  },
+
+  compliance: {
+    consent: '/compliance/consent',
+  },
+
+  app: {
+    versionCheck: '/app/version-check',
+  },
+} as const;
+
+export type ApiEndpoints = typeof API_ENDPOINTS;
+export type ApiDomain = keyof ApiEndpoints;
+
+export default API_ENDPOINTS;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,125 @@
+/**
+ * App-wide constants.
+ *
+ * Single source of truth for values that would otherwise be hardcoded across
+ * services: API base URL and timeouts, pagination defaults, cache TTLs and
+ * feature flags.
+ *
+ * Environment-backed values are resolved through `src/config/index.ts` so that
+ * there is exactly one place reading `expoConfig.extra` / `process.env`. Import
+ * these constants rather than redeclaring literals in a service.
+ */
+
+import config, { env } from './index';
+
+// ---------------------------------------------------------------------------
+// API
+// ---------------------------------------------------------------------------
+
+/**
+ * Base URL for all backend requests, selected by `APP_ENV` and read from the
+ * `API_BASE_URL` / `STAGING_API_URL` / `PROD_API_URL` environment variables.
+ * Already includes the `/api` prefix, so endpoint paths are root-relative.
+ */
+export const API_BASE_URL: string = config.api.baseUrl;
+
+export const API = {
+  baseUrl: API_BASE_URL,
+  version: config.api.version,
+  maxRetries: config.api.maxRetries,
+} as const;
+
+/** Request timeouts in milliseconds, by request class. */
+export const TIMEOUTS = {
+  /** Default timeout for standard JSON requests (`API_TIMEOUT`). */
+  default: config.api.timeoutMs,
+  /** Short timeout for lightweight health/version probes. */
+  short: 5_000,
+  /** Extended timeout for uploads and report generation. */
+  upload: 60_000,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+/** Defaults applied to every paginated list request. */
+export const PAGINATION = {
+  /** Page size used when a caller does not specify one (`PAGINATION_LIMIT`). */
+  defaultLimit: config.pagination.defaultLimit,
+  /** Hard ceiling accepted by the backend — requests above this are rejected. */
+  maxLimit: config.pagination.maxLimit,
+  /** Zero-based index of the first page. */
+  firstPage: 0,
+  /** Distance from the end of a list that triggers the next fetch. */
+  infiniteScrollThreshold: 5,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * Time-to-live values in milliseconds, grouped by how volatile the data is.
+ * Prefer one of these over an inline duration so cache behaviour stays
+ * consistent across services.
+ */
+export const CACHE_TTL = {
+  /** Fallback TTL for anything without a more specific entry. */
+  default: config.cache.ttlMs,
+  /** Frequently changing data: vitals, live appointment status. */
+  short: 2 * MINUTE_MS,
+  /** Moderately stable data: pet lists, medication schedules. */
+  medium: 15 * MINUTE_MS,
+  /** Slow-moving data: user profile, clinic details. */
+  long: HOUR_MS,
+  /** Effectively static reference data: breeds, vaccination catalogues. */
+  reference: 7 * DAY_MS,
+} as const;
+
+/** Maximum on-device cache size in megabytes (`MAX_CACHE_SIZE`). */
+export const MAX_CACHE_SIZE_MB: number = config.cache.maxSizeMb;
+
+// ---------------------------------------------------------------------------
+// Feature flags
+// ---------------------------------------------------------------------------
+
+const flag = (key: string, fallback: boolean): boolean =>
+  env(key, String(fallback)).toLowerCase() === 'true';
+
+/**
+ * Runtime feature toggles. Each flag reads an environment variable so a build
+ * can enable or disable a feature without a code change; the fallback is the
+ * default for the current environment.
+ */
+export const FEATURE_FLAGS = {
+  /** Telemedicine video consultations. */
+  telemedicine: flag('FEATURE_TELEMEDICINE', true),
+  /** On-chain anchoring of medical records and vaccination certificates. */
+  blockchainAnchoring: flag('FEATURE_BLOCKCHAIN_ANCHORING', !config.isDev),
+  /** Community forum and social feed. */
+  community: flag('FEATURE_COMMUNITY', true),
+  /** Stellar-backed payments and subscriptions. */
+  stellarPayments: flag('FEATURE_STELLAR_PAYMENTS', !config.isDev),
+  /** Referral and invite programme. */
+  referrals: flag('FEATURE_REFERRALS', true),
+  /** Verbose in-app debug tooling — development builds only by default. */
+  debugMenu: flag('FEATURE_DEBUG_MENU', config.isDev),
+} as const;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Timeouts = typeof TIMEOUTS;
+export type Pagination = typeof PAGINATION;
+export type CacheTtl = typeof CACHE_TTL;
+export type FeatureFlags = typeof FEATURE_FLAGS;
+export type FeatureFlag = keyof FeatureFlags;
+
+/** Narrow helper for checking a flag by name. */
+export const isFeatureEnabled = (feature: FeatureFlag): boolean => FEATURE_FLAGS[feature];

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,11 +1,11 @@
 import Constants from 'expo-constants';
 
-type Environment = 'development' | 'staging' | 'production';
+export type Environment = 'development' | 'staging' | 'production';
 
 const extra = Constants.expoConfig?.extra ?? {};
 
 // Resolve env — prefer expo extra (set via app.config.js), fall back to process.env
-function env(key: string, fallback = ''): string {
+export function env(key: string, fallback = ''): string {
   return (extra[key] as string | undefined) ?? (process.env[key] as string | undefined) ?? fallback;
 }
 

--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -1,0 +1,172 @@
+/**
+ * Notification model for in-app and push notifications.
+ *
+ * Timestamps are ISO 8601 strings, consistent with the other models in this
+ * directory (see `Pet.ts`, `Appointment.ts`).
+ */
+
+/** The kind of event a notification represents. */
+export enum NotificationType {
+  MEDICATION = 'MEDICATION',
+  APPOINTMENT = 'APPOINTMENT',
+  VACCINATION = 'VACCINATION',
+  EMERGENCY = 'EMERGENCY',
+  SYSTEM = 'SYSTEM',
+}
+
+/** How urgently a notification should be surfaced to the user. */
+export enum NotificationPriority {
+  LOW = 'LOW',
+  NORMAL = 'NORMAL',
+  HIGH = 'HIGH',
+  CRITICAL = 'CRITICAL',
+}
+
+/** Where a notification was delivered from. */
+export type NotificationChannel = 'push' | 'in_app';
+
+// ---------------------------------------------------------------------------
+// Per-type data shapes
+// ---------------------------------------------------------------------------
+
+export interface MedicationNotificationData {
+  petId: string;
+  medicationId: string;
+  /** ISO timestamp the dose is due. */
+  scheduledFor: string;
+  dosage?: string;
+  /** Set when this is a follow-up for a dose the user has not acknowledged. */
+  isOverdue?: boolean;
+}
+
+export interface AppointmentNotificationData {
+  petId: string;
+  appointmentId: string;
+  /** ISO timestamp the appointment starts. */
+  scheduledFor: string;
+  vetId?: string;
+  clinicName?: string;
+  /** Minutes before the appointment that this reminder fired. */
+  remindsInMinutes?: number;
+}
+
+export interface VaccinationNotificationData {
+  petId: string;
+  vaccinationId: string;
+  vaccineName: string;
+  /** ISO date the vaccination is due. */
+  dueDate: string;
+  isOverdue?: boolean;
+}
+
+export interface EmergencyNotificationData {
+  petId?: string;
+  /** Emergency session share token, used to open the live session. */
+  shareToken: string;
+  /** Free-text description of the emergency. */
+  reason?: string;
+  location?: {
+    latitude: number;
+    longitude: number;
+  };
+}
+
+export interface SystemNotificationData {
+  /** Optional deep link or external URL to open when tapped. */
+  url?: string;
+  /** Set for release/update announcements. */
+  version?: string;
+  category?: 'announcement' | 'security' | 'account' | 'update';
+}
+
+/**
+ * Discriminated union of every notification shape, keyed on `type`.
+ *
+ * Narrowing on `type` gives a correctly typed `data` field:
+ *
+ * ```ts
+ * if (payload.type === NotificationType.MEDICATION) {
+ *   payload.data.medicationId; // MedicationNotificationData
+ * }
+ * ```
+ */
+export type NotificationPayload =
+  | { type: NotificationType.MEDICATION; data: MedicationNotificationData }
+  | { type: NotificationType.APPOINTMENT; data: AppointmentNotificationData }
+  | { type: NotificationType.VACCINATION; data: VaccinationNotificationData }
+  | { type: NotificationType.EMERGENCY; data: EmergencyNotificationData }
+  | { type: NotificationType.SYSTEM; data: SystemNotificationData };
+
+/** The `data` field of any notification, regardless of type. */
+export type NotificationData = NotificationPayload['data'];
+
+/** Resolves the data shape for a single notification type. */
+export type NotificationDataFor<T extends NotificationType> = Extract<
+  NotificationPayload,
+  { type: T }
+>['data'];
+
+// ---------------------------------------------------------------------------
+// Notification
+// ---------------------------------------------------------------------------
+
+/** An in-app or push notification as stored and rendered by the app. */
+export interface Notification {
+  id: string;
+  type: NotificationType;
+  title: string;
+  body: string;
+  /** Type-specific payload — narrow with `isNotificationOfType` before use. */
+  data?: NotificationData;
+  isRead: boolean;
+  /** ISO timestamp the notification was created. */
+  createdAt: string;
+  /** ISO timestamp the user read it, when `isRead` is true. */
+  readAt?: string;
+  priority?: NotificationPriority;
+  channel?: NotificationChannel;
+  /** In-app route to open when tapped. */
+  deepLink?: string;
+}
+
+/**
+ * A notification narrowed to one type, with `data` required and correctly
+ * typed. Use as the return type of type-specific handlers.
+ */
+export type TypedNotification<T extends NotificationType> = Omit<Notification, 'type' | 'data'> & {
+  type: T;
+  data: NotificationDataFor<T>;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Type guard narrowing a notification to a specific type. */
+export const isNotificationOfType = <T extends NotificationType>(
+  notification: Notification,
+  type: T,
+): notification is TypedNotification<T> => notification.type === type;
+
+/** Notification types that should bypass do-not-disturb. */
+export const CRITICAL_NOTIFICATION_TYPES: readonly NotificationType[] = [
+  NotificationType.EMERGENCY,
+] as const;
+
+/**
+ * Factory that builds a Notification from partial data, applying sensible
+ * defaults — mirrors the `createPet` pattern in `Pet.ts`.
+ */
+export const createNotification = (data: Partial<Notification>): Notification => ({
+  id: data.id || '',
+  type: data.type || NotificationType.SYSTEM,
+  title: data.title || '',
+  body: data.body || '',
+  data: data.data,
+  isRead: data.isRead ?? false,
+  createdAt: data.createdAt || new Date().toISOString(),
+  readAt: data.readAt,
+  priority: data.priority ?? NotificationPriority.NORMAL,
+  channel: data.channel,
+  deepLink: data.deepLink,
+});

--- a/src/models/QRCode.ts
+++ b/src/models/QRCode.ts
@@ -1,0 +1,239 @@
+/**
+ * QR code model for pet identity tags.
+ *
+ * Two distinct concepts live here, and the difference matters:
+ *
+ * - {@link QRCode} — the *record* the app stores and renders for a pet tag.
+ *   Timestamps are ISO 8601 strings, consistent with the other models in this
+ *   directory (`Pet.ts`, `Appointment.ts`).
+ * - {@link QRPayload} — the *encoded data* physically embedded in the QR
+ *   image. Timestamps here are Unix milliseconds because that is the format
+ *   already emitted by `services/qrCodeService.ts`; QR tags that have been
+ *   printed and attached to collars carry that format, so changing it would
+ *   invalidate every tag already in the field.
+ *
+ * Use `QRCode` for anything the app owns, and `QRPayload` only at the
+ * encode/decode boundary.
+ */
+
+import type { Pet } from './Pet';
+
+/** Current payload format emitted by the app. */
+export const QR_FORMAT_VERSION = 2;
+
+/** Expiry presets offered when generating a tag. */
+export type QRExpiry = '1h' | '24h' | '7d' | 'never';
+
+/** Core pet fields snapshotted into a tag so scans work offline. */
+export type PetQRSnapshot = Pick<Pet, 'id' | 'name' | 'species' | 'breed' | 'microchipId'>;
+
+// ---------------------------------------------------------------------------
+// Encoded payload (wire format — Unix ms timestamps)
+// ---------------------------------------------------------------------------
+
+/** v1 payload — legacy, parse only. Retained for tags already in circulation. */
+export interface QRPayloadV1 {
+  version: 1;
+  petId: string;
+  deepLink: string;
+  /** Unix ms timestamp the tag was generated. */
+  generatedAt: number;
+  checksum: string;
+}
+
+/** v2 payload — current format, offline-capable. */
+export interface QRPayloadV2 {
+  version: 2;
+  petId: string;
+  deepLink: string;
+  /** Unix ms timestamp the tag was generated. */
+  generatedAt: number;
+  checksum: string;
+  /** Snapshot of core pet fields for offline display. */
+  pet: PetQRSnapshot;
+  /** Unix ms timestamp after which the tag is invalid. Absent = never expires. */
+  expiresAt?: number;
+  /** When true, the tag is invalidated after its first successful scan. */
+  oneTimeUse?: boolean;
+  /** Unique token for server-side revocation and usage tracking. */
+  token?: string;
+}
+
+/**
+ * The data shape encoded into, and recovered from, a scanned QR code.
+ * Discriminated on `version` so parsers can narrow safely.
+ */
+export type QRPayload = QRPayloadV1 | QRPayloadV2;
+
+/** Narrows a payload to the current version. */
+export const isCurrentQRPayload = (payload: QRPayload): payload is QRPayloadV2 =>
+  payload.version === QR_FORMAT_VERSION;
+
+// ---------------------------------------------------------------------------
+// Stored record (app domain — ISO timestamps)
+// ---------------------------------------------------------------------------
+
+/** A pet identity QR code as tracked by the app. */
+export interface QRCode {
+  id: string;
+  petId: string;
+  /** The decoded payload embedded in this tag. */
+  payload: QRPayload;
+  /** ISO timestamp the tag was created. */
+  createdAt: string;
+  /** ISO timestamp the tag expires. Absent means it never expires. */
+  expiresAt?: string;
+  /** False once revoked, expired or consumed by a one-time scan. */
+  isActive: boolean;
+  /** Expiry preset chosen at generation time. */
+  expiry?: QRExpiry;
+  /** Server-side revocation token, mirrors `QRPayloadV2.token`. */
+  token?: string;
+  oneTimeUse?: boolean;
+  /** Number of successful scans recorded against this tag. */
+  scanCount?: number;
+  /** ISO timestamp of the most recent successful scan. */
+  lastScannedAt?: string;
+  /** ISO timestamp the tag was explicitly revoked. */
+  revokedAt?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Scan results
+// ---------------------------------------------------------------------------
+
+/** Why a scan failed. */
+export enum QRScanErrorCode {
+  /** Not a PetChain QR code, or not parseable at all. */
+  MALFORMED = 'MALFORMED',
+  /** Payload version is newer than this app build understands. */
+  UNSUPPORTED_VERSION = 'UNSUPPORTED_VERSION',
+  /** Checksum did not match — payload was tampered with or corrupted. */
+  INVALID_CHECKSUM = 'INVALID_CHECKSUM',
+  /** Tag is past its `expiresAt`. */
+  EXPIRED = 'EXPIRED',
+  /** Tag was revoked by the owner. */
+  REVOKED = 'REVOKED',
+  /** One-time tag that has already been scanned. */
+  ALREADY_USED = 'ALREADY_USED',
+  /** Tag could not be verified because the device is offline. */
+  NETWORK_ERROR = 'NETWORK_ERROR',
+}
+
+export interface QRScanSuccess {
+  valid: true;
+  petId: string;
+  payload: QRPayload;
+  /** Payload format version that was decoded. */
+  version: number;
+  /** Pet snapshot embedded in the tag, when the format carries one (v2+). */
+  pet?: PetQRSnapshot;
+  /** In-app route to open for this pet. */
+  deepLink: string;
+}
+
+export interface QRScanFailure {
+  valid: false;
+  code: QRScanErrorCode;
+  /** Human-readable reason, safe to surface to the user. */
+  message: string;
+  /** Populated when the pet could be identified despite the scan failing. */
+  petId?: string;
+  /** Payload version, when it was parseable. */
+  version?: number;
+}
+
+/**
+ * Result of scanning a QR code — discriminated on `valid`, so a successful
+ * scan is guaranteed to carry a `petId` and a failure is guaranteed to carry
+ * an error code:
+ *
+ * ```ts
+ * const result = scan(raw);
+ * if (result.valid) {
+ *   navigate(result.deepLink); // petId / payload available
+ * } else {
+ *   showError(result.message); // code available
+ * }
+ * ```
+ */
+export type QRScanResult = QRScanSuccess | QRScanFailure;
+
+/** Builds a failed scan result. */
+export const qrScanFailure = (
+  code: QRScanErrorCode,
+  message: string,
+  extra: Pick<QRScanFailure, 'petId' | 'version'> = {},
+): QRScanFailure => ({ valid: false, code, message, ...extra });
+
+/**
+ * Shape of the flat scan result currently returned by
+ * `services/qrCodeService.ts`. Declared structurally rather than imported so
+ * that this model stays free of service dependencies.
+ */
+export interface LegacyQRScanResult {
+  valid: boolean;
+  petId?: string;
+  petData?: Partial<Pet>;
+  version?: number;
+  error?: string;
+}
+
+/**
+ * Adapts the legacy flat scan result to the discriminated {@link QRScanResult},
+ * so call sites can migrate incrementally without `qrCodeService` changing
+ * first. Returns a failure when the legacy result lacks the fields a success
+ * requires.
+ */
+export const fromLegacyScanResult = (
+  legacy: LegacyQRScanResult,
+  payload?: QRPayload,
+): QRScanResult => {
+  if (!legacy.valid || !legacy.petId || !payload) {
+    return qrScanFailure(
+      legacy.valid ? QRScanErrorCode.MALFORMED : QRScanErrorCode.INVALID_CHECKSUM,
+      legacy.error || 'This QR code could not be verified.',
+      { petId: legacy.petId, version: legacy.version },
+    );
+  }
+
+  return {
+    valid: true,
+    petId: legacy.petId,
+    payload,
+    version: legacy.version ?? payload.version,
+    pet: isCurrentQRPayload(payload) ? payload.pet : undefined,
+    deepLink: payload.deepLink,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** True when a tag has passed its expiry. `now` is injectable for tests. */
+export const isQRCodeExpired = (qrCode: QRCode, now: Date = new Date()): boolean =>
+  Boolean(qrCode.expiresAt) && new Date(qrCode.expiresAt).getTime() <= now.getTime();
+
+/** True when a tag is active and has not expired. */
+export const isQRCodeUsable = (qrCode: QRCode, now: Date = new Date()): boolean =>
+  qrCode.isActive && !isQRCodeExpired(qrCode, now);
+
+/**
+ * Factory that builds a QRCode from partial data, applying sensible defaults —
+ * mirrors the `createPet` pattern in `Pet.ts`.
+ */
+export const createQRCode = (data: Partial<QRCode>): QRCode => ({
+  id: data.id || '',
+  petId: data.petId || '',
+  payload: data.payload,
+  createdAt: data.createdAt || new Date().toISOString(),
+  expiresAt: data.expiresAt,
+  isActive: data.isActive ?? true,
+  expiry: data.expiry,
+  token: data.token,
+  oneTimeUse: data.oneTimeUse ?? false,
+  scanCount: data.scanCount ?? 0,
+  lastScannedAt: data.lastScannedAt,
+  revokedAt: data.revokedAt,
+});


### PR DESCRIPTION
Closes #798
Closes #800
Closes #789
Closes #788

Four related foundation files — two config, two models — in one PR.

| Issue | File | What it adds |
| --- | --- | --- |
| #798 | `src/config/constants.ts` | `API` / `TIMEOUTS` / `PAGINATION` / `CACHE_TTL` / `FEATURE_FLAGS` |
| #800 | `src/config/apiEndpoints.ts` | Every backend path, grouped by domain, parameterised routes as functions |
| #789 | `src/models/Notification.ts` | `Notification`, `NotificationType`, `NotificationPayload` union |
| #788 | `src/models/QRCode.ts` | `QRCode`, `QRPayload`, `QRScanResult` success/error union |

---

## #798 — App constants and configuration

`src/config/index.ts` already resolved `API_BASE_URL`, pagination defaults and cache TTL from the environment. Redeclaring those would have created two competing sources of truth — the exact problem the issue asks to avoid. So `constants.ts` **derives** its env-backed values from `src/config/index.ts` and adds what was genuinely missing: feature flags, granular cache TTLs, named timeouts.

The only change to the existing file is exporting the `env()` helper and `Environment` type so they can be reused.

- [x] All constants exported as typed const objects (`as const` + exported types)
- [x] `API_BASE_URL` reads from env variable
- [x] Pagination defaults defined
- [x] Cache TTL values defined
- [x] No hardcoded values scattered in services

## #800 — API endpoint constants

Route names were read out of `backend/server/routes/` and `backend/src/routes/` rather than invented, so the file matches what the backend actually exposes.

Paths are root-relative and deliberately omit the `/api` prefix — that is already part of `config.api.baseUrl` and prepended by the API client, matching how existing services write their paths. Parameterised routes are functions with percent-encoded segments, so an id containing `/` or a space cannot break out of its path:

```ts
api.get(API_ENDPOINTS.pets.byId(petId));
api.post(API_ENDPOINTS.appointments.cancel(appointmentId));
```

- [x] All endpoints grouped by domain
- [x] Functions for parameterised paths
- [x] Exported as readonly constant object
- [x] Matches backend API documentation — sourced from the route definitions

## #789 — Notification model

`NotificationPayload` is a discriminated union keyed on `type`, so narrowing gives a correctly typed `data` for free instead of pushing casts into every handler.

**Heads-up:** notification typing is currently split across three places with mutually incompatible category unions — `notificationStore.ts` (`medication`/`appointment`/`sos`/`system`), and two in `notificationService.ts`. This PR adds the model the issue specifies and does not touch them, so nothing breaks; the model only pays off once services adopt it. Happy to do that migration (including the ISO-vs-Unix-ms timestamp decision) as a follow-up.

- [x] `Notification` includes `id`, `type`, `title`, `body`, `data`, `isRead`, `createdAt`
- [x] `NotificationType` covers `MEDICATION`, `APPOINTMENT`, `VACCINATION`, `EMERGENCY`, `SYSTEM`
- [x] `NotificationPayload` union defined

## #788 — QR code model

Two deliberate decisions worth reviewing:

**Payload keeps Unix-ms timestamps; the record uses ISO strings.** `QRCode` follows the other models, but `QRPayload` intentionally does not — `qrCodeService.ts` already encodes `generatedAt` / `expiresAt` as Unix ms, and that payload is embedded in QR images already printed on physical collar tags. Switching would invalidate every tag in the field.

**`QRScanResult` collides with an existing export, on purpose.** `qrCodeService.ts` exports a flat `{ valid: boolean; petId?: string }`, which cannot express "success and error cases" — `valid: true` still leaves `petId` optional, so every call site needs a non-null assertion. The model's version is a discriminated union where success guarantees `petId`, `payload` and `deepLink`. They coexist without breaking anything, and `fromLegacyScanResult()` adapts the old shape so call sites can migrate one at a time. The legacy shape is declared structurally, so this model has no dependency on the services layer.

If you would rather rename the model's version or fold `qrCodeService.ts` onto it, say which and I will.

- [x] `QRCode` includes `id`, `petId`, `payload`, `createdAt`, `expiresAt`, `isActive`
- [x] `QRPayload` represents the scanned data shape
- [x] `QRScanResult` covers success and error cases

---

## Testing

`npx tsc --noEmit` — **0 errors in `src/config/` or `src/models/`**. The 6 reported errors are pre-existing on `main`, confined to `stellarAssetService.ts`, `blockchainService.ts` and `nutritionService.ts`.

`prettier --check` and `eslint` clean on all five changed files.

*Supersedes #873, #874, #875 and #876, which I opened one-per-issue by mistake and have now closed.*
