### PR TITLE
feat: add owner + sync queue models, extend pet model and pet service

### DIFF
--- a/src/models/Owner.ts
+++ b/src/models/Owner.ts
@@ -1,0 +1,113 @@
+/**
+ * Owner (pet owner / app user) model for mobile app.
+ */
+
+import type { Pet } from './Pet';
+
+/**
+ * Postal address of an owner.
+ */
+export interface OwnerAddress {
+  /** Street line, e.g. "12 Baker Street" */
+  street: string;
+  /** City or town */
+  city: string;
+  /** State, province or region */
+  state?: string;
+  /** Postal / ZIP code */
+  postalCode?: string;
+  /** ISO 3166-1 alpha-2 country code, e.g. "NG" */
+  country: string;
+}
+
+/**
+ * A pet owner's full profile as returned by the backend `/owners` API.
+ */
+export interface Owner {
+  /** Unique owner identifier */
+  id: string;
+  /** Login email address (unique) */
+  email: string;
+  /** Full display name */
+  name: string;
+  /** Contact phone number in E.164 format, e.g. "+2348012345678" */
+  phone?: string;
+  /** Home address, used for vet visits and emergencies */
+  address?: OwnerAddress;
+  /** Remote URL of the owner's avatar */
+  avatarUrl?: string;
+  /** Pets linked to this owner */
+  pets: Pet[];
+  /** Whether the email address has been verified */
+  emailVerified?: boolean;
+  /** ISO-8601 creation timestamp */
+  createdAt: string;
+  /** ISO-8601 last-update timestamp */
+  updatedAt?: string;
+}
+
+/**
+ * The subset of `Owner` kept in auth state after login.
+ * Deliberately small — no pet list, no address.
+ */
+export type AuthUser = Pick<Owner, 'id' | 'email' | 'name' | 'avatarUrl'> & {
+  /** Ids of the pets this user owns */
+  petIds: string[];
+};
+
+/**
+ * Fields an owner can edit on their own profile.
+ */
+export type OwnerFormData = Pick<Owner, 'name' | 'phone' | 'address' | 'avatarUrl'>;
+
+/**
+ * Build an `AuthUser` from a full owner record.
+ */
+export const toAuthUser = (owner: Owner): AuthUser => ({
+  id: owner.id,
+  email: owner.email,
+  name: owner.name,
+  avatarUrl: owner.avatarUrl,
+  petIds: (owner.pets ?? []).map(pet => pet.id),
+});
+
+/**
+ * Factory to safely create an Owner from raw data, filling required
+ * fields with sensible defaults.
+ */
+export const createOwner = (data: Partial<Owner>): Owner => ({
+  id: data.id || '',
+  email: data.email || '',
+  name: data.name || 'Unknown Owner',
+  phone: data.phone,
+  address: data.address,
+  avatarUrl: data.avatarUrl,
+  pets: data.pets ?? [],
+  emailVerified: data.emailVerified ?? false,
+  createdAt: data.createdAt || new Date().toISOString(),
+  updatedAt: data.updatedAt,
+});
+
+/**
+ * Validate owner profile input. Returns a list of human-readable errors —
+ * empty when the input is valid.
+ */
+export const validateOwner = (data: Partial<Owner>): string[] => {
+  const errors: string[] = [];
+
+  if (!data.name?.trim()) {
+    errors.push('Name is required');
+  }
+
+  if (!data.email?.trim()) {
+    errors.push('Email is required');
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
+    errors.push('Email format is invalid');
+  }
+
+  if (data.phone && !/^\+?[0-9]{7,15}$/.test(data.phone)) {
+    errors.push('Phone number must be 7-15 digits, optionally prefixed with +');
+  }
+
+  return errors;
+};

--- a/src/models/Pet.ts
+++ b/src/models/Pet.ts
@@ -4,18 +4,56 @@
 
 export type Species = 'dog' | 'cat' | 'bird' | 'rabbit' | 'other';
 
