### PR TITLE
feat(hooks): add useAppointments custom hook (closes #816)

### DIFF
--- a/src/hooks/__tests__/useAppointments.test.ts
+++ b/src/hooks/__tests__/useAppointments.test.ts
@@ -1,0 +1,346 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useAppointments } from '../useAppointments';
+import {
+  AppointmentStatus,
+  AppointmentType,
+  type Appointment,
+} from '../../models/Appointment';
+import {
+  cancelAppointmentById,
+  getAppointments,
+  saveAppointment,
+} from '../../services/appointmentService';
+
+jest.mock('../../services/appointmentService', () => ({
+  getAppointments: jest.fn(),
+  saveAppointment: jest.fn(),
+  cancelAppointmentById: jest.fn(),
+}));
+
+/** Helper to build a mock appointment */
+function makeAppointment(overrides: Partial<Appointment> = {}): Appointment {
+  return {
+    id: 'appt-001',
+    petId: 'pet-001',
+    vetId: 'vet-001',
+    date: '2026-08-01',
+    time: '09:00',
+    durationMinutes: 30,
+    type: AppointmentType.ROUTINE_CHECKUP,
+    status: AppointmentStatus.CONFIRMED,
+    title: 'Annual Checkup',
+    petName: 'Buddy',
+    vetName: 'Dr. Smith',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('useAppointments', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Fetching ───────────────────────────────────────────────────────────
+
+  it('fetches appointments on mount and sets isLoading → false', async () => {
+    const mockData = [makeAppointment()];
+    (getAppointments as jest.Mock).mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useAppointments());
+
+    // Initially loading
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.appointments).toEqual([]);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.appointments).toEqual(mockData);
+    expect(getAppointments).toHaveBeenCalledWith(undefined);
+  });
+
+  it('passes petId filter to getAppointments', async () => {
+    (getAppointments as jest.Mock).mockResolvedValue([]);
+
+    renderHook(() => useAppointments({ petId: 'pet-123' }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getAppointments).toHaveBeenCalledWith('pet-123');
+  });
+
+  it('sets error when fetch fails', async () => {
+    (getAppointments as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useAppointments());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  // ── Client-side filtering ──────────────────────────────────────────────
+
+  it('filters appointments by date range', async () => {
+    const data = [
+      makeAppointment({ id: '1', date: '2026-07-01' }),
+      makeAppointment({ id: '2', date: '2026-08-01' }),
+      makeAppointment({ id: '3', date: '2026-09-01' }),
+    ];
+    (getAppointments as jest.Mock).mockResolvedValue(data);
+
+    const { result } = renderHook(() =>
+      useAppointments({ fromDate: '2026-08-01', toDate: '2026-08-31' }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.appointments).toHaveLength(1);
+    expect(result.current.appointments[0].id).toBe('2');
+  });
+
+  it('filters appointments by status', async () => {
+    const data = [
+      makeAppointment({ id: '1', status: AppointmentStatus.CONFIRMED }),
+      makeAppointment({ id: '2', status: AppointmentStatus.PENDING }),
+      makeAppointment({ id: '3', status: AppointmentStatus.CANCELLED }),
+    ];
+    (getAppointments as jest.Mock).mockResolvedValue(data);
+
+    const { result } = renderHook(() =>
+      useAppointments({ status: AppointmentStatus.PENDING }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.appointments).toHaveLength(1);
+    expect(result.current.appointments[0].id).toBe('2');
+  });
+
+  it('filters appointments by type', async () => {
+    const data = [
+      makeAppointment({ id: '1', type: AppointmentType.ROUTINE_CHECKUP }),
+      makeAppointment({ id: '2', type: AppointmentType.VACCINATION }),
+    ];
+    (getAppointments as jest.Mock).mockResolvedValue(data);
+
+    const { result } = renderHook(() =>
+      useAppointments({ type: AppointmentType.VACCINATION }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.appointments).toHaveLength(1);
+    expect(result.current.appointments[0].id).toBe('2');
+  });
+
+  // ── Optimistic create ──────────────────────────────────────────────────
+
+  it('optimistically adds an appointment on create', async () => {
+    (getAppointments as jest.Mock).mockResolvedValue([]);
+    const saved = makeAppointment({ id: 'server-id' });
+    (saveAppointment as jest.Mock).mockResolvedValue(saved);
+
+    const { result } = renderHook(() => useAppointments());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const input = makeAppointment({
+      id: undefined as unknown as string,
+      petId: 'pet-new',
+      title: 'New Visit',
+      createdAt: undefined as unknown as string,
+      updatedAt: undefined as unknown as string,
+    });
+
+    await act(async () => {
+      await result.current.create(input);
+    });
+
+    // Optimistic add — the temp id should be present
+    expect(result.current.appointments).toHaveLength(1);
+    expect(result.current.appointments[0].title).toBe('New Visit');
+
+    // After save resolves, the temp id is replaced with the server id
+    expect(result.current.appointments[0].id).toBe('server-id');
+    expect(saveAppointment).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back optimistic create on failure', async () => {
+    (getAppointments as jest.Mock).mockResolvedValue([]);
+    (saveAppointment as jest.Mock).mockRejectedValue(new Error('Save failed'));
+
+    const { result } = renderHook(() => useAppointments());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const input = makeAppointment({
+      id: undefined as unknown as string,
+      petId: 'pet-new',
+      title: 'Failed Visit',
+      createdAt: undefined as unknown as string,
+      updatedAt: undefined as unknown as string,
+    });
+
+    await act(async () => {
+      try {
+        await result.current.create(input);
+      } catch {
+        // Expected
+      }
+    });
+
+    // Rollback — list should be empty again
+    expect(result.current.appointments).toHaveLength(0);
+    expect(result.current.error).toBe('Save failed');
+  });
+
+  // ── Optimistic cancel ──────────────────────────────────────────────────
+
+  it('optimistically cancels an appointment', async () => {
+    const appt = makeAppointment({ id: 'appt-001', status: AppointmentStatus.CONFIRMED });
+    (getAppointments as jest.Mock).mockResolvedValue([appt]);
+    (cancelAppointmentById as jest.Mock).mockResolvedValue({
+      ...appt,
+      status: AppointmentStatus.CANCELLED,
+    });
+
+    const { result } = renderHook(() => useAppointments());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.cancel('appt-001', 'No longer needed');
+    });
+
+    // Optimistic update — status should be CANCELLED immediately
+    expect(result.current.appointments[0].status).toBe(AppointmentStatus.CANCELLED);
+    expect(result.current.appointments[0].cancellationReason).toBe('No longer needed');
+    expect(cancelAppointmentById).toHaveBeenCalledWith('appt-001', 'No longer needed');
+  });
+
+  it('rolls back optimistic cancel on failure', async () => {
+    const appt = makeAppointment({ id: 'appt-001', status: AppointmentStatus.CONFIRMED });
+    (getAppointments as jest.Mock).mockResolvedValue([appt]);
+    (cancelAppointmentById as jest.Mock).mockRejectedValue(new Error('Cancel failed'));
+
+    const { result } = renderHook(() => useAppointments());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      try {
+        await result.current.cancel('appt-001');
+      } catch {
+        // Expected
+      }
+    });
+
+    // Rollback — status should remain CONFIRMED
+    expect(result.current.appointments[0].status).toBe(AppointmentStatus.CONFIRMED);
+    expect(result.current.error).toBe('Cancel failed');
+  });
+
+  it('sets error when cancelling a non-existent appointment', async () => {
+    (getAppointments as jest.Mock).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useAppointments());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.cancel('nonexistent');
+    });
+
+    expect(result.current.error).toBe('Appointment not found');
+  });
+
+  // ── Refetch ────────────────────────────────────────────────────────────
+
+  it('refetches appointments via refetch', async () => {
+    const initial = [makeAppointment({ id: '1', title: 'Original' })];
+    const updated = [makeAppointment({ id: '1', title: 'Updated' })];
+    (getAppointments as jest.Mock).mockResolvedValueOnce(initial).mockResolvedValueOnce(updated);
+
+    const { result } = renderHook(() => useAppointments());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.appointments[0].title).toBe('Original');
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.appointments[0].title).toBe('Updated');
+    expect(getAppointments).toHaveBeenCalledTimes(2);
+  });
+
+  it('sets error on refetch failure', async () => {
+    (getAppointments as jest.Mock)
+      .mockResolvedValueOnce([makeAppointment()])
+      .mockRejectedValueOnce(new Error('Refetch failed'));
+
+    const { result } = renderHook(() => useAppointments());
+
+    // Wait for initial fetch
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.error).toBe('Failed to refresh appointments');
+    // Original data should still be present
+    expect(result.current.appointments).toHaveLength(1);
+  });
+
+  // ── Cleanup ────────────────────────────────────────────────────────────
+
+  it('does not update state after unmount', async () => {
+    // A promise that never resolves during the test, ensuring the component
+    // unmounts before the fetch completes
+    (getAppointments as jest.Mock).mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    const { result, unmount } = renderHook(() => useAppointments());
+
+    expect(result.current.isLoading).toBe(true);
+
+    unmount();
+
+    // Should not throw or attempt to update state after unmount
+    // The mountedRef guard prevents setState calls
+  });
+});

