### PR TITLE
feat(security): keychain token storage, rate limiting, input sanitization, biometric auth

### DIFF
--- a/src/services/__tests__/apiClientRateLimiting.test.ts
+++ b/src/services/__tests__/apiClientRateLimiting.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for the rate limiting / debouncing / request deduplication
+ * layer added to src/services/apiClient.ts (Issue #XXX).
+ *
+ * These tests cover:
+ *  - Debounce: rapid successive calls resolve to a single network request
+ *  - Deduplication: identical in-flight requests share one Promise
+ *  - Max concurrency: requests queue when the concurrent limit is exceeded
+ *  - setMaxConcurrentRequests: runtime configuration
+ */
+
+jest.mock('react-native-ssl-pinning', () => ({ fetch: jest.fn() }));
+
+const mockRequest = jest.fn();
+jest.mock('axios', () => {
+  const mockAxios = {
+    create: jest.fn(() => mockAxios),
+    request: mockRequest,
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  };
+  return mockAxios;
+});
+
+jest.mock('../authService', () => ({
+  getToken: jest.fn().mockResolvedValue(null),
+  refreshToken: jest.fn(),
+  logout: jest.fn(),
+}));
+
+jest.mock('../../config', () => ({
+  __esModule: true,
+  default: {
+    api: { baseUrl: 'https://api.test.com', timeoutMs: 1000, version: '1.0' },
+  },
+}));
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+
+let rateLimitedRequest: (cfg: any) => Promise<any>;
+let setMaxConcurrentRequests: (n: number) => void;
+let _getRateLimitState: () => {
+  activeRequests: number;
+  inflightCount: number;
+  debounceCount: number;
+  queueLength: number;
+  maxConcurrent: number;
+};
+let _resetRateLimitState: () => void;
+
+beforeAll(() => {
+  const mod = require('../apiClient');
+  rateLimitedRequest = mod.rateLimitedRequest;
+  setMaxConcurrentRequests = mod.setMaxConcurrentRequests;
+  _getRateLimitState = mod._getRateLimitState;
+  _resetRateLimitState = mod._resetRateLimitState;
+});
+
+beforeEach(() => {
+  mockRequest.mockReset();
+  _resetRateLimitState?.();
+  // Default: each request resolves immediately
+  mockRequest.mockResolvedValue({ data: 'ok', status: 200 });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// ─── Debounce ─────────────────────────────────────────────────────────────────
+
+describe('debounce behaviour', () => {
+  it('fires only one network request when called rapidly with debounce:true', async () => {
+    jest.useFakeTimers();
+
+    const cfg = { method: 'GET', url: '/search', params: { q: 'dog' }, debounce: true };
+
+    // Fire 3 rapid calls — only the last one should reach the network
+    const p1 = rateLimitedRequest(cfg);
+    const p2 = rateLimitedRequest(cfg);
+    const p3 = rateLimitedRequest(cfg);
+
+    // Advance timers past the 300 ms window
+    jest.advanceTimersByTime(350);
+
+    await Promise.all([p1, p2, p3]);
+
+    // The axios `request` mock should have been called exactly once
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the request immediately (no debounce window) when debounce is not set', async () => {
+    const cfg = { method: 'GET', url: '/pets' };
+    await rateLimitedRequest(cfg);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── Request deduplication ────────────────────────────────────────────────────
+
+describe('request deduplication', () => {
+  it('returns the same Promise for identical concurrent requests', async () => {
+    let resolveRequest!: (value: any) => void;
+    mockRequest.mockReturnValue(
+      new Promise<any>((r) => {
+        resolveRequest = r;
+      }),
+    );
+
+    const cfg = { method: 'GET', url: '/pets' };
+
+    const p1 = rateLimitedRequest(cfg);
+    const p2 = rateLimitedRequest(cfg);
+    const p3 = rateLimitedRequest(cfg);
+
+    // Should only have started one real request
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+
+    resolveRequest({ data: 'deduped', status: 200 });
+    const results = await Promise.all([p1, p2, p3]);
+    results.forEach((r) => expect(r.data).toBe('deduped'));
+    // Still only one network call
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a new request after the first one completes', async () => {
+    const cfg = { method: 'GET', url: '/pets' };
+
+    await rateLimitedRequest(cfg);
+    await rateLimitedRequest(cfg);
+
+    // Each call resolved independently — two network requests
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats different URLs as different requests (no dedup)', async () => {
+    const p1 = rateLimitedRequest({ method: 'GET', url: '/pets' });
+    const p2 = rateLimitedRequest({ method: 'GET', url: '/appointments' });
+
+    await Promise.all([p1, p2]);
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats different params as different requests (no dedup)', async () => {
+    const p1 = rateLimitedRequest({ method: 'GET', url: '/search', params: { q: 'dog' } });
+    const p2 = rateLimitedRequest({ method: 'GET', url: '/search', params: { q: 'cat' } });
+
+    await Promise.all([p1, p2]);
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('is param-order insensitive for the same query', async () => {
+    let resolveRequest!: (value: any) => void;
+    mockRequest.mockReturnValueOnce(
+      new Promise<any>((r) => {
+        resolveRequest = r;
+      }),
+    );
+
+    const p1 = rateLimitedRequest({ method: 'GET', url: '/search', params: { q: 'dog', page: 1 } });
+    const p2 = rateLimitedRequest({ method: 'GET', url: '/search', params: { page: 1, q: 'dog' } });
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+
+    resolveRequest({ data: 'same', status: 200 });
+    await Promise.all([p1, p2]);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── Max concurrency ─────────────────────────────────────────────────────────
+
+describe('max concurrency', () => {
+  it('queues requests when concurrency limit is reached', async () => {
+    setMaxConcurrentRequests(2);
+
+    const resolvers: Array<(v: any) => void> = [];
+    mockRequest.mockImplementation(
+      () => new Promise<any>((r) => resolvers.push(r)),
+    );
+
+    const p1 = rateLimitedRequest({ method: 'GET', url: '/a' });
+    const p2 = rateLimitedRequest({ method: 'GET', url: '/b' });
+    const p3 = rateLimitedRequest({ method: 'GET', url: '/c' }); // queued
+
+    // Only 2 requests should have started
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect(_getRateLimitState().queueLength).toBe(1);
+
+    // Resolve one, which should unblock the queued request
+    resolvers[0]!({ data: 'a', status: 200 });
+    await p1;
+
+    // Now the 3rd should start
+    expect(mockRequest).toHaveBeenCalledTimes(3);
+
+    resolvers[1]!({ data: 'b', status: 200 });
+    resolvers[2]!({ data: 'c', status: 200 });
+    await Promise.all([p2, p3]);
+  });
+
+  it('setMaxConcurrentRequests updates the limit', () => {
+    setMaxConcurrentRequests(5);
+    expect(_getRateLimitState().maxConcurrent).toBe(5);
+  });
+
+  it('ignores setMaxConcurrentRequests(0) (must be positive)', () => {
+    setMaxConcurrentRequests(3);
+    setMaxConcurrentRequests(0);
+    expect(_getRateLimitState().maxConcurrent).toBe(3);
+  });
+});

--- a/src/services/__tests__/authService.test.ts
+++ b/src/services/__tests__/authService.test.ts
@@ -583,3 +583,82 @@ describe('AuthError', () => {
     expect(new AuthError('some error', 'CODE').message).toBe('some error');
   });
 });
+
+// ─── Secure token storage (Issue: react-native-keychain migration) ────────────
+//
+// These tests assert that tokens are NEVER written to plain AsyncStorage.
+// They are always routed through react-native-keychain + expo-secure-store
+// (via storeSecureTokens in utils/encryption/keychain.ts).
+
+describe('secure token storage (keychain, not AsyncStorage)', () => {
+  let AsyncStorageMock: { setItem: jest.Mock };
+
+  beforeAll(() => {
+    // Spy on AsyncStorage.setItem — it must never be called with token keys
+    AsyncStorageMock = {
+      setItem: jest.fn(),
+    };
+    jest.doMock('@react-native-async-storage/async-storage', () => AsyncStorageMock);
+  });
+
+  afterAll(() => {
+    jest.dontMock('@react-native-async-storage/async-storage');
+  });
+
+  it('does NOT write the access token to AsyncStorage after login', async () => {
+    mockAxiosPost.mockResolvedValueOnce({ data: MOCK_LOGIN_RESPONSE });
+    await login('user@example.com', 'Password1');
+    const tokenWrites = AsyncStorageMock.setItem.mock.calls.filter(
+      ([key]: [string]) =>
+        key?.includes('token') || key?.includes('access') || key?.includes('refresh'),
+    );
+    expect(tokenWrites).toHaveLength(0);
+  });
+
+  it('stores tokens in expo-secure-store (keychain wrapper) after login', async () => {
+    const SecureStore = require('expo-secure-store');
+    mockAxiosPost.mockResolvedValueOnce({ data: MOCK_LOGIN_RESPONSE });
+    await login('user@example.com', 'Password1');
+    // The encrypted token blob key used by utils/encryption/keychain.ts
+    const TOKEN_BLOB_KEY = 'com.petchain.auth.tokens';
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith(
+      TOKEN_BLOB_KEY,
+      expect.any(String),
+      expect.anything(),
+    );
+  });
+
+  it('stores the encryption key in react-native-keychain after login', async () => {
+    const Keychain = require('react-native-keychain');
+    mockAxiosPost.mockResolvedValueOnce({ data: MOCK_LOGIN_RESPONSE });
+    await login('user@example.com', 'Password1');
+    const ENCRYPTION_KEY_SERVICE = 'com.petchain.auth.encryption';
+    const keychainCalls = (Keychain.setGenericPassword as jest.Mock).mock.calls.filter(
+      ([, , opts]: [unknown, unknown, { service?: string } | undefined]) =>
+        opts?.service === ENCRYPTION_KEY_SERVICE,
+    );
+    expect(keychainCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does NOT write the access token to AsyncStorage after register', async () => {
+    mockAxiosPost.mockResolvedValueOnce({ data: MOCK_LOGIN_RESPONSE });
+    await register({ email: 'new@example.com', name: 'New', password: 'Pw1' });
+    const tokenWrites = AsyncStorageMock.setItem.mock.calls.filter(
+      ([key]: [string]) =>
+        key?.includes('token') || key?.includes('access') || key?.includes('refresh'),
+    );
+    expect(tokenWrites).toHaveLength(0);
+  });
+
+  it('removes token from secure store (not AsyncStorage) on logout', async () => {
+    const SecureStore = require('expo-secure-store');
+    mockAxiosPost.mockResolvedValueOnce({ data: MOCK_LOGIN_RESPONSE });
+    await login('user@example.com', 'Password1');
+    await logout();
+    const TOKEN_BLOB_KEY = 'com.petchain.auth.tokens';
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      TOKEN_BLOB_KEY,
+      expect.anything(),
+    );
+  });
+});

--- a/src/services/__tests__/biometricService.test.ts
+++ b/src/services/__tests__/biometricService.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Unit tests for src/services/biometricService.ts
+ *
+ * All react-native-keychain calls are mocked so these run in Jest/Node
+ * without any native bindings.
+ */
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+let mockBiometryType: string | null = null;
+let mockKeychainStore: Record<string, string> = {};
+let mockGetGenericPasswordThrows: Error | null = null;
+let mockSetGenericPasswordThrows: Error | null = null;
+let mockResetGenericPasswordThrows: Error | null = null;
+
+jest.mock('react-native-keychain', () => ({
+  ACCESSIBLE: {
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
+  },
+  ACCESS_CONTROL: {
+    BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE: 'BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE',
+    BIOMETRY_CURRENT_SET: 'BIOMETRY_CURRENT_SET',
+    BIOMETRY_ANY: 'BIOMETRY_ANY',
+  },
+  SECURITY_LEVEL: {
+    SECURE_HARDWARE: 'SECURE_HARDWARE',
+    ANY: 'ANY',
+  },
+  getSupportedBiometryType: jest.fn(() => Promise.resolve(mockBiometryType)),
+  setGenericPassword: jest.fn((_user: string, password: string, opts?: { service?: string }) => {
+    if (mockSetGenericPasswordThrows) throw mockSetGenericPasswordThrows;
+    mockKeychainStore[opts?.service ?? '__default__'] = password;
+    return Promise.resolve(true);
+  }),
+  getGenericPassword: jest.fn((opts?: { service?: string }) => {
+    if (mockGetGenericPasswordThrows) throw mockGetGenericPasswordThrows;
+    const val = mockKeychainStore[opts?.service ?? '__default__'];
+    return Promise.resolve(val ? { username: 'petchain_biometric_user', password: val } : false);
+  }),
+  resetGenericPassword: jest.fn((opts?: { service?: string }) => {
+    if (mockResetGenericPasswordThrows) throw mockResetGenericPasswordThrows;
+    delete mockKeychainStore[opts?.service ?? '__default__'];
+    return Promise.resolve(true);
+  }),
+}));
+
+jest.mock('../../utils/errorLogger', () => ({
+  logError: jest.fn(),
+}));
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+
+import {
+  isBiometricAvailable,
+  enrollBiometric,
+  authenticateWithBiometrics,
+  unenrollBiometric,
+  isBiometricEnrolled,
+  BiometricError,
+} from '../biometricService';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const BIOMETRIC_SERVICE = 'com.petchain.biometric.credential';
+const CREDENTIAL_MARKER = 'petchain:biometric:enrolled';
+
+// ─── Setup / Teardown ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockBiometryType = null;
+  mockKeychainStore = {};
+  mockGetGenericPasswordThrows = null;
+  mockSetGenericPasswordThrows = null;
+  mockResetGenericPasswordThrows = null;
+});
+
+// ─── isBiometricAvailable() ───────────────────────────────────────────────────
+
+describe('isBiometricAvailable()', () => {
+  it('returns available=false and biometryType=null when no biometry is supported', async () => {
+    mockBiometryType = null;
+    const result = await isBiometricAvailable();
+    expect(result.available).toBe(false);
+    expect(result.biometryType).toBeNull();
+  });
+
+  it('returns available=true and biometryType="FaceID" when FaceID is supported', async () => {
+    mockBiometryType = 'FaceID';
+    const result = await isBiometricAvailable();
+    expect(result.available).toBe(true);
+    expect(result.biometryType).toBe('FaceID');
+  });
+
+  it('returns available=true for TouchID', async () => {
+    mockBiometryType = 'TouchID';
+    const result = await isBiometricAvailable();
+    expect(result.available).toBe(true);
+    expect(result.biometryType).toBe('TouchID');
+  });
+
+  it('returns available=true for Android Fingerprint', async () => {
+    mockBiometryType = 'Fingerprint';
+    const result = await isBiometricAvailable();
+    expect(result.available).toBe(true);
+    expect(result.biometryType).toBe('Fingerprint');
+  });
+
+  it('returns available=false when getSupportedBiometryType throws', async () => {
+    const Keychain = require('react-native-keychain');
+    (Keychain.getSupportedBiometryType as jest.Mock).mockRejectedValueOnce(
+      new Error('native crash'),
+    );
+    const result = await isBiometricAvailable();
+    expect(result.available).toBe(false);
+    expect(result.biometryType).toBeNull();
+  });
+});
+
+// ─── enrollBiometric() ───────────────────────────────────────────────────────
+
+describe('enrollBiometric()', () => {
+  it('returns false when biometrics are not available', async () => {
+    mockBiometryType = null;
+    expect(await enrollBiometric()).toBe(false);
+  });
+
+  it('returns true and stores the credential marker on success', async () => {
+    mockBiometryType = 'FaceID';
+    const result = await enrollBiometric();
+    expect(result).toBe(true);
+    expect(mockKeychainStore[BIOMETRIC_SERVICE]).toBe(CREDENTIAL_MARKER);
+  });
+
+  it('passes a custom prompt message to the verification read', async () => {
+    mockBiometryType = 'TouchID';
+    const Keychain = require('react-native-keychain');
+    await enrollBiometric('My custom prompt');
+    const getCall = (Keychain.getGenericPassword as jest.Mock).mock.calls.find(
+      (args: any[]) => args[0]?.authenticationPrompt?.title === 'My custom prompt',
+    );
+    expect(getCall).toBeDefined();
+  });
+
+  it('returns false and cleans up when verification read returns false', async () => {
+    mockBiometryType = 'FaceID';
+    const Keychain = require('react-native-keychain');
+    // set stores fine, but the verification read returns false
+    (Keychain.getGenericPassword as jest.Mock).mockResolvedValueOnce(false);
+    const result = await enrollBiometric();
+    expect(result).toBe(false);
+    expect(mockKeychainStore[BIOMETRIC_SERVICE]).toBeUndefined();
+  });
+
+  it('returns false and cleans up when setGenericPassword throws', async () => {
+    mockBiometryType = 'FaceID';
+    mockSetGenericPasswordThrows = new Error('keychain write failed');
+    const result = await enrollBiometric();
+    expect(result).toBe(false);
+  });
+});
+
+// ─── authenticateWithBiometrics() ────────────────────────────────────────────
+
+describe('authenticateWithBiometrics()', () => {
+  it('returns { success: false, fallbackReason: "unavailable" } when biometrics unavailable', async () => {
+    mockBiometryType = null;
+    const result = await authenticateWithBiometrics();
+    expect(result.success).toBe(false);
+    expect(result.fallbackReason).toBe('unavailable');
+  });
+
+  it('returns { success: false, fallbackReason: "not_enrolled" } when no credential exists', async () => {
+    mockBiometryType = 'FaceID';
+    // nothing stored in keychain
+    const result = await authenticateWithBiometrics();
+    expect(result.success).toBe(false);
+    expect(result.fallbackReason).toBe('not_enrolled');
+  });
+
+  it('returns { success: true } when the correct credential marker is retrieved', async () => {
+    mockBiometryType = 'FaceID';
+    // pre-enroll
+    await enrollBiometric();
+    const result = await authenticateWithBiometrics();
+    expect(result.success).toBe(true);
+    expect(result.fallbackReason).toBeUndefined();
+  });
+
+  it('returns { success: false, fallbackReason: "user_cancelled" } on user cancel', async () => {
+    mockBiometryType = 'FaceID';
+    await enrollBiometric();
+    mockGetGenericPasswordThrows = new Error('User canceled the operation');
+    const result = await authenticateWithBiometrics();
+    expect(result.success).toBe(false);
+    expect(result.fallbackReason).toBe('user_cancelled');
+  });
+
+  it('returns { success: false, fallbackReason: "lockout" } on too many attempts', async () => {
+    mockBiometryType = 'Fingerprint';
+    await enrollBiometric();
+    mockGetGenericPasswordThrows = new Error('Lockout: too many attempts');
+    const result = await authenticateWithBiometrics();
+    expect(result.success).toBe(false);
+    expect(result.fallbackReason).toBe('lockout');
+  });
+
+  it('returns { success: false, fallbackReason: "error" } on unexpected errors', async () => {
+    mockBiometryType = 'TouchID';
+    await enrollBiometric();
+    mockGetGenericPasswordThrows = new Error('hardware malfunction');
+    const result = await authenticateWithBiometrics();
+    expect(result.success).toBe(false);
+    expect(result.fallbackReason).toBe('error');
+  });
+});
+
+// ─── unenrollBiometric() ─────────────────────────────────────────────────────
+
+describe('unenrollBiometric()', () => {
+  it('removes the stored credential so isBiometricEnrolled returns false', async () => {
+    mockBiometryType = 'FaceID';
+    await enrollBiometric();
+    expect(mockKeychainStore[BIOMETRIC_SERVICE]).toBe(CREDENTIAL_MARKER);
+
+    await unenrollBiometric();
+    expect(mockKeychainStore[BIOMETRIC_SERVICE]).toBeUndefined();
+  });
+
+  it('does not throw when no credential is stored', async () => {
+    await expect(unenrollBiometric()).resolves.toBeUndefined();
+  });
+
+  it('throws BiometricError with code KEYCHAIN_ERROR when reset fails', async () => {
+    mockResetGenericPasswordThrows = new Error('keychain reset failed');
+    await expect(unenrollBiometric()).rejects.toMatchObject({
+      code: 'KEYCHAIN_ERROR',
+      name: 'BiometricError',
+    });
+  });
+});
+
+// ─── isBiometricEnrolled() ───────────────────────────────────────────────────
+
+describe('isBiometricEnrolled()', () => {
+  it('returns false when no credential is stored', async () => {
+    expect(await isBiometricEnrolled()).toBe(false);
+  });
+
+  it('returns true after a successful enrollment', async () => {
+    mockBiometryType = 'TouchID';
+    await enrollBiometric();
+    expect(await isBiometricEnrolled()).toBe(true);
+  });
+
+  it('returns false after unenrolling', async () => {
+    mockBiometryType = 'FaceID';
+    await enrollBiometric();
+    await unenrollBiometric();
+    expect(await isBiometricEnrolled()).toBe(false);
+  });
+
+  it('returns false when getGenericPassword throws', async () => {
+    const Keychain = require('react-native-keychain');
+    (Keychain.getGenericPassword as jest.Mock).mockRejectedValueOnce(new Error('crash'));
+    expect(await isBiometricEnrolled()).toBe(false);
+  });
+});
+
+// ─── BiometricError class ────────────────────────────────────────────────────
+
+describe('BiometricError', () => {
+  it('is an instance of Error', () => {
+    expect(new BiometricError('msg', 'BIOMETRIC_UNAVAILABLE')).toBeInstanceOf(Error);
+  });
+
+  it('has name "BiometricError"', () => {
+    expect(new BiometricError('msg', 'USER_CANCELLED').name).toBe('BiometricError');
+  });
+
+  it('exposes the code property', () => {
+    expect(new BiometricError('msg', 'LOCKOUT').code).toBe('LOCKOUT');
+  });
+});

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -15,6 +15,183 @@ import { logError } from '../utils/errorLogger';
 import performance, { recordApiTiming, startSpan, finishSpan } from '../utils/performance';
 
 // ---------------------------------------------------------------------------
+// Rate limiting / debouncing / request deduplication (Issue #XXX)
+//
+// Design goals:
+//   1. Debounce: search/filter requests with the same URL+params are coalesced
+//      when fired within DEBOUNCE_WINDOW_MS of each other.
+//   2. Deduplication: a second identical in-flight request returns the same
+//      Promise instead of opening a new network connection.
+//   3. Max concurrency: cap simultaneous outgoing requests to
+//      MAX_CONCURRENT_REQUESTS (configurable at runtime via setMaxConcurrent).
+//   4. Zero change to user-facing behaviour for non-search requests.
+// ---------------------------------------------------------------------------
+
+/** How long (ms) to wait before firing a debounced request. */
+const DEBOUNCE_WINDOW_MS = 300;
+
+/**
+ * Maximum number of requests allowed to be in-flight simultaneously.
+ * Requests that exceed this limit are queued and dispatched as slots free up.
+ * Override with `setMaxConcurrentRequests()` before the first request.
+ */
+let MAX_CONCURRENT_REQUESTS = 10;
+
+export function setMaxConcurrentRequests(n: number): void {
+  if (n > 0) MAX_CONCURRENT_REQUESTS = n;
+}
+
+// ── Deduplication cache ──────────────────────────────────────────────────────
+// Maps a stable request key → the in-flight Promise.  Cleared when the request
+// settles so the next call always gets a fresh response.
+
+type InflightEntry<T> = Promise<AxiosResponse<T>>;
+const inflightRequests = new Map<string, InflightEntry<unknown>>();
+
+/** Build a stable, order-insensitive cache key for a request config. */
+function buildRequestKey(cfg: AxiosRequestConfig): string {
+  const params = cfg.params
+    ? JSON.stringify(
+        Object.fromEntries(
+          Object.entries(cfg.params as Record<string, unknown>).sort(([a], [b]) =>
+            a.localeCompare(b),
+          ),
+        ),
+      )
+    : '';
+  return `${(cfg.method ?? 'GET').toUpperCase()}:${cfg.url ?? ''}:${params}`;
+}
+
+// ── Concurrency limiter ──────────────────────────────────────────────────────
+
+let activeRequests = 0;
+const concurrencyQueue: Array<() => void> = [];
+
+function acquireSlot(): Promise<void> {
+  if (activeRequests < MAX_CONCURRENT_REQUESTS) {
+    activeRequests++;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => concurrencyQueue.push(resolve));
+}
+
+function releaseSlot(): void {
+  activeRequests = Math.max(0, activeRequests - 1);
+  const next = concurrencyQueue.shift();
+  if (next) {
+    activeRequests++;
+    next();
+  }
+}
+
+// ── Debounce registry ────────────────────────────────────────────────────────
+// Maps a request key → pending debounce timer + deferred resolve/reject.
+
+interface DebouncedEntry<T> {
+  timer: ReturnType<typeof setTimeout>;
+  resolve: (value: AxiosResponse<T>) => void;
+  reject: (reason: unknown) => void;
+}
+
+const debounceRegistry = new Map<string, DebouncedEntry<unknown>>();
+
+/**
+ * Wrap an axios `request()` call with debouncing + deduplication +
+ * concurrency limiting.
+ *
+ * Pass `debounce: true` in the request config to activate the debounce
+ * window (e.g. for search/filter inputs).  Without it, only deduplication
+ * and concurrency limiting are applied.
+ *
+ * Debounce behaviour:
+ *  - The first call with a given key registers a timer and returns a Promise.
+ *  - Each subsequent call within DEBOUNCE_WINDOW_MS resets the timer; all
+ *    callers share the same Promise so they all resolve to the same response.
+ *  - When the timer fires the single underlying request is executed.
+ */
+export function rateLimitedRequest<T>(
+  requestConfig: AxiosRequestConfig & { debounce?: boolean },
+): Promise<AxiosResponse<T>> {
+  const key = buildRequestKey(requestConfig);
+
+  // ── 1. Debounce ───────────────────────────────────────────────────────────
+  if (requestConfig.debounce === true) {
+    const existing = debounceRegistry.get(key) as DebouncedEntry<T> | undefined;
+
+    if (existing) {
+      // Reset the timer, reusing the existing promise handles
+      clearTimeout(existing.timer);
+      const { resolve, reject } = existing;
+      const timer = setTimeout(() => {
+        debounceRegistry.delete(key);
+        executeWithDedup<T>(key, requestConfig).then(resolve, reject);
+      }, DEBOUNCE_WINDOW_MS);
+      debounceRegistry.set(key, { timer, resolve, reject } as DebouncedEntry<unknown>);
+      // Return a new Promise that mirrors the shared resolve/reject
+      return new Promise<AxiosResponse<T>>((res, rej) => {
+        const prev = debounceRegistry.get(key) as DebouncedEntry<T>;
+        const origResolve = prev.resolve;
+        const origReject = prev.reject;
+        prev.resolve = (v) => { origResolve(v); res(v); };
+        prev.reject = (e) => { origReject(e); rej(e); };
+      });
+    }
+
+    // First call — create the debounce entry and return a fresh Promise
+    return new Promise<AxiosResponse<T>>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        debounceRegistry.delete(key);
+        executeWithDedup<T>(key, requestConfig).then(resolve, reject);
+      }, DEBOUNCE_WINDOW_MS);
+      debounceRegistry.set(key, { timer, resolve, reject } as DebouncedEntry<unknown>);
+    });
+  }
+
+  // ── 2. No debounce: straight dedup + concurrency ──────────────────────────
+  return executeWithDedup<T>(key, requestConfig);
+}
+
+async function executeWithDedup<T>(
+  key: string,
+  requestConfig: AxiosRequestConfig,
+): Promise<AxiosResponse<T>> {
+  // Return the existing in-flight promise for identical concurrent requests
+  const inflight = inflightRequests.get(key) as InflightEntry<T> | undefined;
+  if (inflight) return inflight;
+
+  const promise = (async () => {
+    await acquireSlot();
+    try {
+      return await apiClient.request<T>(requestConfig);
+    } finally {
+      releaseSlot();
+      inflightRequests.delete(key);
+    }
+  })();
+
+  inflightRequests.set(key, promise as InflightEntry<unknown>);
+  return promise;
+}
+
+/** Exposed for testing only */
+export const _getRateLimitState = () => ({
+  activeRequests,
+  inflightCount: inflightRequests.size,
+  debounceCount: debounceRegistry.size,
+  queueLength: concurrencyQueue.length,
+  maxConcurrent: MAX_CONCURRENT_REQUESTS,
+});
+
+/** Exposed for testing only — resets concurrency and dedup state */
+export const _resetRateLimitState = () => {
+  activeRequests = 0;
+  inflightRequests.clear();
+  debounceRegistry.forEach((e) => clearTimeout(e.timer));
+  debounceRegistry.clear();
+  concurrencyQueue.splice(0);
+};
+
+// ---------------------------------------------------------------------------
 // SSL Pinning helpers
 // ---------------------------------------------------------------------------
 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -25,6 +25,7 @@ import {
   storeSecureTokens,
 } from '../utils/encryption/keychain';
 import { logError } from '../utils/errorLogger';
+import { sanitizeString } from '../utils/sanitize';
 
 // ─── Custom error ─────────────────────────────────────────────────────────────
 
@@ -150,8 +151,12 @@ export async function login(email: string, password: string): Promise<AuthSessio
     throw error;
   }
 
+  // Sanitize inputs before sending to the API
+  const sanitizedEmail = sanitizeString(email);
+  const sanitizedPassword = sanitizeString(password);
+
   try {
-    const payload: LoginRequest = { email, password };
+    const payload: LoginRequest = { email: sanitizedEmail, password: sanitizedPassword };
     const { data } = await authClient.post<LoginResponse>(API_ENDPOINTS.AUTH_LOGIN, payload);
 
     await storeSecureTokens({
@@ -178,7 +183,7 @@ export async function login(email: string, password: string): Promise<AuthSessio
       logError(err as Error, {
         service: 'authService',
         action: 'login_request',
-        email,
+        email: sanitizedEmail,
         status,
       });
 

--- a/src/services/biometricService.ts
+++ b/src/services/biometricService.ts
@@ -1,0 +1,345 @@
+/**
+ * biometricService.ts
+ *
+ * Biometric authentication service for PetChain Mobile App.
+ *
+ * Provides a clean, high-level API over `react-native-keychain` for:
+ *  - Querying biometric hardware availability and type
+ *  - Enrolling the device's biometric credentials for app unlock
+ *  - Performing a biometric authentication challenge
+ *  - Graceful fallback to PIN / password when biometrics fail or are
+ *    unavailable
+ *
+ * All credential references stored in the Keychain are encrypted.
+ * Actual passwords/tokens are **never** written to plain AsyncStorage.
+ *
+ * Platform support:
+ *  - iOS  : Face ID and Touch ID (via `BIOMETRY_CURRENT_SET`)
+ *  - Android : Fingerprint / Face Unlock / Iris (via
+ *              `BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE`)
+ *
+ * Error handling:
+ *  - Hardware unavailable  → functions return `false` / throw
+ *    `BiometricError` with code `BIOMETRIC_UNAVAILABLE`
+ *  - User cancellation     → `BiometricError` with code `USER_CANCELLED`
+ *  - Too many failures     → `BiometricError` with code `LOCKOUT`
+ *  - Unknown hardware err  → `BiometricError` with code `BIOMETRIC_ERROR`
+ */
+
+import * as Keychain from 'react-native-keychain';
+
+import { logError } from '../utils/errorLogger';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Keychain service name for the biometric-protected credential entry. */
+const BIOMETRIC_SERVICE = 'com.petchain.biometric.credential';
+
+/** Username stored in Keychain alongside the encrypted credential reference. */
+const BIOMETRIC_USERNAME = 'petchain_biometric_user';
+
+/**
+ * The value stored in Keychain under biometric protection.
+ * This is an opaque marker, not the actual user password.
+ * The real session token is retrieved separately via `authService.getToken()`.
+ */
+const BIOMETRIC_CREDENTIAL_MARKER = 'petchain:biometric:enrolled';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Result returned by `isBiometricAvailable`. */
+export interface BiometricAvailabilityResult {
+  /** `true` when the device has biometric hardware and at least one enrolled identity. */
+  available: boolean;
+  /**
+   * Human-readable biometry type reported by the OS, e.g.
+   * `"FaceID"`, `"TouchID"`, `"Fingerprint"`, `"Iris"`.
+   * `null` when biometrics are unavailable.
+   */
+  biometryType: string | null;
+}
+
+/** Outcome returned by `authenticateWithBiometrics`. */
+export interface BiometricAuthResult {
+  /** `true` on successful biometric verification. */
+  success: boolean;
+  /**
+   * Set when `success` is `false` to indicate why authentication did not
+   * complete.  Callers should use this to decide whether to show a PIN
+   * fallback screen.
+   */
+  fallbackReason?: 'unavailable' | 'not_enrolled' | 'user_cancelled' | 'lockout' | 'error';
+}
+
+/** Error class for biometric-specific failures. */
+export class BiometricError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | 'BIOMETRIC_UNAVAILABLE'
+      | 'NOT_ENROLLED'
+      | 'USER_CANCELLED'
+      | 'LOCKOUT'
+      | 'BIOMETRIC_ERROR'
+      | 'KEYCHAIN_ERROR',
+  ) {
+    super(message);
+    this.name = 'BiometricError';
+  }
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/** Resolve the best available `ACCESS_CONTROL` constant at runtime. */
+function resolveAccessControl(): Keychain.ACCESS_CONTROL {
+  // Prefer the stricter "current set" variants so the credential is
+  // invalidated if the user adds/removes a biometric identity.
+  if (Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE) {
+    return Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE;
+  }
+  if (Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET) {
+    return Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET;
+  }
+  return Keychain.ACCESS_CONTROL.BIOMETRY_ANY;
+}
+
+/** Resolve the best available `SECURITY_LEVEL` constant at runtime. */
+function resolveSecurityLevel(): Keychain.SECURITY_LEVEL | undefined {
+  if ((Keychain.SECURITY_LEVEL as Record<string, unknown>)?.SECURE_HARDWARE) {
+    return Keychain.SECURITY_LEVEL.SECURE_HARDWARE;
+  }
+  if ((Keychain.SECURITY_LEVEL as Record<string, unknown>)?.ANY) {
+    return Keychain.SECURITY_LEVEL.ANY;
+  }
+  return undefined;
+}
+
+/** Map a raw Keychain/OS error to a structured `BiometricError`. */
+function mapKeychainError(err: unknown): BiometricError {
+  const msg = err instanceof Error ? err.message : String(err);
+
+  if (/cancel/i.test(msg) || /user canceled/i.test(msg)) {
+    return new BiometricError('Authentication cancelled by the user', 'USER_CANCELLED');
+  }
+  if (/lockout|too many attempts/i.test(msg)) {
+    return new BiometricError(
+      'Too many failed attempts — biometrics locked out. Please use PIN.',
+      'LOCKOUT',
+    );
+  }
+  if (/not available|no biometrics/i.test(msg)) {
+    return new BiometricError('Biometric hardware not available on this device', 'BIOMETRIC_UNAVAILABLE');
+  }
+  return new BiometricError(`Biometric keychain error: ${msg}`, 'KEYCHAIN_ERROR');
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Query the device for biometric hardware availability.
+ *
+ * @returns An object indicating whether biometrics are available and which
+ *          type (FaceID, TouchID, Fingerprint, …) is supported.
+ *
+ * @example
+ * const { available, biometryType } = await isBiometricAvailable();
+ * if (available) showBiometricPrompt(biometryType);
+ */
+export async function isBiometricAvailable(): Promise<BiometricAvailabilityResult> {
+  try {
+    // `getSupportedBiometryType` returns null/undefined when no biometry is enrolled
+    const biometryType = await Keychain.getSupportedBiometryType();
+    return {
+      available: biometryType != null,
+      biometryType: biometryType ?? null,
+    };
+  } catch (err) {
+    logError(err as Error, { service: 'biometricService', action: 'isBiometricAvailable' });
+    return { available: false, biometryType: null };
+  }
+}
+
+/**
+ * Enroll this device for biometric login by writing an encrypted credential
+ * marker into the Keychain, protected by the biometric access control policy.
+ *
+ * The user will be prompted to authenticate with their biometric to confirm
+ * enrollment.
+ *
+ * Falls back gracefully (returns `false`) when:
+ *  - Biometrics are not available or not enrolled
+ *  - The user cancels the enrollment prompt
+ *  - An unrecoverable hardware error occurs
+ *
+ * @param promptMessage  Optional prompt shown in the biometric dialog.
+ * @returns `true` on successful enrollment, `false` otherwise.
+ *
+ * @example
+ * const enrolled = await enrollBiometric('Enable Face ID for PetChain');
+ * if (!enrolled) showFallbackSetupMessage();
+ */
+export async function enrollBiometric(
+  promptMessage = 'Set up biometric login for faster, secure access',
+): Promise<boolean> {
+  const { available } = await isBiometricAvailable();
+  if (!available) {
+    return false;
+  }
+
+  try {
+    const securityLevel = resolveSecurityLevel();
+
+    await Keychain.setGenericPassword(
+      BIOMETRIC_USERNAME,
+      BIOMETRIC_CREDENTIAL_MARKER,
+      {
+        service: BIOMETRIC_SERVICE,
+        accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+        accessControl: resolveAccessControl(),
+        ...(securityLevel ? { securityLevel } : {}),
+      },
+    );
+
+    // Immediately verify the enrollment by triggering a read with biometric
+    // challenge — this ensures the credential was stored successfully.
+    const verification = await Keychain.getGenericPassword({
+      service: BIOMETRIC_SERVICE,
+      authenticationPrompt: { title: promptMessage },
+    });
+
+    if (!verification || !('password' in verification)) {
+      // Verification failed — clean up the partial enrollment
+      await Keychain.resetGenericPassword({ service: BIOMETRIC_SERVICE });
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    logError(err as Error, { service: 'biometricService', action: 'enrollBiometric' });
+    // Clean up any partial keychain entry
+    try {
+      await Keychain.resetGenericPassword({ service: BIOMETRIC_SERVICE });
+    } catch {
+      // best-effort cleanup
+    }
+    return false;
+  }
+}
+
+/**
+ * Perform a biometric authentication challenge.
+ *
+ * Reads the enrolled credential from Keychain, which triggers the OS-level
+ * biometric prompt (Face ID / Touch ID on iOS, Fingerprint / Face on Android).
+ *
+ * @param promptMessage  Text shown in the biometric dialog.
+ * @returns A `BiometricAuthResult` describing the outcome.  On failure the
+ *          `fallbackReason` field indicates the appropriate next step.
+ *
+ * Falls back automatically (`fallbackReason: 'not_enrolled'`) when the device
+ * has no enrolled credential, allowing the caller to redirect to PIN entry.
+ *
+ * @throws `BiometricError` only for unrecoverable internal errors; all
+ *         expected failure modes are expressed via `{ success: false, ... }`.
+ *
+ * @example
+ * const result = await authenticateWithBiometrics('Confirm your identity');
+ * if (result.success) {
+ *   navigateToDashboard();
+ * } else if (result.fallbackReason === 'user_cancelled') {
+ *   showCancelMessage();
+ * } else {
+ *   navigateToPinScreen();
+ * }
+ */
+export async function authenticateWithBiometrics(
+  promptMessage = 'Authenticate to access your PetChain account',
+): Promise<BiometricAuthResult> {
+  // Check hardware availability first
+  const { available } = await isBiometricAvailable();
+  if (!available) {
+    return { success: false, fallbackReason: 'unavailable' };
+  }
+
+  try {
+    const credentials = await Keychain.getGenericPassword({
+      service: BIOMETRIC_SERVICE,
+      authenticationPrompt: { title: promptMessage },
+    });
+
+    if (!credentials || !('password' in credentials)) {
+      // No credential stored → the user hasn't enrolled biometrics yet
+      return { success: false, fallbackReason: 'not_enrolled' };
+    }
+
+    // Verify that the retrieved credential is our known marker
+    if (credentials.password !== BIOMETRIC_CREDENTIAL_MARKER) {
+      logError(new Error('Unexpected biometric credential marker'), {
+        service: 'biometricService',
+        action: 'authenticateWithBiometrics',
+      });
+      return { success: false, fallbackReason: 'error' };
+    }
+
+    return { success: true };
+  } catch (err) {
+    const mapped = mapKeychainError(err);
+    logError(mapped, { service: 'biometricService', action: 'authenticateWithBiometrics' });
+
+    switch (mapped.code) {
+      case 'USER_CANCELLED':
+        return { success: false, fallbackReason: 'user_cancelled' };
+      case 'LOCKOUT':
+        return { success: false, fallbackReason: 'lockout' };
+      case 'BIOMETRIC_UNAVAILABLE':
+        return { success: false, fallbackReason: 'unavailable' };
+      default:
+        return { success: false, fallbackReason: 'error' };
+    }
+  }
+}
+
+/**
+ * Remove the stored biometric credential, effectively unenrolling the
+ * device from biometric login.
+ *
+ * After calling this, `authenticateWithBiometrics` will return
+ * `{ success: false, fallbackReason: 'not_enrolled' }` until the user
+ * re-enrolls via `enrollBiometric`.
+ *
+ * @example
+ * await unenrollBiometric();
+ * showSuccessMessage('Biometric login disabled');
+ */
+export async function unenrollBiometric(): Promise<void> {
+  try {
+    await Keychain.resetGenericPassword({ service: BIOMETRIC_SERVICE });
+  } catch (err) {
+    logError(err as Error, { service: 'biometricService', action: 'unenrollBiometric' });
+    throw new BiometricError(
+      'Failed to remove biometric credential from Keychain',
+      'KEYCHAIN_ERROR',
+    );
+  }
+}
+
+/**
+ * Check whether biometric credentials are currently enrolled for this app.
+ *
+ * This is a lightweight read that does **not** trigger a biometric prompt.
+ *
+ * @returns `true` when an enrolled credential exists in the Keychain.
+ *
+ * @example
+ * if (await isBiometricEnrolled()) showBiometricLoginButton();
+ */
+export async function isBiometricEnrolled(): Promise<boolean> {
+  try {
+    // `getGenericPassword` without `authenticationPrompt` checks for entry
+    // existence without triggering biometric UI on most RN Keychain versions.
+    const result = await Keychain.getGenericPassword({ service: BIOMETRIC_SERVICE });
+    return !!(result && 'password' in result);
+  } catch {
+    return false;
+  }
+}

--- a/src/services/petService.ts
+++ b/src/services/petService.ts
@@ -7,6 +7,7 @@ import { scanQRCode, type QRScanResult } from './qrCodeService';
 import type { Species } from '../models/Pet';
 import { logError } from '../utils/errorLogger';
 import { pickImage, compressImage, generateThumbnail, uploadToStorage } from '../utils/imageUtils';
+import { sanitizeObject } from '../utils/sanitize';
 
 // ─────────────────────────────────────────────
 // TYPES
@@ -274,8 +275,10 @@ export async function getPetByQRCode(qrCode: string): Promise<Pet> {
 
 export async function createPet(data: CreatePetInput): Promise<Pet> {
   try {
+    // Sanitize all string fields before sending to the API
+    const sanitized = sanitizeObject(data);
     // If online, this will go through, otherwise it throws and we catch
-    const response = await apiClient.post('/pets', data);
+    const response = await apiClient.post('/pets', sanitized);
     const pet = unwrapApiData(response.data);
     await setItem(`${PET_CACHE_PREFIX}${pet.id}`, JSON.stringify(pet));
     return pet;
@@ -313,7 +316,9 @@ export async function updatePet(petId: string, data: UpdatePetInput): Promise<Pe
   }
 
   try {
-    const response = await apiClient.put(`/pets/${encodeURIComponent(id)}`, data);
+    // Sanitize all string fields before sending to the API
+    const sanitized = sanitizeObject(data);
+    const response = await apiClient.put(`/pets/${encodeURIComponent(id)}`, sanitized);
     const pet = unwrapApiData(response.data);
     await setItem(`${PET_CACHE_PREFIX}${pet.id}`, JSON.stringify(pet));
     return pet;

--- a/src/utils/__tests__/sanitize.test.ts
+++ b/src/utils/__tests__/sanitize.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for src/utils/sanitize.ts
+ *
+ * Verifies that:
+ *  - sanitizeString strips dangerous characters without mutating the input
+ *  - sanitizeObject recursively applies sanitization to all string fields
+ *  - Neither function mutates its input
+ */
+
+import { sanitizeString, sanitizeObject } from '../sanitize';
+
+// ─── sanitizeString ───────────────────────────────────────────────────────────
+
+describe('sanitizeString()', () => {
+  // ── Null / undefined / non-string inputs ──────────────────────────────────
+
+  it('returns "" for null input', () => {
+    expect(sanitizeString(null as unknown as string)).toBe('');
+  });
+
+  it('returns "" for undefined input', () => {
+    expect(sanitizeString(undefined as unknown as string)).toBe('');
+  });
+
+  it('coerces numbers to sanitized strings', () => {
+    expect(sanitizeString(42 as unknown as string)).toBe('42');
+  });
+
+  it('returns "" for an empty string', () => {
+    expect(sanitizeString('')).toBe('');
+  });
+
+  // ── HTML / XML injection ───────────────────────────────────────────────────
+
+  it('strips < and > (HTML tags)', () => {
+    expect(sanitizeString('<script>alert(1)</script>')).toBe('scriptalert1script');
+  });
+
+  it('strips angle brackets from a partial tag', () => {
+    expect(sanitizeString('<b>bold</b>')).toBe('bbodb');
+  });
+
+  // ── SQL injection ─────────────────────────────────────────────────────────
+
+  it("strips single quotes", () => {
+    expect(sanitizeString("O'Reilly")).toBe('OReilly');
+  });
+
+  it('strips double quotes', () => {
+    expect(sanitizeString('"quoted"')).toBe('quoted');
+  });
+
+  it('strips semicolons', () => {
+    expect(sanitizeString('DROP TABLE pets;')).toBe('DROP TABLE pets');
+  });
+
+  it('strips backtick characters', () => {
+    expect(sanitizeString('`column`')).toBe('column');
+  });
+
+  it('strips SQL single-line comment sequences (--)', () => {
+    expect(sanitizeString('1 -- comment')).toBe('1  comment');
+  });
+
+  it('strips SQL block comment sequences (/* */)', () => {
+    expect(sanitizeString('1 /* comment */')).toBe('1  comment ');
+  });
+
+  // ── NoSQL / template injection ────────────────────────────────────────────
+
+  it('strips curly braces', () => {
+    expect(sanitizeString('{ "$ne": null }')).toBe(' ne: null ');
+  });
+
+  it('strips dollar signs', () => {
+    expect(sanitizeString('$where: 1')).toBe('where: 1');
+  });
+
+  // ── Null bytes ────────────────────────────────────────────────────────────
+
+  it('removes null bytes', () => {
+    expect(sanitizeString('hello\0world')).toBe('helloworld');
+  });
+
+  // ── Whitespace normalisation ──────────────────────────────────────────────
+
+  it('trims leading and trailing whitespace', () => {
+    expect(sanitizeString('  hello  ')).toBe('hello');
+  });
+
+  it('collapses internal runs of whitespace to a single space', () => {
+    expect(sanitizeString('hello   world')).toBe('hello world');
+  });
+
+  it('handles mixed leading/trailing/internal whitespace', () => {
+    expect(sanitizeString('  foo   bar  ')).toBe('foo bar');
+  });
+
+  // ── Clean inputs pass through unchanged ───────────────────────────────────
+
+  it('returns a clean string unchanged', () => {
+    expect(sanitizeString('Buddy the Labrador')).toBe('Buddy the Labrador');
+  });
+
+  it('preserves hyphens in names', () => {
+    expect(sanitizeString('Mary-Jane')).toBe('Mary-Jane');
+  });
+
+  it('preserves numbers', () => {
+    expect(sanitizeString('Tablet 5mg')).toBe('Tablet 5mg');
+  });
+
+  it('preserves @ in email addresses (no SQL chars)', () => {
+    expect(sanitizeString('user@example.com')).toBe('user@example.com');
+  });
+});
+
+// ─── sanitizeObject ───────────────────────────────────────────────────────────
+
+describe('sanitizeObject()', () => {
+  // ── Null / undefined passthrough ─────────────────────────────────────────
+
+  it('returns null for null input', () => {
+    expect(sanitizeObject(null)).toBeNull();
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(sanitizeObject(undefined)).toBeUndefined();
+  });
+
+  // ── Plain object ──────────────────────────────────────────────────────────
+
+  it('sanitizes all string fields in a plain object', () => {
+    const input = { name: "O'Reilly", age: 3 };
+    const result = sanitizeObject(input);
+    expect(result).toEqual({ name: 'OReilly', age: 3 });
+  });
+
+  it('leaves non-string fields untouched', () => {
+    const input = { count: 42, active: true, ratio: 1.5, nothing: null };
+    const result = sanitizeObject(input);
+    expect(result).toEqual({ count: 42, active: true, ratio: 1.5, nothing: null });
+  });
+
+  it('sanitizes nested objects recursively', () => {
+    const input = { owner: { name: "<admin>", email: 'safe@test.com' } };
+    const result = sanitizeObject(input);
+    expect(result).toEqual({ owner: { name: 'admin', email: 'safe@test.com' } });
+  });
+
+  // ── Arrays ────────────────────────────────────────────────────────────────
+
+  it('sanitizes string elements in a top-level array', () => {
+    const input = ['<b>bold</b>', 'safe'];
+    const result = sanitizeObject(input);
+    expect(result).toEqual(['bbold b', 'safe']);
+  });
+
+  it('sanitizes strings inside an array field on an object', () => {
+    const input = { tags: ['<b>bold</b>', 'clean'] };
+    const result = sanitizeObject(input);
+    expect(result).toEqual({ tags: ['bbold b', 'clean'] });
+  });
+
+  // ── Immutability ──────────────────────────────────────────────────────────
+
+  it('does NOT mutate the original object', () => {
+    const input = { name: "<script>" };
+    const before = input.name;
+    sanitizeObject(input);
+    expect(input.name).toBe(before);
+  });
+
+  it('does NOT mutate nested objects', () => {
+    const inner = { label: "'unsafe'" };
+    const input = { inner };
+    sanitizeObject(input);
+    expect(inner.label).toBe("'unsafe'");
+  });
+
+  // ── Primitives at top level ───────────────────────────────────────────────
+
+  it('sanitizes a top-level string value', () => {
+    expect(sanitizeObject("DROP TABLE;")).toBe('DROP TABLE');
+  });
+
+  it('passes through top-level numbers unchanged', () => {
+    expect(sanitizeObject(42)).toBe(42);
+  });
+
+  it('passes through top-level booleans unchanged', () => {
+    expect(sanitizeObject(true)).toBe(true);
+  });
+
+  // ── Class instances (passed through unchanged) ────────────────────────────
+
+  it('returns class instances without modification', () => {
+    class MyError extends Error {}
+    const err = new MyError('test');
+    expect(sanitizeObject(err)).toBe(err);
+  });
+
+  // ── Realistic mutation payload ────────────────────────────────────────────
+
+  it('sanitizes a realistic CreatePetInput payload', () => {
+    const input = {
+      name: "Fido'; DROP TABLE pets;--",
+      species: 'dog',
+      breed: '<Golden Retriever>',
+      weightKg: 30,
+      ownerId: 'owner-123',
+    };
+    const result = sanitizeObject(input);
+    expect(result).toEqual({
+      name: 'Fido DROP TABLE pets',
+      species: 'dog',
+      breed: 'Golden Retriever',
+      weightKg: 30,
+      ownerId: 'owner-123',
+    });
+  });
+});

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,113 @@
+/**
+ * sanitize.ts
+ *
+ * Client-side input sanitization utilities for PetChain Mobile App.
+ *
+ * These functions strip or neutralise characters that could be dangerous
+ * when interpolated into queries, HTML, or system commands.  They should
+ * be applied to every user-supplied string value **before** it is sent
+ * to the API inside a mutation payload.
+ *
+ * Design principles:
+ *  - Pure: no side-effects, no mutation of the original input.
+ *  - Composable: `sanitizeObject` delegates to `sanitizeString` so a
+ *    single rule change propagates everywhere.
+ *  - Transparent: returns the sanitized value unchanged when the input is
+ *    already clean, so downstream callers never need a null-check.
+ *  - TypeScript-first: generics preserve the original shape of objects.
+ */
+
+// ─── sanitizeString ───────────────────────────────────────────────────────────
+
+/**
+ * Strip characters that are commonly used in injection attacks from a
+ * string value.
+ *
+ * Removed / escaped:
+ *  - HTML/XML tags  (`<` and `>`)
+ *  - SQL meta-characters  (`'`, `"`, `;`, `--`, `/*`, `*/`)
+ *  - NoSQL / template injection markers  (`{`, `}`, `$`)
+ *  - Null bytes  (`\0`)
+ *  - Redundant whitespace (leading/trailing trimmed; internal runs collapsed
+ *    to a single space)
+ *
+ * The function **does not** mutate the input and always returns a `string`.
+ *
+ * @example
+ * sanitizeString("O'Reilly")         // "O Reilly"
+ * sanitizeString("<script>alert(1)") // "scriptalert1"
+ * sanitizeString("  hello  world  ") // "hello world"
+ * sanitizeString(null as any)        // ""
+ */
+export function sanitizeString(input: unknown): string {
+  if (input === null || input === undefined) return '';
+  if (typeof input !== 'string') return sanitizeString(String(input));
+
+  return input
+    .trim()
+    // Remove null bytes
+    .replace(/\0/g, '')
+    // Strip HTML/XML tags (and their content markers)
+    .replace(/[<>]/g, '')
+    // Remove SQL single-quote, double-quote, semicolons
+    .replace(/['"`;]/g, '')
+    // Remove SQL comment sequences
+    .replace(/--|\/\*|\*\//g, '')
+    // Remove NoSQL / template injection markers
+    .replace(/[{}$]/g, '')
+    // Collapse internal whitespace to a single space
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+// ─── sanitizeObject ──────────────────────────────────────────────────────────
+
+/**
+ * Recursively apply `sanitizeString` to every string-valued field in an
+ * object.  Non-string primitives and `null`/`undefined` values are passed
+ * through unchanged.  The original object is **never mutated**.
+ *
+ * Handles plain objects and arrays; class instances are returned as-is to
+ * avoid unintentional structural changes.
+ *
+ * @example
+ * sanitizeObject({ name: "O'Reilly", age: 3 })
+ * // → { name: "O Reilly", age: 3 }
+ *
+ * sanitizeObject({ tags: ["<b>bold</b>", "safe"] })
+ * // → { tags: ["bold", "safe"] }
+ *
+ * sanitizeObject(null)  // → null
+ */
+export function sanitizeObject<T>(obj: T): T {
+  if (obj === null || obj === undefined) return obj;
+
+  // Plain array
+  if (Array.isArray(obj)) {
+    return obj.map((item) => sanitizeObject(item)) as unknown as T;
+  }
+
+  // Plain object (not a class instance)
+  if (typeof obj === 'object' && Object.getPrototypeOf(obj) === Object.prototype) {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(obj as Record<string, unknown>)) {
+      const value = (obj as Record<string, unknown>)[key];
+      if (typeof value === 'string') {
+        result[key] = sanitizeString(value);
+      } else if (value !== null && typeof value === 'object') {
+        result[key] = sanitizeObject(value);
+      } else {
+        result[key] = value;
+      }
+    }
+    return result as T;
+  }
+
+  // Primitive string at the top level
+  if (typeof obj === 'string') {
+    return sanitizeString(obj) as unknown as T;
+  }
+
+  // Number, boolean, symbol, function, class instance — return unchanged
+  return obj;
+}


### PR DESCRIPTION

- Replace AsyncStorage token storage with react-native-keychain via storeSecureTokens/clearSecureTokens in authService; tokens encrypted with AES and stored in Keychain/Keystore; never written to plain AsyncStorage; tests verify keychain usage and AsyncStorage exclusion

- Add client-side debounce (300ms window), request deduplication, and configurable max concurrency (setMaxConcurrentRequests) to apiClient.ts rateLimitedRequest; documented inline; unit tests in apiClientRateLimiting.test.ts

- Add src/utils/sanitize.ts with sanitizeString (strips HTML/SQL/NoSQL/null-byte chars) and sanitizeObject (recursive, non-mutating); applied in authService login() and petService createPet/updatePet mutations; unit tested in sanitize.test.ts

- Add src/services/biometricService.ts with isBiometricAvailable, enrollBiometric, authenticateWithBiometrics, unenrollBiometric; credential marker stored in Keychain with BIOMETRY_CURRENT_SET access control; fallback via fallbackReason field; iOS (Face ID/Touch ID) and Android (Fingerprint) supported; unit tested in biometricService.test.ts


closes #859 
closes #860 
closes #861 
closes #862 