### PR TITLE
feat(hooks): add usePetList custom hook (closes #815)

### DIFF
--- a/src/hooks/__tests__/usePetList.test.ts
+++ b/src/hooks/__tests__/usePetList.test.ts
@@ -1,0 +1,309 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { usePetList } from '../usePetList';
+import { getAllPets, type Pet } from '../../services/petService';
+
+jest.mock('../../services/petService', () => ({
+  getAllPets: jest.fn(),
+}));
+
+/** Helper to build a mock pet */
+function makePet(overrides: Partial<Pet> = {}): Pet {
+  return {
+    id: 'pet-001',
+    name: 'Buddy',
+    species: 'dog',
+    breed: 'Golden Retriever',
+    dateOfBirth: '2020-03-15',
+    weightKg: 25,
+    ownerId: 'user-001',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('usePetList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Fetching ───────────────────────────────────────────────────────────
+
+  it('fetches pets on mount and sets isLoading → false', async () => {
+    const mockData = [makePet()];
+    (getAllPets as jest.Mock).mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => usePetList());
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.pets).toEqual(mockData);
+    expect(getAllPets).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets error when fetch fails', async () => {
+    (getAllPets as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => usePetList());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  // ── Pagination ─────────────────────────────────────────────────────────
+
+  it('returns the first page and tracks hasMore', async () => {
+    const data = Array.from({ length: 25 }, (_, i) =>
+      makePet({ id: `pet-${i}`, name: `Pet ${i}` }),
+    );
+    (getAllPets as jest.Mock).mockResolvedValue(data);
+
+    const { result } = renderHook(() => usePetList({ pageSize: 10 }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.pets).toHaveLength(10);
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.total).toBe(25);
+  });
+
+  it('fetchMore loads the next page', async () => {
+    const data = Array.from({ length: 25 }, (_, i) =>
+      makePet({ id: `pet-${i}`, name: `Pet ${i}` }),
+    );
+    (getAllPets as jest.Mock).mockResolvedValue(data);
+
+    const { result } = renderHook(() => usePetList({ pageSize: 10 }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.fetchMore();
+    });
+
+    expect(result.current.pets).toHaveLength(20);
+
+    act(() => {
+      result.current.fetchMore();
+    });
+
+    expect(result.current.pets).toHaveLength(25);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('fetchMore is a no-op when hasMore is false', async () => {
+    const data = [makePet()];
+    (getAllPets as jest.Mock).mockResolvedValue(data);
+
+    const { result } = renderHook(() => usePetList());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.hasMore).toBe(false);
+
+    act(() => {
+      result.current.fetchMore();
+    });
+
+    expect(result.current.pets).toHaveLength(1);
+  });
+
+  it('returns the full list when pageSize is larger than the dataset', async () => {
+    const data = [makePet({ id: '1' }), makePet({ id: '2' })];
+    (getAllPets as jest.Mock).mockResolvedValue(data);
+
+    const { result } = renderHook(() => usePetList({ pageSize: 100 }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.pets).toHaveLength(2);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  // ── Filtering ──────────────────────────────────────────────────────────
+
+  it('filters by species', async () => {
+    const data = [
+      makePet({ id: '1', species: 'dog', name: 'Rex' }),
+      makePet({ id: '2', species: 'cat', name: 'Whiskers' }),
+      makePet({ id: '3', species: 'dog', name: 'Buddy' }),
+    ];
+    (getAllPets as jest.Mock).mockResolvedValue(data);
+
+    const { result } = renderHook(() => usePetList({ species: 'dog' }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.pets).toHaveLength(2);
+    expect(result.current.pets.every((p) => p.species === 'dog')).toBe(true);
+  });
+
+  it('filters by search query (name match)', async () => {
+    const data = [
+      makePet({ id: '1', name: 'Rex' }),
+      makePet({ id: '2', name: 'Buddy' }),
+    ];
+    (getAllPets as jest.Mock).mockResolvedValue(data);
+
+    const { result } = renderHook(() => usePetList({ search: 'rex' }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.pets).toHaveLength(1);
+    expect(result.current.pets[0].name).toBe('Rex');
+  });
+
+  it('filters by search query (breed match)', async () => {
+    const data = [
+      makePet({ id: '1', breed: 'Golden Retriever', name: 'Buddy' }),
+      makePet({ id: '2', breed: 'Poodle', name: 'Max' }),
+    ];
+    (getAllPets as jest.Mock).mockResolvedValue(data);
+
+    const { result } = renderHook(() => usePetList({ search: 'poodle' }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.pets).toHaveLength(1);
+    expect(result.current.pets[0].breed).toBe('Poodle');
+  });
+
+  it('combines species and search filters', async () => {
+    const data = [
+      makePet({ id: '1', species: 'dog', name: 'Rex', breed: 'German Shepherd' }),
+      makePet({ id: '2', species: 'dog', name: 'Buddy', breed: 'Golden Retriever' }),
+      makePet({ id: '3', species: 'cat', name: 'Rex', breed: 'Siamese' }),
+    ];
+    (getAllPets as jest.Mock).mockResolvedValue(data);
+
+    const { result } = renderHook(() =>
+      usePetList({ species: 'dog', search: 'rex' }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.pets).toHaveLength(1);
+    expect(result.current.pets[0].id).toBe('1');
+  });
+
+  // ── Caching ────────────────────────────────────────────────────────────
+
+  it('reuses cached results on re-render with same options', async () => {
+    const data = [makePet()];
+    (getAllPets as jest.Mock).mockResolvedValue(data);
+
+    const { result, rerender } = renderHook(
+      (props) => usePetList(props),
+      { initialProps: { species: 'dog' } },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getAllPets).toHaveBeenCalledTimes(1);
+
+    // Re-render with the same options — should not re‑fetch
+    rerender({ species: 'dog' });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getAllPets).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies filters client-side without re‑fetching', async () => {
+    const data = [
+      makePet({ id: '1', species: 'dog', name: 'Rex' }),
+      makePet({ id: '2', species: 'cat', name: 'Whiskers' }),
+    ];
+    (getAllPets as jest.Mock).mockResolvedValue(data);
+
+    const { result, rerender } = renderHook(
+      (props) => usePetList(props),
+      { initialProps: { species: 'dog' as const } },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.pets).toHaveLength(1);
+    expect(result.current.pets[0].species).toBe('dog');
+
+    // Change filter → should NOT re‑fetch (getAllPets already has all data)
+    rerender({ species: 'cat' as const });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getAllPets).toHaveBeenCalledTimes(1);
+    expect(result.current.pets).toHaveLength(1);
+    expect(result.current.pets[0].species).toBe('cat');
+  });
+
+  // ── Refetch ────────────────────────────────────────────────────────────
+
+  it('refetch forces a fresh API call', async () => {
+    const initial = [makePet({ id: '1', name: 'Old' })];
+    const refreshed = [makePet({ id: '2', name: 'New' })];
+    (getAllPets as jest.Mock)
+      .mockResolvedValueOnce(initial)
+      .mockResolvedValueOnce(refreshed);
+
+    const { result } = renderHook(() => usePetList());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.pets[0].name).toBe('Old');
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.pets[0].name).toBe('New');
+    expect(getAllPets).toHaveBeenCalledTimes(2);
+  });
+
+  // ── Cleanup ────────────────────────────────────────────────────────────
+
+  it('does not update state after unmount', async () => {
+    (getAllPets as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+    const { result, unmount } = renderHook(() => usePetList());
+
+    expect(result.current.isLoading).toBe(true);
+
+    unmount();
+
+    // Should not throw or attempt setState after unmount
+  });
+});

--- a/src/hooks/usePetList.ts
+++ b/src/hooks/usePetList.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type { Species } from '../models/Pet';
+import { getAllPets, type Pet } from '../services/petService';
+
+/** Options accepted by usePetList */
+export interface UsePetListOptions {
+  /** Filter by species */
+  species?: Species;
+  /** Full‑text search across name and breed */
+  search?: string;
+  /** Number of pets per page (default 10) */
+  pageSize?: number;
+}
+
+/** Return type for the usePetList hook */
+export interface UsePetListReturn {
+  /** The current page of filtered pets */
+  pets: Pet[];
+  /** True during the initial fetch or a refetch */
+  isLoading: boolean;
+  /** The most recent error message, or null */
+  error: string | null;
+  /** Load the next page of results (no‑op when hasMore is false) */
+  fetchMore: () => void;
+  /** Re‑fetch all pets from the backend */
+  refetch: () => Promise<void>;
+  /** True when more pages are available */
+  hasMore: boolean;
+  /** Total number of pets matching the current filters */
+  total: number;
+}
+
+const DEFAULT_PAGE_SIZE = 10;
+
+/**
+ * usePetList
+ *
+ * React hook that fetches, filters, paginates, and caches a list of pets
+ * for the current user.
+ *
+ * - The full list is fetched once via {@link getAllPets} (which itself hits
+ *   the API and falls back to local cache).
+ * - Filters (species / search) and pagination are applied client‑side.
+ * - `fetchMore()` advances the page; `refetch()` forces a fresh API call.
+ * - The full result set is held in a ref so cached data survives re‑renders
+ *   caused by parent state changes.
+ *
+ * @param options - Optional filters and page size
+ * @returns {UsePetListReturn}
+ */
+export function usePetList(options: UsePetListOptions = {}): UsePetListReturn {
+  const { species, search, pageSize = DEFAULT_PAGE_SIZE } = options;
+
+  const [allPets, setAllPets] = useState<Pet[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+
+  const mountedRef = useRef(true);
+
+  // Ref mirror of allPets so fetchPets can read length without listing
+  // allPets as a dependency (keeping the callback stable).
+  const allPetsRef = useRef(allPets);
+  allPetsRef.current = allPets;
+
+  // ── Client‑side filtering ───────────────────────────────────────────────
+
+  const filtered = useMemo(() => {
+    let list = allPets;
+
+    if (species) {
+      list = list.filter((p) => p.species === species);
+    }
+    if (search) {
+      const q = search.toLowerCase();
+      list = list.filter(
+        (p) => p.name.toLowerCase().includes(q) || (p.breed ?? '').toLowerCase().includes(q),
+      );
+    }
+
+    return list;
+  }, [allPets, species, search]);
+
+  // ── Client‑side pagination ──────────────────────────────────────────────
+
+  const total = filtered.length;
+  const hasMore = page * pageSize < total;
+  const pets = useMemo(() => filtered.slice(0, page * pageSize), [filtered, page, pageSize]);
+
+  // ── Fetch (once on mount; refetch forces a fresh call) ─────────────────
+
+  const fetchPets = useCallback(async (force = false) => {
+    // Reuse cached data when already loaded and not forced
+    if (!force && allPetsRef.current.length > 0) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await getAllPets();
+      if (!mountedRef.current) return;
+      setAllPets(data);
+      setPage(1);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err.message : 'Failed to load pets');
+    } finally {
+      if (mountedRef.current) setIsLoading(false);
+    }
+  }, []);
+
+  // ── Public actions ──────────────────────────────────────────────────────
+
+  const fetchMore = useCallback(() => {
+    setPage((p) => (p * pageSize < total ? p + 1 : p));
+  }, [pageSize, total]);
+
+  const refetch = useCallback(async () => {
+    await fetchPets(true);
+  }, [fetchPets]);
+
+  // ── Initial fetch + cleanup ─────────────────────────────────────────────
+
+  useEffect(() => {
+    mountedRef.current = true;
+    fetchPets();
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []); // fetchPets is stable (ref‑based guard) — only run on mount
+
+  return { pets, isLoading, error, fetchMore, refetch, hasMore, total };
+}
+
+export default usePetList;


### PR DESCRIPTION
## Summary

Resolves #815 — Build a React hook to fetch and paginate a list of pets for the current user.

## Changes

### `src/hooks/usePetList.ts`
- Returns `{ pets, isLoading, error, fetchMore, refetch, hasMore, total }`
- Accepts optional `UsePetListOptions` (species, search, pageSize)
- **Fetch once on mount** via `getAllPets()` (API + local cache fallback)
- **Client‑side filtering** — `species` and `search` (name/breed) never trigger a network call
- **Client‑side pagination** — `fetchMore()` increments the page; `hasMore` tracks availability
- **Cache reuse** — stable `fetchPets` callback (`[]` deps + `allPetsRef`) avoids wasted re‑renders and unnecessary API calls on filter changes
- `refetch()` forces a fresh API call
- Unmount-safe via `mountedRef` guard

### `src/hooks/__tests__/usePetList.test.ts`
- 14 unit tests covering:
  - Fetch on mount with loading state
  - Fetch error handling
  - Pagination: first page, fetchMore, no‑op at end, oversized pageSize
  - Species filter
  - Search filter (name and breed match)
  - Combined species + search filter
  - Cache reuse on same‑option re‑render
  - Client‑side filter change without re‑fetching
  - Refetch forces a fresh API call
  - Unmount safety (no setState after unmount)

## Acceptance Criteria
- [x] Returns `{ pets, isLoading, error, fetchMore, refetch }`
- [x] Handles pagination (page, hasMore)
- [x] Filters supported (species, search)
- [x] Cached result reused on re‑render