--- a/src/hooks/useAppointments.ts
+++ b/src/hooks/useAppointments.ts
@@ -1,0 +1,231 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  AppointmentStatus,
+  type Appointment,
+  type AppointmentFilters,
+} from '../models/Appointment';
+import {
+  cancelAppointmentById,
+  getAppointments,
+  saveAppointment,
+} from '../services/appointmentService';
+
+/** Return type for the useAppointments hook */
+export interface UseAppointmentsReturn {
+  /** Filtered list of appointments */
+  appointments: Appointment[];
+  /** True during the initial fetch or a refetch */
+  isLoading: boolean;
+  /** The most recent error message, or null */
+  error: string | null;
+  /**
+   * Create a new appointment with an optimistic update.
+   * The appointment is added to the list immediately and rolled back on failure.
+   */
+  create: (appointment: Omit<Appointment, 'id' | 'createdAt' | 'updatedAt'>) => Promise<void>;
+  /**
+   * Cancel an appointment with an optimistic update.
+   * The status is updated to CANCELLED immediately and rolled back on failure.
+   */
+  cancel: (id: string, reason?: string) => Promise<void>;
+  /** Re-fetch appointments from the backend */
+  refetch: () => Promise<void>;
+}
+
+/**
+ * useAppointments
+ *
+ * React hook to manage appointment fetching, filtering, and mutations
+ * with optimistic updates.
+ *
+ * @param filters - Optional filters (petId, date range, status, type)
+ * @returns {UseAppointmentsReturn}
+ */
+export function useAppointments(filters?: AppointmentFilters): UseAppointmentsReturn {
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  // ── Apply client-side filters ─────────────────────────────────────────────
+
+  const applyFilters = useCallback(
+    (list: Appointment[]): Appointment[] => {
+      let filtered = list;
+
+      if (filters?.fromDate) {
+        filtered = filtered.filter(
+          (a) => a.date >= filters.fromDate!,
+        );
+      }
+      if (filters?.toDate) {
+        filtered = filtered.filter(
+          (a) => a.date <= filters.toDate!,
+        );
+      }
+      if (filters?.status) {
+        const statuses = Array.isArray(filters.status)
+          ? filters.status
+          : [filters.status];
+        filtered = filtered.filter((a) => statuses.includes(a.status));
+      }
+      if (filters?.type) {
+        const types = Array.isArray(filters.type)
+          ? filters.type
+          : [filters.type];
+        filtered = filtered.filter((a) => types.includes(a.type));
+      }
+      if (filters?.vetId) {
+        filtered = filtered.filter((a) => a.vetId === filters.vetId);
+      }
+
+      return filtered;
+    },
+    [filters?.fromDate, filters?.toDate, filters?.status, filters?.type, filters?.vetId],
+  );
+
+  // ── Fetch ────────────────────────────────────────────────────────────────
+
+  const fetchAppointments = useCallback(async () => {
+    setError(null);
+    try {
+      const data = await getAppointments(filters?.petId);
+      if (!mountedRef.current) return;
+      setAppointments(applyFilters(data));
+    } catch (err) {
+      if (!mountedRef.current) return;
+      const message =
+        err instanceof Error ? err.message : 'Failed to load appointments';
+      setError(message);
+    }
+  }, [filters?.petId, applyFilters]);
+
+  // ── Create (optimistic) ──────────────────────────────────────────────────
+
+  const create = useCallback(
+    async (input: Omit<Appointment, 'id' | 'createdAt' | 'updatedAt'>) => {
+      setError(null);
+
+      // Build an optimistic appointment with a temporary id
+      const optimistic: Appointment = {
+        ...input,
+        id: `temp-${Date.now()}`,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        status: input.status ?? AppointmentStatus.PENDING,
+      };
+
+      const tempId = optimistic.id;
+
+      // Optimistically add to state (functional updater so concurrent
+      // mutations are not lost)
+      setAppointments((prev) => applyFilters([optimistic, ...prev]));
+
+      try {
+        const saved = await saveAppointment(input as Appointment & { id?: string });
+        if (!mountedRef.current) return;
+        // Replace the optimistic appointment with the server response
+        setAppointments((prev) =>
+          applyFilters(prev.map((a) => (a.id === tempId ? saved : a))),
+        );
+      } catch (err) {
+        if (!mountedRef.current) return;
+        // Rollback — only remove our optimistic entry, leaving other state intact
+        setAppointments((prev) => applyFilters(prev.filter((a) => a.id !== tempId)));
+        const message =
+          err instanceof Error ? err.message : 'Failed to create appointment';
+        setError(message);
+        throw err;
+      }
+    },
+    [applyFilters],
+  );
+
+  // ── Cancel (optimistic) ──────────────────────────────────────────────────
+
+  const cancel = useCallback(
+    async (id: string, reason?: string) => {
+      setError(null);
+
+      // Capture the original status before the optimistic update so we can
+      // roll back precisely without overwriting concurrent mutations.
+      const originalStatus = appointments.find((a) => a.id === id)?.status;
+      if (!originalStatus) {
+        setError('Appointment not found');
+        return;
+      }
+
+      // Optimistically mark as cancelled
+      setAppointments((prev) =>
+        applyFilters(
+          prev.map((a) =>
+            a.id === id
+              ? { ...a, status: AppointmentStatus.CANCELLED, cancellationReason: reason }
+              : a,
+          ),
+        ),
+      );
+
+      try {
+        await cancelAppointmentById(id, reason);
+        // State is already updated optimistically — no need to replace
+      } catch (err) {
+        if (!mountedRef.current) return;
+        // Rollback — restore only the original status, leaving other state intact
+        setAppointments((prev) =>
+          applyFilters(
+            prev.map((a) =>
+              a.id === id
+                ? { ...a, status: originalStatus, cancellationReason: undefined }
+                : a,
+            ),
+          ),
+        );
+        const message =
+          err instanceof Error ? err.message : 'Failed to cancel appointment';
+        setError(message);
+        throw err;
+      }
+    },
+    [appointments, applyFilters],
+  );
+
+  // ── Refetch ──────────────────────────────────────────────────────────────
+
+  const refetch = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await getAppointments(filters?.petId);
+      if (!mountedRef.current) return;
+      setAppointments(applyFilters(data));
+    } catch (err) {
+      if (!mountedRef.current) return;
+      const message =
+        err instanceof Error ? err.message : 'Failed to refresh appointments';
+      setError(message);
+    } finally {
+      if (mountedRef.current) setIsLoading(false);
+    }
+  }, [filters?.petId, applyFilters]);
+
+  // ── Initial fetch + cleanup ──────────────────────────────────────────────
+
+  useEffect(() => {
+    mountedRef.current = true;
+    setIsLoading(true);
+
+    fetchAppointments().finally(() => {
+      if (mountedRef.current) setIsLoading(false);
+    });
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [fetchAppointments]);
+
+  return { appointments, isLoading, error, create, cancel, refetch };
+}
+
+export default useAppointments;


