### PR TITLE
feat(hooks): add useNetworkStatus custom hook (closes #818)

### DIFF
--- a/src/hooks/__tests__/useNetworkStatus.test.ts
+++ b/src/hooks/__tests__/useNetworkStatus.test.ts
@@ -1,0 +1,134 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useNetworkStatus } from '../useNetworkStatus';
+import { networkMonitor } from '../../utils/networkMonitor';
+
+jest.mock('../../utils/networkMonitor', () => ({
+  networkMonitor: {
+    getStatus: jest.fn(),
+    onStatusChange: jest.fn(),
+  },
+}));
+
+describe('useNetworkStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns default values before initial fetch resolves', () => {
+    (networkMonitor.getStatus as jest.Mock).mockReturnValue(new Promise(() => {})); // never resolves
+    (networkMonitor.onStatusChange as jest.Mock).mockReturnValue(jest.fn());
+
+    const { result } = renderHook(() => useNetworkStatus());
+
+    expect(result.current).toEqual({
+      isOnline: true,
+      networkType: 'unknown',
+    });
+  });
+
+  it('fetches and returns initial network status', async () => {
+    (networkMonitor.getStatus as jest.Mock).mockResolvedValue({
+      isOnline: true,
+      connectionType: 'wifi',
+    });
+    (networkMonitor.onStatusChange as jest.Mock).mockReturnValue(jest.fn());
+
+    const { result } = renderHook(() => useNetworkStatus());
+
+    // Wait for the async getStatus to resolve
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(networkMonitor.getStatus).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual({
+      isOnline: true,
+      networkType: 'wifi',
+    });
+  });
+
+  it('re-renders when network status changes', () => {
+    let statusCallback: (status: { isOnline: boolean; connectionType: string }) => void;
+    (networkMonitor.getStatus as jest.Mock).mockResolvedValue({
+      isOnline: true,
+      connectionType: 'wifi',
+    });
+    (networkMonitor.onStatusChange as jest.Mock).mockImplementation(
+      (cb: (status: { isOnline: boolean; connectionType: string }) => void) => {
+        statusCallback = cb;
+        return jest.fn();
+      },
+    );
+
+    const { result } = renderHook(() => useNetworkStatus());
+
+    // Simulate going offline
+    act(() => {
+      statusCallback!({ isOnline: false, connectionType: 'none' });
+    });
+
+    expect(result.current).toEqual({
+      isOnline: false,
+      networkType: 'none',
+    });
+  });
+
+  it('re-renders when connection type changes', () => {
+    let statusCallback: (status: { isOnline: boolean; connectionType: string }) => void;
+    (networkMonitor.getStatus as jest.Mock).mockResolvedValue({
+      isOnline: true,
+      connectionType: 'wifi',
+    });
+    (networkMonitor.onStatusChange as jest.Mock).mockImplementation(
+      (cb: (status: { isOnline: boolean; connectionType: string }) => void) => {
+        statusCallback = cb;
+        return jest.fn();
+      },
+    );
+
+    const { result } = renderHook(() => useNetworkStatus());
+
+    // Simulate switching to cellular
+    act(() => {
+      statusCallback!({ isOnline: true, connectionType: 'cellular' });
+    });
+
+    expect(result.current).toEqual({
+      isOnline: true,
+      networkType: 'cellular',
+    });
+  });
+
+  it('cleans up listener on unmount', () => {
+    const unsubscribeMock = jest.fn();
+    (networkMonitor.getStatus as jest.Mock).mockResolvedValue({
+      isOnline: true,
+      connectionType: 'wifi',
+    });
+    (networkMonitor.onStatusChange as jest.Mock).mockReturnValue(unsubscribeMock);
+
+    const { unmount } = renderHook(() => useNetworkStatus());
+
+    unmount();
+
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still works when getStatus fails (defaults kept)', async () => {
+    (networkMonitor.getStatus as jest.Mock).mockRejectedValue(new Error('Network error'));
+    (networkMonitor.onStatusChange as jest.Mock).mockReturnValue(jest.fn());
+
+    const { result } = renderHook(() => useNetworkStatus());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Should keep the default values since getStatus failed
+    expect(result.current).toEqual({
+      isOnline: true,
+      networkType: 'unknown',
+    });
+  });
+});

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+import {
+  networkMonitor,
+  type ConnectionType,
+  type NetworkStatus,
+} from '../utils/networkMonitor';
+
+/**
+ * useNetworkStatus
+ *
+ * React hook that exposes current network connectivity status and type.
+ *
+ * @returns {{ isOnline: boolean; networkType: ConnectionType }}
+ *   - isOnline: whether the device has an active internet connection
+ *   - networkType: the active connection type ('wifi' | 'cellular' | 'unknown' | 'none')
+ *
+ * Re-renders on any network change (online/offline, connection type switch).
+ * Cleans up the NetInfo listener automatically on unmount.
+ *
+ * Works on iOS and Android via @react-native-community/netinfo.
+ */
+export function useNetworkStatus(): {
+  isOnline: boolean;
+  networkType: ConnectionType;
+} {
+  const [status, setStatus] = useState<NetworkStatus>({
+    isOnline: true,
+    connectionType: 'unknown',
+  });
+
+  useEffect(() => {
+    // Fetch initial status so we don't flash a default
+    networkMonitor.getStatus().then(setStatus).catch(() => {});
+
+    // Subscribe to real-time status changes
+    const unsubscribe = networkMonitor.onStatusChange(setStatus);
+    return unsubscribe;
+  }, []);
+
+  return {
+    isOnline: status.isOnline,
+    networkType: status.connectionType,
+  };
+}
+
+export default useNetworkStatus;


### PR DESCRIPTION
## Summary

Resolves #818 — Build a React hook that exposes current network connectivity status and type.

## Changes

### `src/hooks/useNetworkStatus.ts`
- Wraps the existing `networkMonitor` singleton from `src/utils/networkMonitor.ts`
- Returns `{ isOnline: boolean, networkType: ConnectionType }`
- Fetches initial status via `getStatus()` to avoid stale defaults
- Subscribes to `onStatusChange()` for real-time updates on connectivity/type changes
- Cleans up the listener on unmount via the returned unsubscribe function
- Works on both iOS and Android via `@react-native-community/netinfo`

### `src/hooks/__tests__/useNetworkStatus.test.ts`
- 6 unit tests covering:
  - Default values before initial fetch resolves
  - Async initial status resolution
  - Re-render on going offline
  - Re-render on connection type switch (wifi → cellular)
  - Cleanup on unmount
  - Graceful degradation when `getStatus()` fails

## Acceptance Criteria
- [x] Returns `{ isOnline, networkType }`
- [x] Re-renders on network change
- [x] Works on iOS and Android
- [x] Cleans up listener on unmount