-export interface Pet {
+/**
+ * Minimal owner reference embedded in a pet payload, so screens can render
+ * the owner without a second request. Full owner data lives in `Owner`.
+ */
+export interface PetOwnerRef {
+  /** Owner (user) id — matches `Pet.ownerId` */
   id: string;
+  /** Owner display name */
   name: string;
+  /** Owner contact email */
+  email?: string;
+  /** Owner contact phone */
+  phone?: string;
+}
+
+/**
+ * A pet profile as returned by the backend `/pets` API.
+ */
+export interface Pet {
+  /** Unique pet identifier */
+  id: string;
+  /** Pet's display name */
+  name: string;
+  /** Species category */
   species: Species;
+  /** Breed, when known */
   breed?: string;
+  /** ISO-8601 date of birth */
   dateOfBirth?: string;
+  /** Age in years — derived from `dateOfBirth` when the backend supplies it */
+  age?: number;
+  /** Current weight in kilograms */
   weightKg?: number;
+  /** 15-character hexadecimal microchip identifier */
   microchipId?: string;
+  /** Value encoded in the pet's QR tag, used for scan lookups */
+  qrCode?: string;
+  /** Remote URL of the pet's profile photo */
   photoUrl?: string;
+  /** Id of the owning user */
   ownerId: string;
+  /** Embedded owner summary, when the backend expands it */
+  owner?: PetOwnerRef;
+  /** Ids of medical records linked to this pet */
+  medicalRecordIds?: string[];
+  /** ISO-8601 creation timestamp */
   createdAt: string;
+  /** ISO-8601 last-update timestamp */
   updatedAt: string;
+  /** Free-form extras (e.g. daily step goal) */
   metadata?: { stepGoal?: number; [key: string]: unknown };
 }
 
@@ -30,9 +68,13 @@ export const createPet = (data: Partial<Pet>): Pet => ({
   breed: data.breed,
   dateOfBirth: data.dateOfBirth,
   weightKg: data.weightKg,
+  age: data.age,
   microchipId: data.microchipId,
+  qrCode: data.qrCode,
   photoUrl: data.photoUrl,
   ownerId: data.ownerId || '',
+  owner: data.owner,
+  medicalRecordIds: data.medicalRecordIds,
   createdAt: data.createdAt || new Date().toISOString(),
   updatedAt: data.updatedAt || new Date().toISOString(),
   metadata: data.metadata,

--- a/src/models/SyncQueue.ts
+++ b/src/models/SyncQueue.ts
@@ -1,0 +1,82 @@
+/**
+ * Offline-to-online sync queue model.
+ *
+ * Mutations made while the device is offline are appended to this queue and
+ * replayed against the backend once connectivity returns.
+ */
+
+/** Mutation kind represented by a queued item. */
+export enum SyncOperation {
+  CREATE = 'CREATE',
+  UPDATE = 'UPDATE',
+  DELETE = 'DELETE',
+}
+
+/** Lifecycle state of a queued item. */
+export enum SyncStatus {
+  PENDING = 'PENDING',
+  IN_PROGRESS = 'IN_PROGRESS',
+  FAILED = 'FAILED',
+  COMPLETED = 'COMPLETED',
+}
+
+/** Entities that can be synced offline. */
+export type SyncEntity =
+  | 'pet'
+  | 'owner'
+  | 'appointment'
+  | 'medicalRecord'
+  | 'medication'
+  | 'healthMetric';
+
+/** Maximum retry attempts before an item is left in `FAILED`. */
+export const MAX_SYNC_RETRIES = 5;
+
+/**
+ * A single queued mutation waiting to be replayed against the backend.
+ */
+export interface SyncQueueItem<TPayload = unknown> {
+  /** Unique queue item identifier (client-generated) */
+  id: string;
+  /** Mutation kind */
+  operation: SyncOperation;
+  /** Entity type the mutation applies to */
+  entity: SyncEntity;
+  /** Id of the affected record; absent for CREATE until the server responds */
+  entityId?: string;
+  /** Request body to replay */
+  payload: TPayload;
+  /** Number of failed attempts so far */
+  retries: number;
+  /** Current lifecycle state */
+  status: SyncStatus;
+  /** Message from the most recent failure */
+  lastError?: string;
+  /** ISO-8601 timestamp of when the item was queued */
+  createdAt: string;
+  /** ISO-8601 timestamp of the most recent attempt */
+  updatedAt?: string;
+}
+
+/**
+ * Factory for a new queue item — always starts `PENDING` with zero retries.
+ */
+export const createSyncQueueItem = <TPayload>(
+  data: Pick<SyncQueueItem<TPayload>, 'operation' | 'entity' | 'payload'> &
+    Partial<SyncQueueItem<TPayload>>,
+): SyncQueueItem<TPayload> => ({
+  id: data.id || `sync_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`,
+  operation: data.operation,
+  entity: data.entity,
+  entityId: data.entityId,
+  payload: data.payload,
+  retries: data.retries ?? 0,
+  status: data.status ?? SyncStatus.PENDING,
+  lastError: data.lastError,
+  createdAt: data.createdAt || new Date().toISOString(),
+  updatedAt: data.updatedAt,
+});
+
+/** Whether an item still has retry budget left. */
+export const isRetryable = (item: SyncQueueItem): boolean =>
+  item.status !== SyncStatus.COMPLETED && item.retries < MAX_SYNC_RETRIES;

--- a/src/services/petService.ts
+++ b/src/services/petService.ts
@@ -202,6 +202,46 @@ function toPetServiceError(error: unknown, context: Record<string, unknown>): Pe
 // API METHODS
 // ─────────────────────────────────────────────
 
+/**
+ * Optional filters accepted by {@link getPets}.
+ */
+export interface PetQueryFilters {
+  species?: Species;
+  breed?: string;
+  ownerId?: string;
+}
+
+/**
+ * Fetch pets, optionally narrowed by species / breed / owner.
+ * Falls back to the local cache (filtered client-side) when offline.
+ */
+export async function getPets(filters: PetQueryFilters = {}): Promise<Pet[]> {
+  const params: Record<string, string> = {};
+  if (filters.species) params.species = filters.species;
+  if (filters.breed?.trim()) params.breed = filters.breed.trim();
+  if (filters.ownerId?.trim()) params.ownerId = filters.ownerId.trim();
+
+  try {
+    const response = await apiClient.get<ApiResponse<Pet[]> | Pet[]>('/pets', { params });
+    const pets = unwrapApiData(response.data);
+    await cachePets(pets);
+    return pets;
+  } catch (error) {
+    const cached = await getCachedPets();
+    if (cached.length > 0) return matchesFilters(cached, filters);
+    throw toPetServiceError(error, { action: 'get_pets' });
+  }
+}
+
+function matchesFilters(pets: Pet[], filters: PetQueryFilters): Pet[] {
+  return pets.filter(
+    pet =>
+      (!filters.species || pet.species === filters.species) &&
+      (!filters.breed || pet.breed?.toLowerCase() === filters.breed.trim().toLowerCase()) &&
+      (!filters.ownerId || pet.ownerId === filters.ownerId.trim()),
+  );
+}
+
 export async function getAllPets(): Promise<Pet[]> {
   try {
     const response = await apiClient.get<ApiResponse<Pet[]> | Pet[]>('/pets');
@@ -394,6 +434,7 @@ export async function uploadPetPhoto(
 
 // Default export for screens that import petService as default
 const petService = {
+  getPets,
   getAllPets,
   getPetById,
   getPetByQRCode,


### PR DESCRIPTION
Closes #783: Pet interface now documents every field and adds age, qrCode, medicalRecordIds and a nested PetOwnerRef owner reference.

Closes #784: new src/models/Owner.ts with Owner, OwnerAddress, the AuthUser login subset, a factory and validation helpers.

Closes #790: new src/models/SyncQueue.ts with SyncQueueItem plus the SyncOperation and SyncStatus enums and a queue item factory.

Closes #791: petService gains getPets(filters) supporting species, breed and ownerId query filters with an offline cache fallback.