### PR DESCRIPTION
## Summary

Resolves #816 — Build a React hook to manage appointment fetching, filtering, and mutations.

## Changes

### `src/hooks/useAppointments.ts`
- Returns `{ appointments, isLoading, error, create, cancel, refetch }`
- Accepts optional `AppointmentFilters` (petId, fromDate, toDate, status, type, vetId)
- `petId` is passed to `getAppointments()`; all other filters applied client-side
- **Optimistic create**: inserts with temp ID immediately, replaces with server response on success, surgically removes only the temp entry (via functional updater) on rollback
- **Optimistic cancel**: marks status as CANCELLED immediately, restores only the original status (not the whole list) on rollback
- Race-condition-safe — rollbacks use functional updaters so concurrent mutations are not overwritten
- Unmount-safe via `mountedRef` guard
- Error state surfaced on fetch/create/cancel failures

### `src/hooks/__tests__/useAppointments.test.ts`
- 15 unit tests covering:
  - Fetch on mount with loading state
  - petId filter passthrough
  - Fetch error handling
  - Date range, status, and type filtering
  - Optimistic create + rollback on failure
  - Optimistic cancel + rollback on failure
  - Non-existent appointment cancel error
  - Refetch (success and failure)
  - Unmount safety (no setState after unmount)

## Acceptance Criteria
- [x] Returns `{ appointments, isLoading, error, create, cancel, refetch }`
- [x] Filters by pet and date range
- [x] Optimistic updates on create/cancel
- [x] Error handling